### PR TITLE
Add Swiftx and a Prelude port to Swift

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,6 +782,7 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 * [Money](https://github.com/danthorpe/Money) - Currency formatter in Swift.
 * [Oriole](https://github.com/tptee/Oriole) - A functional utility belt implemented as Swift 2.0 protocol extensions.
 * [Popsicle](https://github.com/DavdRoman/Popsicle) - Delightful, extensible Swift value interpolation framework.
+* [Prelude](https://github.com/robrix/Prelude) - Swift µframework of simple functional programming tools.
 * [protobuf-swift](https://github.com/alexeyxo/protobuf-swift) - ProtocolBuffers for Swift.
 * [Prototope](http://khan.github.io/Prototope/) - Swift library of lightweight interfaces for prototyping, bridged to JS.
 * [Pythonic.swift](https://github.com/practicalswift/Pythonic.swift) - Pythonic tool-belt for Swift: a Swift implementation of selected parts of Python standard library.
@@ -806,6 +807,7 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 * [SwiftSequence](https://github.com/oisdk/SwiftSequence) - A μframework of extensions for SequenceType in Swift 2.0, inspired by Python's itertools.
 * [SwiftValidators](https://github.com/gkaimakas/SwiftValidators) - String validation for iOS developed in Swift (inspired by validator.js).
 * [SwiftyStateMachine](https://github.com/macoscope/SwiftyStateMachine) - Swift µframework for creating state machines.
+* [Swiftx](https://github.com/typelift/Swiftx) - Functional data types and functions for any project.
 * [Swiftz](https://github.com/typelift/Swiftz) - Functional programming in Swift.
 * [Swift Sugar](https://github.com/RuiAAPeres/Swift-Sugar) - objsugar ported to Swift.
 * [undefined](https://github.com/weissi/swift-undefined) - Nano framework which defines Haskell's undefined in Swift.


### PR DESCRIPTION
This *PR* just adds two useful libs for functional programming in Swift:

- [Swiftx](https://github.com/typelift/Swiftx) is a small and simpler version of [Swiftz](https://github.com/typelift/swiftz).
- [Prelude](https://github.com/robrix/Prelude) is a port of the [Haskell Prelude](https://hackage.haskell.org/package/base-4.8.1.0/docs/Prelude.html) to Swift.