### PR TITLE
Remove FCAlertView, does not support Swift 3

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -3362,11 +3362,6 @@
 		"description": "Easy Swift UIAlertController.",
 		"homepage": "https://github.com/thellimist/EZAlertController"
 	}, {
-		"title": "FCAlertView",
-		"category": "alert",
-		"description": "A Flat Customizable AlertView for iOS.",
-		"homepage": "https://github.com/k9101/FCAlertView"
-	}, {
 		"title": "GoogleWearAlert",
 		"category": "alert",
 		"description": "Google Wear Alert style.",


### PR DESCRIPTION
Originally added in #700 