### PR TITLE
add SwiftFormat

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -5766,6 +5766,11 @@
       "category": "utility",
       "description": "📦 KeyPath dynamicMemberLookup based syntax sugar for Swift.",
       "homepage": "https://github.com/marty-suzuki/DuctTape"
+    }, {
+      "title": "SwiftFormat",
+      "category": "quality",
+      "description": "A code library and command-line formatting tool for reformatting Swift code",
+      "homepage": "https://github.com/nicklockwood/SwiftFormat"
     }
   ]
 }

--- a/contents.json
+++ b/contents.json
@@ -5769,7 +5769,7 @@
     }, {
       "title": "SwiftFormat",
       "category": "quality",
-      "description": "A code library and command-line formatting tool for reformatting Swift code",
+      "description": "A code library and command-line formatting tool for reformatting Swift code.",
       "homepage": "https://github.com/nicklockwood/SwiftFormat"
     }
   ]


### PR DESCRIPTION
- **Project Name**: SwiftFormat
- **Project URL**: https://github.com/nicklockwood/SwiftFormat
- **Project Description**: A code library and command-line formatting tool for reformatting Swift code
- **Why it should be added to `awesome-swift`**:
- [x] At least 15 stars (GitHub project)
- [x] Support `Swift 5`
- [x] Updated **contents.json** instead of README
- [x] Lib is fully open sourced, written in Swift and not a wrapper over compiled lib
- [x] Description does not say "written in Swift" or variant 🤓

