### PR TITLE
Move Fuzi from XML to HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,6 @@ Please take a quick look at the [contribution guidelines](.github/CONTRIBUTING.m
 
 * [AEXML](https://github.com/tadija/AEXML) - xml wrapper.
 * [AlamofireXmlToObjects](https://github.com/evermeer/AlamofireXmlToObjects) - An Alamofire extension for fetching an XML feed and parsing it into objects.
-* [Fuzi](https://github.com/cezheng/Fuzi) - A fast & lightweight XML/HTML parser with XPath & CSS support in Swift 2.
 * [SWXMLHash](https://github.com/drmohundro/SWXMLHash) - Simple XML parsing in Swift.
 * [XMLParser](https://github.com/Mozharovsky/XMLParser) - A lightweight XMLParser for assembling and parsing XML values written for iOS 8+ in Swift 2.
 
@@ -647,6 +646,7 @@ Please take a quick look at the [contribution guidelines](.github/CONTRIBUTING.m
 #### HTML
 *Need to manipulate contents from html easily?*
 
+* [Fuzi](https://github.com/cezheng/Fuzi) - A fast & lightweight XML/HTML parser with XPath & CSS support.
 * [Ji](https://github.com/honghaoz/Ji) - an XML/HTML parser for Swift.
 * [Kanna](https://github.com/tid-kijyun/Kanna) - another XML/HTML parser for Swift.
 * [WKZombie](https://github.com/mkoehnke/WKZombie) - Headless browser

--- a/content.json
+++ b/content.json
@@ -1269,11 +1269,6 @@
 		"description": "An Alamofire extension for fetching an XML feed and parsing it into objects.",
 		"homepage": "https://github.com/evermeer/AlamofireXmlToObjects"
 	}, {
-		"title": "Fuzi",
-		"category": "xml",
-		"description": "A fast & lightweight XML/HTML parser with XPath & CSS support in Swift 2.",
-		"homepage": "https://github.com/cezheng/Fuzi"
-	}, {
 		"title": "SWXMLHash",
 		"category": "xml",
 		"description": "Simple XML parsing in Swift.",
@@ -2136,6 +2131,11 @@
 		"category": "network",
 		"description": "http request in async.",
 		"homepage": "https://github.com/yayuhh/YYHRequest-Swift"
+	}, {
+		"title": "Fuzi",
+		"category": "html",
+		"description": "A fast & lightweight XML/HTML parser with XPath & CSS support.",
+		"homepage": "https://github.com/cezheng/Fuzi"
 	}, {
 		"title": "Ji",
 		"category": "html",


### PR DESCRIPTION
Fuzi is used more for parsing HTML files when scraping websites so it is better to put it in HTML category than XML.