### PR TITLE
Add KeyClip

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Feel free to contribute!
 
 - [swift-smc](https://github.com/beltex/swift-smc) - Read temperature sensors, fan RPM, etc.
 
-#### Keychain
+#### Security
 
 - [KeyClip](https://github.com/s-aska/KeyClip) - Keychain framework for iOS written in Swift.
 


### PR DESCRIPTION
Hello,

I just added KeyClip.
- It is comprehensive and continually testing.
- Carthage support (Can be used in release build)

Category is the correct or anxiety.

Please add it if appropriate.
