### PR TITLE
Added: URLQueryItemEncoder

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -5511,6 +5511,12 @@
       "description": "Iridescent Effect View (inspired by Apple Pay Cash)",
       "homepage": "https://github.com/efremidze/Shiny",
       "tags": ["hologram", "animation", "applepay", "swift"]
+    }, {
+      "title": "URLQueryItemEncoder",
+      "category": "utility",
+      "description": "A Swift Encoder for encoding any Encodable value into an array of URLQueryItem."
+      "homepage": "https://github.com/pitiphong-p/URLQueryItemEncoder",
+      "tags": ["urlqueryitem", "codable", "encoder", "swift"]
     }
   ]
 }

--- a/contents.json
+++ b/contents.json
@@ -5514,7 +5514,7 @@
     }, {
       "title": "URLQueryItemEncoder",
       "category": "utility",
-      "description": "A Swift Encoder for encoding any Encodable value into an array of URLQueryItem."
+      "description": "An Encoder for encoding any Encodable value into an array of URLQueryItem.",
       "homepage": "https://github.com/pitiphong-p/URLQueryItemEncoder",
       "tags": ["urlqueryitem", "codable", "encoder", "swift"]
     }


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-swift 😊 -->

<!-- Reminder: Please update contents.json instead of the README -->

<!-- Please fill out the short form below -->

- **Project Name**: URLQueryItemEncoder
- **Project URL**: https://github.com/pitiphong-p/URLQueryItemEncoder
- **Project Description**:
An Encoder for encoding any Encodable value into an array of URLQueryItem. As part of the SE-0166, Swift has a foundation for any type to define how its value should be archived. This encoder allows you to encode those value into an array of URLQueryItem which represent that value in one command.
- **Why it should be added to `awesome-swift`**:
*URLQueryItemEncoder* is an Encoder which isn't included in the Swift Standard Library. 
URL Query is a common data representation on the internet and has some edge cases. It's used for serializing data in `REST`, `HTTP` etc. which are common operations on the internet. However Swift Standard Library doesn't include this type of encoder with it. This library will help many developers to save time and headache to implement this feature. It comes with a simple interface and is easy to use.

- [x] At least 15 stars (GitHub project)
- [x] Support `Swift 4`
- [x] Updated **contents.json** instead of README
- [x] Lib is fully open sourced, written in Swift and not a wrapper over compiled lib
- [x] Description does not say "written in Swift" or variant 🤓