### PR TITLE
Review guideline coherency

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,13 +9,14 @@ The README is generated from **contents.json**, please update the JSON file inst
 
 To be added to the list, software should meet the following criteria:
 
+- Written in Swift
 - Actively maintained
 - Performs a useful function
 - Used by the community
 - Well documented
 - Work with the latest SDK
 - Have at least 15 stars on (GitHub project)
-- Support `Swift 3`
+- ~~Support `Swift 3`~~
 
 If an item on the list no longer meets the above criteria, open an issue to have it be removed.
 


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-swift 😊 -->

<!-- Reminder: Please update contents.json instead of the README -->

<!-- Please fill out the short form below -->

- **Project Name**:
- **Project URL**:
- **Project Description**:
- **Why it should be added to `awesome-swift`**:
- [ ] At least 15 stars (GitHub project)
- [ ] Support `Swift 3`
- [ ] Updated **contents.json** instead of README

The guideline ask for project to Support Swift 3 but you are rejecting PR of projects that support Swift 3 **perfectly** (see https://github.com/matteocrippa/awesome-swift/pull/756) while listing others that do **not** support Swift 3  , see https://github.com/Haneke/HanekeSwift