### PR TITLE
Add official API design guidelines

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -412,6 +412,11 @@
 		"description": "Official Apple eBook for swift beginners.",
 		"homepage": "https://itunes.apple.com/us/book/swift-programming-language/id881256329?mt=11"
 	}, {
+		"title": "API Design Guidelines",
+		"category": "official-guides",
+		"description": "Official Swift API design guidelines.",
+		"homepage": "https://swift.org/documentation/api-design-guidelines/"
+	}, {
 		"title": "Swift Education",
 		"category": "third-party-guides",
 		"description": "A community of educators sharing materials for teaching Swift and app development.",


### PR DESCRIPTION
- **Project Name**: API Design Guidelines
- **Project URL**: https://swift.org/documentation/api-design-guidelines/
- **Project Description**: Official Swift API design guidelines.
- **Why it should be added to `awesome-swift`**: It's the official guide
- [x] Updated **contents.json** instead of README
