### PR TITLE
Adds Arrow JSON Parsing library

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ Check out apps on these projects:
 * [Alembic](https://github.com/ra1028/Alembic) - Functional JSON parsing, mapping to objects, and serialize to JSON.
 * [Alexander](https://github.com/hodinkee/alexander) - An extremely simple JSON helper written in Swift.
 * [Argo](https://github.com/thoughtbot/Argo) - Json parsing library.
+* [Arrow 🏹](https://github.com/s4cha/Arrow) - Elegant JSON Parsing in Swift.
 * [Decodable](https://github.com/Anviking/Decodable) 🐧 - JSON parsing for Swift 2.
 * [EVReflection](https://github.com/evermeer/EVReflection) - Reflection based JSON encoding and decoding. Including support for NSDictionary, NSCoding, Printable, Hashable and Equatable
 * [Genome](https://github.com/LoganWright/Genome) - A simple, type safe, failure driven mapping library for serializing JSON to models in Swift 2.0.


### PR DESCRIPTION
Arrow : 
https://github.com/s4cha/Arrow

Because parsing JSON in Swift is full of unecessary if lets, obvious casts and nil-checks, there must be a better way. By using a simple arrow operator that takes care of the boilerplate code for us.
Json mapping code becomes concise and maintainable <3

This saves a ton of boilerplate JSON parsing code :)
