### PR TITLE
Add FlexLayout layout framework

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -2109,6 +2109,11 @@
       "description": "A simple static table views for iOS.",
       "homepage": "https://github.com/venmo/Static"
     }, {
+      "title": "FlexLayout",
+      "category": "layout",
+      "description": "FlexLayout adds a nice Swift interface to the highly optimized facebook/yoga flexbox implementation. Concise, intuitive & chainable syntax. Works perfectly with PinLayout.",
+      "homepage": "https://github.com/lucdion/FlexLayout/"
+    }, {
       "title": "PinLayout",
       "category": "layout",
       "description": "Manual views layouting without auto layout, no magic, pure code, full control. Concise syntax, readable & chainable.",

--- a/contents.json
+++ b/contents.json
@@ -2111,7 +2111,7 @@
     }, {
       "title": "FlexLayout",
       "category": "layout",
-      "description": "FlexLayout adds a nice Swift interface to the highly optimized facebook/yoga flexbox implementation. Concise, intuitive & chainable syntax. Works perfectly with PinLayout.",
+      "description": "FlexLayout adds a nice and clean interface to the highly optimized facebook/yoga flexbox implementation. Concise, intuitive & chainable syntax. Works perfectly with PinLayout.",
       "homepage": "https://github.com/lucdion/FlexLayout/"
     }, {
       "title": "PinLayout",


### PR DESCRIPTION
- **Project Name**: FlexLayout
- **Project URL**: https://github.com/lucdion/FlexLayout
- **Project Description**: FlexLayout adds a nice Swift interface to the highly optimized facebook/yoga flexbox implementation. Concise, intuitive & chainable syntax. Works perfectly with PinLayout.
- **Why it should be added to `awesome-swift`**:
There is already some other Yoga wrapper, but none expose a clean and simple Swift interface as FlexLayout.

Also, FlexLayout can be used in cooperation with PinLayout (https://github.com/mirego/PinLayout). They share a similar syntax and method names.

- [x] At least 15 stars (GitHub project)
- [x] Support `Swift 3`
- [x] Updated **contents.json** instead of README
- [x] Lib is fully open sourced, written in Swift and not a wrapper over compiled lib
- [x] Description does not say "written in Swift" or variant 🤓
