### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Please take a quick look at the [contribution guidelines](.github/CONTRIBUTING.m
 * [AudioPlayerSwift](https://github.com/recisio/AudioPlayerSwift) - AudioPlayer is a simple class for playing audio (basic and advanced usage) in iOS, OS X and tvOS apps.
 * [Beethoven](https://github.com/vadymmarkov/Beethoven) - An audio processing Swift library for pitch detection of musical signals.
 * [MusicKit](https://github.com/benzguo/MusicKit) - A framework for composing and transforming music in Swift.
-* [TuningFork](https://github.com/comyarzaheri/TuningFork) - A Simple Tuner for iOS.
+* [TuningFork](https://github.com/comyar/TuningFork) - A Simple Tuner for iOS.
 
 ### Authentication
 *Easy way to manage auth in your apps.* [back to top](#readme) 
@@ -364,7 +364,7 @@ Please take a quick look at the [contribution guidelines](.github/CONTRIBUTING.m
 * [JSQCoreDataKit](https://github.com/jessesquires/JSQCoreDataKit) - A swifter Core Data stack.
 * [QueryKit](https://github.com/QueryKit/QueryKit) - an easy way to play with coredata filtering within your Swift projects.
 * [Skopelos](https://github.com/albertodebortoli/Skopelos) - A minimalistic, thread safe, non-boilerplate and super easy to use version of Active Record on Core Data.
-* [SugarRecord](https://github.com/pepibumur/SugarRecord) - an easy with to work with coredata and realm.
+* [SugarRecord](https://github.com/carambalabs/SugarRecord) - an easy with to work with coredata and realm.
 * [SuperRecord](https://github.com/michaelarmstrong/SuperRecord) - A small set of utilities to make working with CoreData and Swift a bit easier.
 
 #### Data Structures
@@ -800,7 +800,7 @@ Please take a quick look at the [contribution guidelines](.github/CONTRIBUTING.m
 * [Taylor](https://github.com/izqui/Taylor) - A lightweight library for writing HTTP web servers with Swift.
 * [Trevi](https://github.com/Yoseob/Trevi) - A powerful Swift Web Application Server Framework Project.
 * [Vapor](https://github.com/vapor/vapor) :penguin: - Elegant web framework for Swift that works on iOS, OS X, and Ubuntu.
-* [XcodeServerSDK](https://github.com/czechboy0/XcodeServerSDK) - Access Xcode Server API with native Swift objects.
+* [XcodeServerSDK](https://github.com/buildasaurs/XcodeServerSDK) - Access Xcode Server API with native Swift objects.
 * [Zewo](https://github.com/Zewo/Zewo) :penguin: - Server-Side Swift.
 
 ### Natural Language Processing
@@ -873,7 +873,7 @@ Please take a quick look at the [contribution guidelines](.github/CONTRIBUTING.m
 ### Testing
 *A collection of testing frameworks.* [back to top](#readme) 
 
-* [Buildasaur](https://github.com/czechboy0/Buildasaur) - Automatic testing of your Pull Requests on GitHub and BitBucket using Xcode Server.
+* [Buildasaur](https://github.com/buildasaurs/Buildasaur) - Automatic testing of your Pull Requests on GitHub and BitBucket using Xcode Server.
 * [CatchingFire](https://github.com/mrackwitz/CatchingFire) - Test Library for Swift's Error Handling.
 * [DVR](https://github.com/venmo/DVR) - A simple network testing framework for Swift.
 * [Erik](https://github.com/phimage/Erik) - An headless browser to access and manipulate webpages using javascript allowing to run functional tests.
@@ -920,7 +920,7 @@ Please take a quick look at the [contribution guidelines](.github/CONTRIBUTING.m
 
 * [Async](https://github.com/duemunk/Async) - Syntactic Swift sugar for Grand Central Dispatch.
 * [AwaitKit](https://github.com/yannickl/AwaitKit) - The ES7 Async/Await control flow for Swift.
-* [Chronos](https://github.com/comyarzaheri/Chronos-Swift) - Grand Central Dispatch Utilities.
+* [Chronos](https://github.com/comyar/Chronos-Swift) - Grand Central Dispatch Utilities.
 * [Dispatcher](https://github.com/aleclarson/dispatcher) - Queues, timers, and task groups in Swift.
 * [EKI](https://github.com/kodlian/Eki) - Make Grand Central Dispatch easy and fun to use (queue, task, group, timer and semaphore).
 * [GCD](https://github.com/nghialv/GCD) - A wrapper of Grand Central Dispatch written in Swift.
@@ -1072,7 +1072,7 @@ Please take a quick look at the [contribution guidelines](.github/CONTRIBUTING.m
 * [CountdownLabel](https://github.com/suzuki-0000/CountdownLabel) - Simple countdown UILabel with morphing animation, and some useful function.
 * [FloatLabelFields](https://github.com/FahimF/FloatLabelFields) - Text entry controls which contain a built-in title/label so that you don't have to add a separate title for each field.
 * [GlitchLabel](https://github.com/kciter/GlitchLabel) - Glitching UILabel for iOS.
-* [IconLabel](https://github.com/anatoliyv/IconLabel) - UILabel with image placed from left or right.
+* [IconLabel](https://github.com/anatoliyv/SMIconLabel) - UILabel with image placed from left or right.
 * [IncrementableLabel](https://github.com/recisio/IncrementableLabel) - An UILabel subclass to (de)increment numbers in an UILabel
 * [KDEDateLabel](https://github.com/delannoyk/KDEDateLabel) - An UILabel subclass that updates itself to make time ago's format easier.
 * [LTMorphingLabel](https://github.com/lexrus/LTMorphingLabel) - Graceful morphing effects for UILabel written in Swift.


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/anatoliyv/IconLabel | https://github.com/anatoliyv/SMIconLabel 
https://github.com/comyarzaheri/Chronos-Swift | https://github.com/comyar/Chronos-Swift 
https://github.com/comyarzaheri/TuningFork | https://github.com/comyar/TuningFork 
https://github.com/czechboy0/Buildasaur | https://github.com/buildasaurs/Buildasaur 
https://github.com/czechboy0/XcodeServerSDK | https://github.com/buildasaurs/XcodeServerSDK 
https://github.com/pepibumur/SugarRecord | https://github.com/carambalabs/SugarRecord 
