### PR TITLE
Add ApplicationGroupKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -925,6 +925,7 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 *Some interesting utilities to help you in your projects*
 
 * [__](https://github.com/lotz84/__.swift) - Underscore.js power in your Swift projects.
+* [ApplicationGroupKit](https://github.com/phimage/ApplicationGroupKit) - Share informations betweens your applications and your extensions using group identifier.
 * [AppVersionMonitor](https://github.com/eure/AppVersionMonitor) - Monitor iOS app version easily.
 * [ArrayDiff](https://github.com/Adlai-Holler/ArrayDiff) - a fast, UITableView/UICollectionView-compatible array diffing microframework.
 * [AwesomeCache](https://github.com/aschuch/AwesomeCache) - manage cache easy in your Swift project.


### PR DESCRIPTION
- Project name: ApplicationGroupKit
- Project description: Share informations betweens your applications and your extensions using group identifier
- Why it should be added to `awesome-swift`: This framework make it easy to use application group sharing feature between app and its extension. Easy also to switch the method to use to share data (`NSUserDefaults`, KeyChain, File)
  - For `NSUserDefaults` apple document it [here](https://developer.apple.com/library/ios/documentation/General/Conceptual/ExtensibilityPG/ExtensionScenarios.html#//apple_ref/doc/uid/TP40014214-CH21-SW6)
