### PR TITLE
Add CSS3ColorsSwift

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -1047,6 +1047,11 @@
 		"description": "Hex to UIColor converter.",
 		"homepage": "https://github.com/yeahdongcn/UIColor-Hex-Swift"
 	}, {
+		"title": "CSS3ColorsSwift",
+		"category": "colors",
+		"description": "A UIColor extension with CSS3 Colors name.",
+		"homepage": "https://github.com/WorldDownTown/CSS3ColorsSwift"
+	}, {
 		"title": "Commander",
 		"category": "command-line",
 		"description": "Compose beautiful command line interfaces in Swift.",


### PR DESCRIPTION
- **Project Name**: CSS3ColorsSwift
- **Project URL**: https://github.com/WorldDownTown/CSS3ColorsSwift
- **Project Description**: A UIColor extension with CSS3 Colors name.
- **Why it should be added to `awesome-swift`**: Because this library is simpler than other similar libraries. and you can write web color like UIColor in Swift 3.
- [x] At least 15 stars (GitHub project)
- [x] Support `Swift 3`
- [x] Updated **contents.json** instead of README
