### PR TITLE
add nef in command line section

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -595,7 +595,6 @@
     "parent": "game-engine"
   }],
   "projects": [{
-	  
       "title": "ModelAssistant",
       "category": "multi-database",
       "description": "Elegant library to manage the interactions between view and model",
@@ -1172,6 +1171,12 @@
       "description": "A zero-dependency replacement for readline.",
       "homepage": "https://github.com/andybest/linenoise-swift",
       "tags": ["linux"]
+    }, {
+      "title": "nef",
+      "category": "command-line",
+      "description": "A set of command line tools that lets you have compile time verification of your documentation written as Xcode Playground.",
+      "homepage": "https://github.com/bow-swift/nef",
+      "tags": ["macOS"]
     }, {
       "title": "SwiftCLI",
       "category": "command-line",


### PR DESCRIPTION
- **Project Name**: nef
- **Project URL**: https://github.com/bow-swift/nef
- **Project Description**: A set of command-line tools that lets you have compile time verification of your documentation written as Xcode Playground.
- **Why it should be added to `awesome-swift`**:
It is a cool tool to expand a lot the powerfull of Xcode Playgrounds. You can write documentation using Xcode Playgrounds markdown and using `nef` you can verify from command line everything is working properly. 

It is not only you can do with `nef`. Additionally, `nef` provides the following features:

+ Eases the creation of Xcode Playgrounds with support for **third party libraries**.
+ **Compiles Xcode Playgrounds** with support for third-party libraries from the command line.
+ Generates **Markdown** project from Xcode Playground.
+ Generates Markdown files that can be consumed from **Jekyll for building a microsite**.
+ Export **Carbon** code snippets for given Xcode Playgrounds.

- [x] At least 15 stars (GitHub project)
- [x] Support `Swift 4`
- [x] Updated **contents.json** instead of README
- [x] Lib is fully open sourced, written in Swift and not a wrapper over compiled lib
- [x] Description does not say "written in Swift" or variant 🤓
