### PR TITLE
Adding CodableWrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,6 @@ PLEASE DO NOT UPDATE THIS FILE, UPDATE CONTENTS.JSON INSTEAD. THANK YOU :-)
 ## Misc
 *Miscellaneous Swift related projects* 
 * [Beak](https://github.com/yonaskolb/Beak) - A command line interface for your Swift scripts.
-* [CodableWrappers](https://github.com/GottaGetSwifty/CodableWrappers) - A Collection of PropertyWrappers to make custom Serialization of Swift Codable Types easy (Swift 5.1)
 * [Model2App](https://github.com/Q-Mobile/Model2App) - Turn your data model into a working CRUD app.
 * [SwagGen](https://github.com/yonaskolb/SwagGen) :penguin: - A command line tool for generating a REST API from a Swagger spec based off Stencil templates.
 * [swift-compiler-crashes](https://github.com/practicalswift/swift-compiler-crashes) - A collection of test cases crashing the compiler.

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ PLEASE DO NOT UPDATE THIS FILE, UPDATE CONTENTS.JSON INSTEAD. THANK YOU :-)
 ## Misc
 *Miscellaneous Swift related projects* 
 * [Beak](https://github.com/yonaskolb/Beak) - A command line interface for your Swift scripts.
+* [CodableWrappers](https://github.com/GottaGetSwifty/CodableWrappers) - A Collection of PropertyWrappers to make custom Serialization of Swift Codable Types easy (Swift 5.1)
 * [Model2App](https://github.com/Q-Mobile/Model2App) - Turn your data model into a working CRUD app.
 * [SwagGen](https://github.com/yonaskolb/SwagGen) :penguin: - A command line tool for generating a REST API from a Swagger spec based off Stencil templates.
 * [swift-compiler-crashes](https://github.com/practicalswift/swift-compiler-crashes) - A collection of test cases crashing the compiler.

--- a/contents.json
+++ b/contents.json
@@ -4866,6 +4866,13 @@
       "description": "A command line interface for your Swift scripts.",
       "homepage": "https://github.com/yonaskolb/Beak"
     }, {
+      "title": "CodableWrappers",
+      "category": "misc",
+      "description": "A Collection of PropertyWrappers to make custom Serialization of Swift Codable Types easy.",
+      "homepage": "https://github.com/GottaGetSwifty/CodableWrappers",
+      "tags": ["swift", "codable", "property-wrappers"]
+    },
+    {
       "title": "Fluid Slider",
       "category": "ui",
       "description": "A slider widget with a popup bubble displaying the precise value selected.",

--- a/contents.json
+++ b/contents.json
@@ -4868,7 +4868,7 @@
     }, {
       "title": "CodableWrappers",
       "category": "misc",
-      "description": "A Collection of PropertyWrappers to make custom Serialization of Swift Codable Types easy.",
+      "description": "A Collection of PropertyWrappers to make custom Serialization of Codable Types easy.",
       "homepage": "https://github.com/GottaGetSwifty/CodableWrappers",
       "tags": ["swift", "codable", "property-wrappers"]
     },


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-swift 😊 -->

<!-- Reminder: Please update contents.json instead of the README -->

<!-- Please fill out the short form below -->

- **Project Name**:
CodableWrappers
- **Project URL**:
https://github.com/GottaGetSwifty/CodableWrappers
- **Project Description**:
A Collection of PropertyWrappers to make custom Serialization of Codable Types easy
- **Why it should be added to `awesome-swift`**:
Compact library that utilizes Swift 5.1 features to make Custom serialization simple
- [✅] At least 15 stars (GitHub project)
- [5.1] Support `Swift 5`
- [✅] Updated **contents.json** instead of README
- [✅] Lib is fully open sourced, written in Swift and not a wrapper over compiled lib
- [✅] Description does not say "written in Swift" or variant 🤓
