### PR TITLE
Add GCDTimer to contents.json

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -2531,6 +2531,11 @@
 		"description": "Grand Central Dispatch simplified with Swift.",
 		"homepage": "https://github.com/JohnEstropia/GCDKit"
 	}, {
+		"title": "GCDTimer",
+		"category": "thread",
+		"description": "A well-tested GCD timer in Swift.",
+		"homepage": "https://github.com/hemantasapkota/GCDTimer"
+	}, {
 		"title": "ActiveLabel",
 		"category": "label",
 		"description": "UILabel drop-in replacement supporting Hashtags (#), Mentions (@) and URLs (http://).",


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-swift 😊 -->

<!-- Reminder: Please update contents.json instead of the README -->

<!-- Please fill out the short form below -->

- **Project Name**: GCDTimer
- **Project URL**: https://github.com/hemantasapkota/GCDTimer
- **Project Description**: A well-tested Grand Central Dispatch timer in Swift.
- **Why it should be added to `awesome-swift`**: Anyone who starts out by abstracting their own **timer** would eventually have to spend a lot of time and effort trying to ensure  that it runs properly under different cases. They might benefit from using **GCDTimer** because it already takes care of most of the common test cases. See [1](https://github.com/hemantasapkota/GCDTimer/blob/master/GCDTimerTests/GCDTimerTests.swift).
- [x] At least 15 stars (GitHub project)
- [x] Updated **contents.json** instead of README

