### PR TITLE
Add App Store category

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
   - [Vim](#vim)
 - [Libs](#libs)
   - [Animation](#animation)
+  - [App Store](#app-store)
   - [Audio](#audio)
   - [API](#api)
   - [Chat](#chat)
@@ -215,6 +216,13 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 * [EasyAnimation](https://github.com/icanzilb/EasyAnimation) - A Swift library to take the power of UIView.animateWithDuration(_:, animations:...) to a whole new level.
 * [Presentation](https://github.com/hyperoslo/Presentation) - A Swift library to help you to make tutorials, release notes and animated pages.
 * [Spring](https://github.com/MengTo/Spring) - A library to simplify iOS animations in Swift.
+
+### App Store
+*Libs to help with apple app store, in app purchases and receipt validation.*
+
+* [InAppFw](https://github.com/sandorgyulai/InAppFramework) - In App Purchase Manager framework.
+* [SwiftInAppPurchase] (https://github.com/rpzzzzzz/SwiftInAppPurchase) - A swift wrapper for iOS in app purchases.
+* [SwiftyStoreKit](https://github.com/bizz84/SwiftyStoreKit) - Lightweight In App Purchases Swift framework.
 
 ### Audio
 *Libs to work with audio*


### PR DESCRIPTION
wrapper for StoreKit

* [InAppFw](https://github.com/sandorgyulai/InAppFramework) - In App Purchase Manager framework.
* [SwiftInAppPurchase] (https://github.com/rpzzzzzz/SwiftInAppPurchase) - A swift wrapper for iOS in app purchases.
* [SwiftyStoreKit](https://github.com/bizz84/SwiftyStoreKit) - Lightweight In App Purchases Swift framework.

I put 3 frameworks to let end-user choose, but I you want I keep only framework with more than 20 stars, as you wich