### PR TITLE
Add SimplePDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -967,6 +967,7 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 * [Result](https://github.com/antitypical/Result) - Swift type modelling the success/failure of arbitrary operations.
 * [Runes](https://github.com/thoughtbot/Runes) - Functional operators for Swift - flatMap, map, apply, pure.
 * [seguecode](https://github.com/Adorkable/seguecode) - seguecode is a support tool that provides compile-time safeties around building with UIStoryboards by exporting code regarding Scenes, Segues, Table and Collection Views and more.
+* [SimplePDF](https://github.com/nRewik/SimplePDF) - Create a simple PDF effortlessly.
 * [SpecificationPattern](https://github.com/neoneye/SpecificationPattern) - chainable rules useful for form validation.
 * [SpriteKit+Spring](https://github.com/ataugeron/SpriteKit-Spring) - SpriteKit API reproducing UIView's spring animations with SKAction.
 * [Stream](https://github.com/antitypical/Stream) - Lazy streams in Swift.


### PR DESCRIPTION
- **Project name**: SimplePDF
- **Project url**: https://github.com/nRewik/SimplePDF
- **Project description**: Create a simple PDF effortlessly.
- **Why it should be added to `awesome-swift`**: Because it is a cumbersome task to create a pdf file. When we  want to create a simple pdf, we have to deal with `UIGraphic`. SimplePDF abstracts that detail and help you create a pdf effortlessly. The quality of pdf is good. We get text rendering quality as it should be, not the screenshot of `UIView`.