### PR TITLE
Remove SuperDelegate(Deprecated)

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -486,10 +486,6 @@
     "parent": "ui",
     "description": "Libs to display alert, action sheet, notification, popup."
   }, {
-    "title": "ApplicationDelegate",
-    "id": "applicationdelegate",
-    "parent": "ui"
-  }, {
     "title": "Blur",
     "id": "blur",
     "parent": "ui"
@@ -3340,11 +3336,6 @@
       "category": "alert",
       "description": "Fully customizable and extensible action sheet controller.",
       "homepage": "https://github.com/xmartlabs/XLActionController"
-    }, {
-      "title": "SuperDelegate",
-      "category": "applicationdelegate",
-      "description": "SuperDelegate provides a clean application delegate interface and protects you from bugs in the application lifecycle.",
-      "homepage": "https://github.com/Square/SuperDelegate"
     }, {
       "title": "NFDownloadButton",
       "category": "button",


### PR DESCRIPTION
Removed the deprecated library [SuperDelegate](https://github.com/Square/SuperDelegate)