### PR TITLE
Fix link for SuperRecord

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -1307,7 +1307,7 @@
       "title": "SugarRecord",
       "category": "core-data",
       "description": "Helps with Core Data and Realm.",
-      "homepage": "https://github.com/carambalabs/SugarRecord"
+      "homepage": "https://github.com/modo-studio/SugarRecord"
     }, {
       "title": "SuperRecord",
       "category": "core-data",


### PR DESCRIPTION
301 https://github.com/carambalabs/SugarRecord  → https://github.com/modo-studio/SugarRecord 