### PR TITLE
add URLEmbeddedView by @szk-atmosphere

### DIFF
--- a/README.md
+++ b/README.md
@@ -904,6 +904,7 @@ Please take a quick look at the [contribution guidelines](.github/CONTRIBUTING.m
 * [TouchVisualizer](https://github.com/morizotter/TouchVisualizer) - Lightweight touch visualization library in Swift. A single line of code and visualize your touches.
 * [Twinkle](https://github.com/piemonte/Twinkle) - a Swift and easy way to make elements in your iOS app twinkle.
 * [TZStackView](https://github.com/tomvanzummeren/TZStackView) - An iOS9 UIStackView layout component re-implemented for iOS 7 and 8.
+* [URLEmbeddedView](https://github.com/szk-atmosphere/URLEmbeddedView) - Automatically caches the object that is confirmed the Open Graph Protocol, and displays it as URL embedded card.
 
 #### Alert
 


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-swift 😊 -->

<!-- Reminder: for new projects, add your entry in alphabetical order -->

<!-- Please fill out the short form below -->

- **Project name**: URLEmbeddedView
- **Project url**: [https://github.com/szk-atmosphere/URLEmbeddedView](https://github.com/szk-atmosphere/URLEmbeddedView)
- **Project description**: URLEmbeddedView automatically caches the object that is confirmed the Open Graph Protocol.
- **Why it should be added to `awesome-swift`**: There was no library, that is able to display URL embedded card like twitter feed, facebook feed and so on. URLEmbeddedView realizes that feature with only passing a URL string! In addition, it caches OG Data automatically!

