### PR TITLE
Add Swiftkube Kubernetes client

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -996,6 +996,12 @@
       "description": "Instagram API wrapper.",
       "homepage": "https://github.com/AnderGoig/SwiftInstagram"
     }, {
+      "title": "Swiftkube",
+      "category": "api",
+      "description": "Swift client for Kubernetes.",
+      "homepage": "https://github.com/swiftkube/client",
+      "tags": ["linux", "macos", "kubernetes", "cloud"]
+    }, {
       "title": "SwiftyInsta",
       "category": "api",
       "description": "Private and Tokenless Instagram RESTful API.",


### PR DESCRIPTION
- **Project Name**: SwiftkubeClient
- **Project URL**: https://github.com/swiftkube/client
- **Project Description**: Swift client for Kubernetes
- **Why it should be added to `awesome-swift`**: Talking to Kubernetes in Swift wasn't possible before.
- [x] At least 15 stars (GitHub project)
- [x] Support `Swift 5`
- [x] Updated **contents.json** instead of README
- [x] Lib is fully open sourced, written in Swift and not a wrapper over compiled lib
- [x] Description _does not say_ "written in Swift" or variant 🤓 😉 (It is literally a Kubernetes client in Swift)

**PS**: I couldn't find a more suitable category for this, so I put it under API. How would you feel about introducing a dedicated `Server-Side`, or `Kubernetes` or `Cloud Native` category. `Serverless` could become a subcategory then.
