### PR TITLE
Add Sorry

### DIFF
--- a/README.md
+++ b/README.md
@@ -876,6 +876,7 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 #### Permissions
 
 * [PermissionScope](https://github.com/nickoneill/PermissionScope) - A Periscope-inspired way to ask for iOS permissions.
+* [Sorry](https://github.com/delba/Sorry) - Ask for iOS permissions through a single, uniform interface.
 * [Swift-Prompts](https://github.com/GabrielAlva/Swift-Prompts) - A Swift library to design custom prompts with a great scope of options to choose from.
 
 #### Transition


### PR DESCRIPTION
Sorry provides a single, uniform interface to ask for iOS permissions. I love PermissionScope but it's sometimes too opinionated about your interface...

**The simplest example:**

```swift
let permission = Permission(.Contacts)

permission.request { status in
    print(status)
}
```

**Configure the alerts:**

```swift
permission.configureAlert(.Denied) { alert in
    alert.title = "You denied access to your contacts"
    alert.message = "Please allow access in the settings app"
    alert.cancel = "Cancel"
    alert.settings = "Settings"
}
```

**Sorry has some helpers too :)**

```swift
let button = PermissionButton(.Contacts)

button.setTitles([
    .Authorized: "Authorized",
    .Denied: "Denied"
])

// etc.
```

**And you can create some permissions set**

Let's say you want to know if the user allowed access to both your photos **and** your events:

```swift
let photos = PermissionButton(.Photos)
let events = PermissionButton(.Events)

let permissionSet = PermissionSet(photos, events)
```  

More in the [README](https://github.com/delba/Sorry)
