### PR TITLE
Add MaterialActionSheetController

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -3251,6 +3251,11 @@
 		"description": "Fully customizable and extensible action sheet controller written in Swift 2.",
 		"homepage": "https://github.com/xmartlabs/XLActionController"
 	}, {
+		"title": "MaterialActionSheetController",
+		"category": "alert",
+		"description": "A Google like action sheet, easy to use and customizable.",
+		"homepage": "https://github.com/ntnhon/MaterialActionSheetController"
+	}, {
 		"title": "SuperDelegate",
 		"category": "applicationdelegate",
 		"description": "SuperDelegate provides a clean application delegate interface and protects you from bugs in the application lifecycle.",


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-swift 😊 -->

<!-- Reminder: Please update contents.json instead of the README -->

<!-- Please fill out the short form below -->

- **Project Name**: MaterialActionSheetController
- **Project URL**: https://github.com/ntnhon/MaterialActionSheetController
- **Project Description**: A Google like action sheet, easy to use and customizable.
- **Why it should be added to `awesome-swift`**: It replaces the trivial default action sheet which is most of the time out of tune with the application style. It's easy to create action with closures like UIAlertController and highly customizable.
- [x] At least 15 stars (GitHub project)
- [x] Updated **contents.json** instead of README

