### PR TITLE
Adding SlideShare Style Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Feel free to contribute!
 ### Style Guides
 * [Swift Style Guide](https://github.com/raywenderlich/swift-style-guide) - Raywenderlich swift guide, a must read.
 * [swift-style-guide](https://github.com/github/swift-style-guide) - Style guide & coding conventions for Swift projects.
+* [SlideShare (LinkedIn)](https://github.com/SlideShareInc/swift-style-guide) - Style guides that SlideShare (LinkedIn) uses for their Swift iOS app.
 
 ## Editor Support
 


### PR DESCRIPTION
Adding the SlideShare (LinkedIn company) Swift and Cocoa style guides that are kept up-to-date with our coding practices in our iOS 8 only, Swift app. 