### PR TITLE
Add MCScratchImageView

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -5500,7 +5500,7 @@
       "category": "uicollectionview",
       "description": "UICollectionViewLayout to show slanted content.",
       "homepage": "https://github.com/yacir/CollectionViewSlantedLayout"
-    } , {
+    }, {
       "title": "Sukari",
       "category": "Syntactic Sugar",
       "description": "Sweet Syntactic Sugar for your Swift",
@@ -5517,6 +5517,11 @@
       "description": "An Encoder for encoding any Encodable value into an array of URLQueryItem.",
       "homepage": "https://github.com/pitiphong-p/URLQueryItemEncoder",
       "tags": ["urlqueryitem", "codable", "encoder", "swift"]
+    }, {
+      "title": "MCScratchImageView",
+      "category": "images",
+      "description": "A custom ImageView that is used to cover the surface of other view like a scratch card, user can swipe the mulch to see the view below",
+      "homepage": "https://github.com/Minecodecraft/MCScratchImageView"
     }
   ]
 }


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-swift 😊 -->

<!-- Reminder: Please update contents.json instead of the README -->

<!-- Please fill out the short form below -->

- **Project Name**: MCScratchImageView
- **Project URL**: https://github.com/Minecodecraft/MCScratchImageView
- **Project Description**: A custom ImageView that is used to cover the surface of another view like a scratch card, the user can swipe the mulch to see the view below
- **Why it should be added to `awesome-swift`**: --
- [x] At least 15 stars (GitHub project)
- [x] Support `Swift 4`
- [x] Updated **contents.json** instead of README
- [x] Lib is fully open sourced, written in Swift and not a wrapper over compiled lib
- [x] Description does not say "written in Swift" or variant 🤓