### PR TITLE
Add CloudCore to core-data category

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -1247,6 +1247,11 @@
       "description": "Framework that hides the complexity of managed object contexts.",
       "homepage": "https://github.com/jmfieldman/cadmium"
     }, {
+      "title": "CloudCore",
+      "category": "core-data",
+      "description": "Robust CloudKit synchronization: offline editing, relationships, shared and public databases, and more.",
+      "homepage": "https://github.com/deeje/CloudCore/"
+    }, {
       "title": "CoreStore",
       "category": "core-data",
       "description": "simple and elegant way to handle Core Data.",


### PR DESCRIPTION
- **Project Name**: CloudCore
- **Project URL**: https://github.com/deeje/CloudCore/
- **Project Description**: Robust CloudKit synchronization: offline editing, relationships, shared and public databases, and more.
- **Why it should be added to `awesome-swift`**: I took over the project from another developer, and continue to refine it, adding support for offline editing (via NSPersistentHistoryTracking) as well as support for all three databases in CloudKit.  The repository ReadMe has a comparison with Apple's built in CloudKit sync engine to show all the features and benefits of CloudCore.  I'll be rolling out support for watchOS soon.
- [√] At least 15 stars (GitHub project)
- [√] Support `Swift 5`
- [√] Updated **contents.json** instead of README
- [√] Lib is fully open sourced, written in Swift and not a wrapper over compiled lib
- [√] Description does not say "written in Swift" or variant 🤓
