### PR TITLE
Add SwiftCurrent to the App Routing category

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -6138,6 +6138,12 @@
       "description": "Library that converts SVG images to UIImage, NSImage and generates CoreGraphics source code.",
       "homepage": "https://github.com/swhitty/SwiftDraw",
       "tags": ["swift", "ios", "macos"]
+    }, {
+      "title": "SwiftCurrent",
+      "category": "app-routing",
+      "description": "Manage complex workflows wherever Swift can be built. It comes with built-in support for UIKit, Storyboards, and SwiftUI.",
+      "homepage": "https://github.com/wwt/SwiftCurrent",
+      "tags": ["uikit", "storyboard", "swiftui", "iOS", "watchOS", "tvOS", "macOS", "declarative", "navigation"]
     }
   ]
 }


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-swift 😊 -->

<!-- Reminder: Please update contents.json instead of the README -->

<!-- Please fill out the short form below -->

- **Project Name**: SwiftCurrent
- **Project URL**: https://github.com/wwt/SwiftCurrent
- **Project Description**: Manage complex workflows wherever Swift can be built. It comes with built-in support for UIKit, Storyboards, and SwiftUI.
- **Why it should be added to `awesome-swift`**: It provides a near boilerplate free approach to declarative navigations and workflows. A different (possibly better) approach than other app-routing offerings.
- [X] At least 15 stars (GitHub project)
- [X] Support `Swift 5`
- [X] Updated **contents.json** instead of README
- [X] Lib is fully open sourced, written in Swift and not a wrapper over compiled lib
- [X] Description does not say "written in Swift" or variant 🤓
