### PR TITLE
Add VersionTrackerSwift

### DIFF
--- a/README.md
+++ b/README.md
@@ -992,6 +992,7 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 * [undefined](https://github.com/weissi/swift-undefined) - Nano framework which defines Haskell's undefined in Swift.
 * [Versions](https://github.com/zenangst/Versions) - Helping you find inner peace when comparing version numbers in Swift.
 * [VersionsTracker](https://github.com/martnst/VersionsTracker) - Keeping track of version installation history including dates.
+* [VersionTrackerSwift](https://github.com/tbaranes/VersionTrackerSwift) - Track which versions of your app a user has previously installed. Available for iOS, OS X and tvOS.
 * [Wyrd](https://github.com/explicitcall/Wyrd) - Asynchronous programming in Swift made easy. Wyrd is inspired by Promises/A+.
 
 ### Video


### PR DESCRIPTION
New PR due to a bad manipulation with the fork (#457)

- **Project name:** [VersionTrackerSwift](https://github.com/tbaranes/VersionTrackerSwift)
- **Project description:** Track which versions of your app a user has previously installed. Available for iOS, OS X and tvOS.
- **Why it should be added to `awesome-swift`:** because it's always a lot of boiler plate code to track each versions of our apps (to handle migrations...). That library takes care of that to make your daily work more confortable. 
