### PR TITLE
Add xcprofiler

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -4254,6 +4254,12 @@
         "category": "network",
         "description": "A toolkit for Network Extension Framework",
         "homepage": "https://github.com/zhuhaow/NEKit"
+ 	},
+	{
+	 "title": "xcprofiler",
+	 "category": "benchmark",
+	 "description": "Command line utility to profile compilation time of Swift project.",
+	 "homepage": "https://github.com/giginet/xcprofiler"
  	}
 ]
 }


### PR DESCRIPTION
- **Project Name**:

xcprofiler

- **Project URL**:

https://github.com/giginet/xcprofiler

- **Project Description**:

Command line utility to profile compilation time of Swift project.

- **Why it should be added to `awesome-swift`**:

There is only one project in benchmark category.
I think this is useful for all Swift projects.

- [x] At least 15 stars (GitHub project)
- [x] Support `Swift 3`
- [x] Updated **contents.json** instead of README
