### PR TITLE
Remove "Swift 3 VIPER Module Template"

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -4157,11 +4157,6 @@
       "homepage": "https://github.com/yonaskolb/SwagGen",
       "tags": ["linux", "swagger", "swift", "CI", "generator", "template", "open-api"]
     }, {
-      "title": "Swift 3 VIPER Module Template",
-      "category": "boilerplates",
-      "description": "Xcode template for VIPER Architecture.",
-      "homepage": "https://github.com/Juanpe/Swift-VIPER-Module"
-    }, {
       "title": "Hydra",
       "category": "concurrency",
       "description": "Promises & Await - Write better async code.",


### PR DESCRIPTION
I've removed "Swift 3 VIPER Module Template", as it is no longer supported by the original developer:
https://github.com/Juanpe/Swift-VIPER-Module

![image](https://user-images.githubusercontent.com/8013017/118881274-8c97e900-b8fb-11eb-946f-d8724de38686.png)
