### PR TITLE
Fix link issue

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -1062,7 +1062,7 @@
       "title": "Gradients",
       "category": "colors",
       "description": "A curated collection of splendid 180+ gradients.",
-      "homepage": "https://github.com/cruisediary/Gradients"
+      "homepage": "https://github.com/Gradients/Gradients"
     }, {
       "title": "HexColor",
       "category": "colors",


### PR DESCRIPTION
1. [L1065] 301 https://github.com/cruisediary/Gradients  → https://github.com/Gradients/Gradients