### PR TITLE
Remove linux tag from SwiftyJSON

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -1477,8 +1477,7 @@
       "title": "SwiftyJSON",
       "category": "json",
       "description": "A lib for JSON with error handling.",
-      "homepage": "https://github.com/SwiftyJSON/SwiftyJSON",
-      "tags": ["linux"]
+      "homepage": "https://github.com/SwiftyJSON/SwiftyJSON"
     }, {
       "title": "Freddy",
       "category": "json",


### PR DESCRIPTION
I'm neither removing or adding a resource to the list, I'm removing a linux tag. Feel free to close this PR and I can create an issue if that's more appropriate!

This package had the 🐧  but unfortunately [doesn't work](https://github.com/SwiftyJSON/SwiftyJSON/issues/413) on Linux now. There is a fork by IBM with Linux support but the documentation is not updated and it is not as well maintained at the moment.

Thanks for maintaining this awesome Awesome List 👏 