### PR TITLE
Removing GradientProgressBar from UI category

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -4798,11 +4798,6 @@
       "description": "An animated gradient loading bar.",
       "homepage": "https://github.com/fxm90/GradientLoadingBar"
     }, {
-      "title": "GradientProgressBar",
-      "category": "ui",
-      "description": "A customizable gradient progress bar (UIProgressView).",
-      "homepage": "https://github.com/fxm90/GradientProgressBar"
-    }, {
       "title": "Thingy",
       "category": "device",
       "description": "A modern device detection and querying library.",


### PR DESCRIPTION
Fixes #1331 
Leaves `GradientProgressBar` in the HUD category while removing it from the UI category, as the latter is less specific