### PR TITLE
Remove SlideShare style guide

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -620,11 +620,6 @@
 		"description": "Raywenderlich Swift guide, a must read.",
 		"homepage": "https://github.com/raywenderlich/swift-style-guide"
 	}, {
-		"title": "SlideShare",
-		"category": "style-guides",
-		"description": "Style guides that SlideShare uses for their Swift iOS app.",
-		"homepage": "https://github.com/SlideShareInc/swift-style-guide"
-	}, {
 		"title": "LinkedIn",
 		"category": "style-guides",
 		"description": "LinkedIn's Official Swift Style Guide",


### PR DESCRIPTION
https://github.com/SlideShareInc/swift-style-guide has not been updated in 8 months