### PR TITLE
Add a framework to the auto-layout section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,6 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 * [Swiftstraints](https://github.com/Skyvive/Swiftstraints) - Powerful auto-layout framework that lets you write constraints in one line of code.
 * [Tails](https://github.com/nickynick/Tails) - declarative autolayout for ios app written in swift.
 * [VFLToolbox](https://github.com/0xc010d/VFLToolbox) - fancy Swift implementation of the Visual Format Language
-* [FormulaStyleConstraint](https://github.com/fhisa/FormulaStyleConstraint) - Lightweight mathematical declarative auto-layout framework for Swift.
 
 ### Localization
 *Frameworks that helps with localizing your app*

--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 
 * [CleanroomASL](https://github.com/emaloney/CleanroomASL) — a low-level Swift API for writing to and reading from the Apple System Log daemon
 * [CleanroomLogger](https://github.com/emaloney/CleanroomLogger) — a configurable and extensible high-level logging API that is simple, lightweight and performant
+* [swiftRemoteLogger](https://github.com/matteocrippa/swiftRemoteLogger) - remote logging easy as 1..2..3 in swift
 
 ### Maps
 * [GEOSwift](https://github.com/andreacremaschi/GEOSwift) - The Swift Geographic Engine, make it easier to work with geographic models and calculate intersections, overlapping, projections etc.


### PR DESCRIPTION
added [FormulaStyleConstraint](https://github.com/fhisa/FormulaStyleConstraint) to the auto-layout section.

Use of the framework example:
```swift
baseView.addConstraints([
    mainView[.Top] == topLayoutGuide[.Bottom] + 8
    mainView[.Leading] == baseView[.Leading] + 8
    mainView[.Trailing] == baseView[.Trailing] + 8
    mainView[.Height] == (3.0 / 4.0) * baseView[.Height]
    subView[.Top] == mainView[.Bottom] + 8
    subView[.Leading] == baseView[.Leading] + 8
    subView[.Trailing] == baseView[.Trailing] + 8
    subView[.Bottom] == bottomLayoutGuide[.Top] - 8
    ])
```
