### PR TITLE
Add Async+

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -4306,6 +4306,12 @@
       "homepage": "https://github.com/efremidze/Magnetic",
       "tags": ["spritekit", "floating", "bubble", "picker", "applemusic", "swift"]
     }, {
+      "title": "async+",
+      "category": "concurrency",
+      "description": "A chainable interface for Swift 5.5's async/await.",
+      "homepage": "https://github.com/async-plus/async-plus",
+      "tags": ["linux", "macOS", "iOS", "tvOS", "watchOS", "5.5"]
+    }, {
       "title": "AsyncNinja",
       "category": "concurrency",
       "description": "A complete set of concurrency and reactive programming primitives.",


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-swift 😊 -->

<!-- Reminder: Please update contents.json instead of the README -->

<!-- Please fill out the short form below -->

- **Project Name**:  async+
- **Project URL**:  https://github.com/async-plus/async-plus
- **Project Description**:  A chainable interface for Swift 5.5's async/await.
- **Why it should be added to `awesome-swift`**:  Swift 5.5's async/await introduces a native solution for asynchronous programming, which is much easier to work with than any of the previous promise/future-based libraries, as it is integrated into the language itself (this probably makes it more performant too at least in the future). However, certain patterns that were once easy involving thrown errors are now awkward to implement with async/await, such as recovery, ignoring, or rethrowing of errors.  Async+ extends swift's native async/await code with a chainable interface to allow these useful patterns once more.  This means more readable, unnested code for asynchronous tasks in Swift 5.5.
- [*] At least 15 stars (GitHub project)
- [*] Support `Swift 5`
- [*] Updated **contents.json** instead of README
- [*] Lib is fully open sourced, written in Swift and not a wrapper over compiled lib
- [*] Description does not say "written in Swift" or variant 🤓
