### PR TITLE
Add pull request template

### DIFF
--- a/PULL_REQUEST_TEMPLATE
+++ b/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,3 @@
+- Project name:
+- Project description:
+- Why it should be added to `awesome-swift`:


### PR DESCRIPTION
This is a new feature announced on GitHub today https://github.com/blog/2111-issue-and-pull-request-templates

When someone creates a pull request, they would see the text in `PULL_REQUEST_TEMPLATE`, which I've put together:

![template](https://cloud.githubusercontent.com/assets/4723115/13124970/168919d0-d578-11e5-88e8-5a151342e9cb.png)
