### PR TITLE
Remove comment about CocoaPods Swift support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,7 @@ Feel free to contribute!
 *Dependency manager software for swift.*
 
 * [carthage](https://github.com/Carthage/Carthage) - a new dependency manager for swift.
-* [cocoapods](https://github.com/CocoaPods/CocoaPods) - the most used dependency manager for Objective-C (swift is still in porting).
-
+* [cocoapods](https://github.com/CocoaPods/CocoaPods) - the most used dependency manager for Objective-C.
 
 ## Guides
 *An awesome list of swift related guides.*


### PR DESCRIPTION
CocoaPods has had support for Swift from version 0.36 and up: http://blog.cocoapods.org/CocoaPods-0.36/