### PR TITLE
Add PMKVObserver

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -1830,6 +1830,11 @@
       "description": "NoticeObserveKit is type-safe NotificationCenter wrapper that associates notice type with info type.",
       "homepage": "https://github.com/marty-suzuki/NoticeObserveKit"
     }, {
+      "title": "PMKVObserver",
+      "category": "events",
+      "description": "Modern thread-safe and type-safe key-value observing for Swift and Objective-C.",
+      "homepage": "https://github.com/postmates/PMKVObserver/"
+    }, {
       "title": "FontAwesome.swift",
       "category": "fonts",
       "description": "Use FontAwesome in your projects.",


### PR DESCRIPTION
- **Project Name**: PMKVObserver
- **Project URL**: https://github.com/postmates/PMKVObserver/
- **Project Description**: Modern thread-safe and type-safe key-value observing for Swift and Objective-C
- **Why it should be added to `awesome-swift`**:
- [X] At least 15 stars (GitHub project)
- [X] Support `Swift 4`
- [X] Updated **contents.json** instead of README
- [X] Lib is fully open sourced, written in Swift and not a wrapper over compiled lib
- [X] Description does not say "written in Swift" or variant 🤓

I didn't see any pre-existing category that seemed more specific than "utility". You have a KVC category, which appears to be completely empty, but KVO != KVC.

Also the library itself is still marked as Swift 3.3, but it builds just fine with a Swift 4.1 compiler. It's only marked as Swift 3.3 still to retain compatibility with older Xcodes.