### PR TITLE
Add CocoaMQTT to Messaging Protocol category

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ Please take a quick look at the [contribution guidelines](.github/CONTRIBUTING.m
   - [Maps](#maps)
   - [Math](#math)
   - [Network](#network)
-    - [Html](#html)  
+    - [Html](#html)
+    - [Messaging Protocol](#messaging-protocol)
     - [Socket](#socket)
     - [Webserver](#webserver)
-    - [Messaging Protocol](#messaging-protocol)
   - [Quality](#quality)
   - [Security](#security)
     - [Cryptography](#cryptography)
@@ -628,6 +628,9 @@ Check out apps on these projects:
 * [Kanna](https://github.com/tid-kijyun/Kanna) - another XML/HTML parser for Swift.
 * [WKZombie](https://github.com/mkoehnke/WKZombie) - Headless browser
 
+#### Messaging Protocol
+
+* [CocoaMQTT](https://github.com/emqtt/CocoaMQTT) - MQTT for iOS and OS X written with Swift.
 
 #### Webserver
 *Would you like host a webserver in your device? Here you can find how to do it.*
@@ -652,10 +655,6 @@ Check out apps on these projects:
 * [Vapor](https://github.com/qutheory/vapor) 🐧 - Elegant web framework for Swift that works on iOS, OS X, and Ubuntu.
 * [XcodeServerSDK](https://github.com/czechboy0/XcodeServerSDK) - Access Xcode Server API with native Swift objects.
 * [Zewo](https://github.com/Zewo/Zewo) 🐧 - Server-Side Swift.
-
-#### Messaging Protocol
-
-* [CocoaMQTT](https://github.com/emqtt/CocoaMQTT) - MQTT for iOS and OS X written with Swift.
 
 #### Socket
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Please take a quick look at the [contribution guidelines](.github/CONTRIBUTING.m
     - [Html](#html)  
     - [Socket](#socket)
     - [Webserver](#webserver)
+    - [Messaging Protocol](#messaging-protocol)
   - [Quality](#quality)
   - [Security](#security)
     - [Cryptography](#cryptography)
@@ -651,6 +652,10 @@ Check out apps on these projects:
 * [Vapor](https://github.com/qutheory/vapor) 🐧 - Elegant web framework for Swift that works on iOS, OS X, and Ubuntu.
 * [XcodeServerSDK](https://github.com/czechboy0/XcodeServerSDK) - Access Xcode Server API with native Swift objects.
 * [Zewo](https://github.com/Zewo/Zewo) 🐧 - Server-Side Swift.
+
+#### Messaging Protocol
+
+* [CocoaMQTT](https://github.com/emqtt/CocoaMQTT) - MQTT for iOS and OS X written with Swift.
 
 #### Socket
 


### PR DESCRIPTION
- **Project name**: CocoaMQTT
- **Project url**: https://github.com/emqtt/CocoaMQTT
- **Project description**: MQTT for iOS and OS X written with Swift.
- **Why it should be added to `awesome-swift`**: Because messaging protocol is important, and CocoaMQTT is good and convenient.