### PR TITLE
Add RestEssentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,7 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 * [Reach](https://github.com/Isuru-Nanayakkara/Reach) - A simple class to check for internet connection availability in Swift.
 * [Reachability.swift](https://github.com/ashleymills/Reachability.swift) - A replacement for Apple's Reachability re-written in Swift with closures.
 * [ResponseDetective](https://github.com/netguru/ResponseDetective) - A non-intrusive framework for intercepting any outgoing requests and incoming responses between your app and server for debugging purposes.
+* [RestEssentials](https://github.com/sean7512/RestEssentials) - An extremely lightweight REST and JSON library for Swift.
 * [RSNetworking](https://github.com/hoffmanjon/RSNetworking) - Network library written purely in Swift.
 * [Siesta](https://bustoutsolutions.github.io/siesta/) Elegant abstraction for REST APIs that untangles stateful messes. An alternative to callback- and delegate-based networking.
 * [Stargate](https://github.com/contentful-labs/Stargate) - A communication channel from your Mac to your watch.


### PR DESCRIPTION
Rest Essentials - https://github.com/sean7512/RestEssentials is a great lightweight Rest/JSON lib written in Swift.  For when you don't want the bulk of  AFNetworking or Restkit.