### PR TITLE
Add SVGView

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -615,6 +615,10 @@
     "title": "SOAP",
     "id": "soap",
     "parent": "network"
+  }, {
+    "title": "SVG",
+    "id": "svg",
+    "parent": "libs"
   }],
   "projects": [
     {
@@ -6194,6 +6198,12 @@
       "category": "utility",
       "description": "🏈 Cache CocoaPods for faster rebuild and indexing Xcode project.",
       "homepage": "https://github.com/swiftyfinch/Rugby"
+    },
+    {
+      "title": "SVGView",
+      "category": "svg",
+      "description": "SVG parser and renderer written in SwiftUI.",
+      "homepage": "https://github.com/exyte/SVGView"
     }
   ]
 }


### PR DESCRIPTION
Thought that SVG could be a separate category. I saw a library here that converts SVG images to UIImages in image category, but this library converts every SVG element to SwiftUI elements, so I didn't find a category for it. And seeing as PDF has its own category I decided to go with a separate category for SVG as well. Also contribution guide says to create issue in case I want new category, but should I open a PR in that case as well or just create the issue? I'll create one just in case. Also I know it shouldn't say "written in Swift", but it is in SwiftUI which is imo different, please let me know if I should rephrase the description. Sorry if I messed it up, thank you for all your work, and have a great day!

<!-- Thanks for contributing to awesome-swift 😊 -->

<!-- Reminder: Please update contents.json instead of the README -->

<!-- Please fill out the short form below -->

- **Project Name**: SVGView
- **Project URL**: https://github.com/exyte/SVGView
- **Project Description**: SVG parser and renderer written in SwiftUI
- **Why it should be added to `awesome-swift`**: There are no SVG parsers yet neither in `awesome-swift` nor built-in into Swift or SwiftUI
- [x] At least 15 stars (GitHub project)
- [x] Support `Swift 5`
- [x] Updated **contents.json** instead of README
- [x] Lib is fully open sourced, written in Swift and not a wrapper over compiled lib
- [ ] Description does not say "written in Swift" or variant 🤓
