### PR TITLE
Add Tuist and xcodeproj

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -726,6 +726,16 @@
       "description": "Easily generate cross platform framework projects from the command line.",
       "homepage": "https://github.com/JohnSundell/SwiftPlate"
     }, {
+      "title": "Tuist",
+      "category": "tuist",
+      "description": "An open source command line tool written in Swift to create, maintain and interact with your Xcode projects at scale.",
+      "homepage": "https://github.com/tuist/tuist"
+    }, {
+      "title": "xcodeproj",
+      "category": "misc",
+      "description": "A Swift library to read, update and write Xcode projects and workspaces.",
+      "homepage": "https://github.com/tuist/xcodeproj"
+    }, {
       "title": "Capable",
       "category": "accessibility",
       "description": "Track accessibility features to improve your app for people with certain disabilities.",


### PR DESCRIPTION
- **Project Name**: Tuist
- **Project URL**: https://github.com/tuist
- **Project Description**: Tuist is a command line tool to create, maintain and interact with Xcode projects. I've also added xcodeproj, the library Tuist depends on.
- **Why it should be added to `awesome-swift`**:
- [x] At least 15 stars (GitHub project)
- [x] Support `Swift 4`
- [x] Updated **contents.json** instead of README
- [x] Lib is fully open sourced, written in Swift and not a wrapper over compiled lib
- [x] Description does not say "written in Swift" or variant 🤓