### PR TITLE
Updated description of FileProvider

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -1218,7 +1218,7 @@
 	}, {
 		"title": "FileProvider",
 		"category": "files",
-		"description": "NSFileManager replacement for Local and Remote (WebDAV/Dropbox/SMB2) files.",
+		"description": "FileManager replacement for Local and Remote (WebDAV/Dropbox/OneDrive/SMB2) files for iOS/tvOS and macOS.",
 		"homepage": "https://github.com/amosavian/FileProvider"
 	}, {
 		"title": "AlamofireJsonToObjects",


### PR DESCRIPTION
Updated FileProvider description:
Added OneDrive
Using Swift 3 naming convention

- **Project Name**: FileProvider
- **Project URL**: https://github.com/amosavian/FileProvider
- **Project Description**: FileManager replacement for Local and Remote (WebDAV/Dropbox/OneDrive/SMB2) files
- **Why it should be added to `awesome-swift`**: Already added
- [x] At least 15 stars (GitHub project)
- [x] Support `Swift 3`
- [x] Updated **contents.json** instead of README