### PR TITLE
Added SSEventFlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 * [Safe](https://github.com/tidwall/Safe) - A modern concurrency and synchronization for Swift.
 * [SignalKit](https://github.com/yankodimitrov/SignalKit) - Swift event and binding framework.
 * [Signals](https://github.com/artman/Signals) - replaces delegates and notifications.
+* [SSEventFlow](https://github.com/neoneye/SSEventFlow) - A type safe alternative to NSNotification, inspired by Flux.
 * [SwiftEventBus](https://github.com/cesarferreira/SwiftEventBus) - A publish/subscribe event bus optimized for iOS.
 
 ### Fonts


### PR DESCRIPTION
- **Project name**:
SSEventFlow

- **Project description**:
A type safe alternative to NSNotification, inspired by Flux

- **Why it should be added to `awesome-swift`**:
NSNotification is painful to work with. Fortunately Facebook recently (2014 i think) announced Flux Application Architecture. I have seen other swift implementations of Flux that uses generics. My impl doesn't use generics and is less than 100 lines. I think it's great.
