### PR TITLE
Add PinLayout layout framework

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -2039,7 +2039,7 @@
     }, {
       "title": "PinLayout",
       "category": "layout",
-      "description": "Manual views layouting, no magic, pure code, full control. Concise syntax, readable & chainable.",
+      "description": "Manual views layouting without auto layout, no magic, pure code, full control. Concise syntax, readable & chainable.",
       "homepage": "https://mirego.github.io/PinLayout/"
     }, {
       "title": "Stevia",

--- a/contents.json
+++ b/contents.json
@@ -2039,7 +2039,7 @@
     }, {
       "title": "PinLayout",
       "category": "layout",
-      "description": "Swift manual views layouting, no magic, pure code, full control. Concise syntax, readable & chainable.",
+      "description": "Manual views layouting, no magic, pure code, full control. Concise syntax, readable & chainable.",
       "homepage": "https://mirego.github.io/PinLayout/"
     }, {
       "title": "Stevia",

--- a/contents.json
+++ b/contents.json
@@ -2037,6 +2037,11 @@
       "description": "A simple static table views for iOS.",
       "homepage": "https://github.com/venmo/Static"
     }, {
+      "title": "PinLayout",
+      "category": "layout",
+      "description": "Swift manual views layouting, no magic, pure code, full control. Concise syntax, readable & chainable.",
+      "homepage": "https://mirego.github.io/PinLayout/"
+    }, {
       "title": "Stevia",
       "category": "layout",
       "description": "Elegant view layout for iOS.",


### PR DESCRIPTION
Manual views layouting without auuto layout, no magic, pure code, full control. Concise syntax, readable & chainable.
https://mirego.github.io/PinLayout

<!-- Thanks for contributing to awesome-swift 😊 -->

<!-- Reminder: Please update contents.json instead of the README -->

<!-- Please fill out the short form below -->

- **PinLayout**:
- **https://mirego.github.io/PinLayout**:
- ** Manual views layouting without auto layout, no magic, pure code, full control. Concise syntax, readable & chainable.**:
- ** I know, another Layout framework, but this one is totally stateless and doesn't rely on auto layout, so it can be used with any other layout framework, including LayoutKit, SnapKit, Yoga Flexbox, ... The syntax is really simple, concise, readable and chainable. Currently trending in https://github.com/trending/swift :-) **:
- [X] At least 15 stars (GitHub project)
- [X] Support `Swift 3`
- [X] Updated **contents.json** instead of README
- [X] Lib is fully open sourced, written in Swift and not a wrapper over compiled lib
- [X] Description does not say "written in Swift" or variant 🤓
