### PR TITLE
Removed `acli`, deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ Feel free to contribute!
 
 *Dependency manager software for Swift.*
 
-* [acli](https://github.com/eugenpirogoff/acli) - downloads repos from command line listed in awesome-Swift readme.
 * [carthage](https://github.com/Carthage/Carthage) - a new dependency manager for Swift.
 * [cocoapods](https://github.com/CocoaPods/CocoaPods) - the most used dependency manager for Objective-C (Swift is still in porting).
 


### PR DESCRIPTION
> ACLI IS DEPRECATED
> Swift is getting more and more a mature language and so the tools that are used in the ecosystem finally have support of it, so please use them. The acli gem is also no longer available for installation from rubygems.

[acli](https://github.com/eugenpirogoff/acli)