### PR TITLE
Add ShowTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,7 +721,6 @@ Please take a quick look at the [contribution guidelines](.github/CONTRIBUTING.m
 * [SwiftyGestureRecognition](https://github.com/b3ll/SwiftyGestureRecognition) - UIGestureRecognizers in Xcode Playgrounds.
 * [SwipyCell](https://github.com/moritzsternemann/SwipyCell) - UITableViewCell implementing swiping to trigger actions (known from the Mailbox App).
 * [Tactile](https://github.com/delba/Tactile) - Attach function handlers to gesture and control events in a more expressive and safer way.
-* [ShowTime](https://github.com/KaneCheshire/ShowTime) - The easiest way to show off your iOS taps and gestures for demos and videos.
 
 ### Hardware
 *A category dedicated to hardware related libs* [back to top](#readme) 

--- a/README.md
+++ b/README.md
@@ -721,6 +721,7 @@ Please take a quick look at the [contribution guidelines](.github/CONTRIBUTING.m
 * [SwiftyGestureRecognition](https://github.com/b3ll/SwiftyGestureRecognition) - UIGestureRecognizers in Xcode Playgrounds.
 * [SwipyCell](https://github.com/moritzsternemann/SwipyCell) - UITableViewCell implementing swiping to trigger actions (known from the Mailbox App).
 * [Tactile](https://github.com/delba/Tactile) - Attach function handlers to gesture and control events in a more expressive and safer way.
+* [ShowTime](https://github.com/KaneCheshire/ShowTime) - The easiest way to show off your iOS taps and gestures for demos and videos.
 
 ### Hardware
 *A category dedicated to hardware related libs* [back to top](#readme) 

--- a/contents.json
+++ b/contents.json
@@ -1957,6 +1957,11 @@
       "description": "Attach function handlers to gesture and control events in a more expressive and safer way.",
       "homepage": "https://github.com/delba/Tactile"
     }, {
+      "title": "ShowTime",
+      "category": "gesture",
+      "description": "Show off your iOS taps and gestures for demos and videos with just one line of code.",
+      "homepage": "https://github.com/KaneCheshire/ShowTime"
+    }, {
       "title": "iBeacon",
       "category": "ibeacon",
       "description": "iBeacon implementation.",


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-swift 😊 -->

<!-- Reminder: Please update contents.json instead of the README -->

<!-- Please fill out the short form below -->

- **Project Name**: ShowTime
- **Project URL**: https://github.com/KaneCheshire/ShowTime
- **Project Description**: The easiest way to show off your iOS taps and gestures for demos and videos.
- **Why it should be added to `awesome-swift`**: With just one line of code after installing the pod, you can show off your multitouch taps and gestures for presentations and videos. ShowTime works with single- and multi-window setups out-the-box without subclassing, and also works with iOS Widgets. ShowTime shows the level of force you're applying and can be configured to show or ignore Apple Pencil events. ShowTime is heavily customisable but also works perfectly out-the-box after setting `ShowTime.enabled = .always` somewhere in your code.
- [x] At least 15 stars (GitHub project)
- [x] Support `Swift 4`
- [x] Updated **contents.json** instead of README
- [x] Lib is fully open sourced, written in Swift and not a wrapper over compiled lib
- [x] Description does not say "written in Swift" or variant 🤓