### PR TITLE
Add BottomSheet

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -6292,7 +6292,7 @@
       "homepage": "https://github.com/exyte/ScalingHeaderScrollView",
       "tags": ["swiftui", "iOS", "sticky-header", "scaling-header"]
     }, {
-      "title": "Bottom Sheet",
+      "title": "BottomSheet",
       "category": "ui",
       "description": "Powerful Bottom Sheet component with content based size, interactive dismissal and navigation controller support.",
       "homepage": "https://github.com/joomcode/BottomSheet",

--- a/contents.json
+++ b/contents.json
@@ -6292,7 +6292,7 @@
       "homepage": "https://github.com/exyte/ScalingHeaderScrollView",
       "tags": ["swiftui", "iOS", "sticky-header", "scaling-header"]
     }, {
-      "title": "Bottom Sheet component",
+      "title": "Bottom Sheet",
       "category": "ui",
       "description": "Powerful Bottom Sheet component with content based size, interactive dismissal and navigation controller support.",
       "homepage": "https://github.com/joomcode/BottomSheet",

--- a/contents.json
+++ b/contents.json
@@ -6291,6 +6291,12 @@
       "description": "A scroll view with a sticky header which shrinks as you scroll. Written with SwiftUI.",
       "homepage": "https://github.com/exyte/ScalingHeaderScrollView",
       "tags": ["swiftui", "iOS", "sticky-header", "scaling-header"]
+    }, {
+      "title": "Bottom Sheet component",
+      "category": "ui",
+      "description": "Powerful Bottom Sheet component with content based size, interactive dismissal and navigation controller support.",
+      "homepage": "https://github.com/joomcode/BottomSheet",
+      "tags": ["uikit", "iOS", "bottom-sheet"]
     }
   ]
 }


### PR DESCRIPTION
- **Project Name**:
BottomSheet

- **Project URL**:
https://github.com/joomcode/BottomSheet

- **Project Description**:
Powerful Bottom Sheet component with content based size, interactive dismissal and navigation controller support.

- **Why it should be added to `awesome-swift`**:
Though Apple introduced [native bottom sheet](https://developer.apple.com/documentation/uikit/uisheetpresentationcontroller), it only work on iOS 15 and above, which makes it practically impossible to use now, so developers need to implement their own.

Suggested component besides standard features as adaptation to content size and interactive dismissal also seamlessly handles scrollable content and UINavigationController without losing any transitions (including interactive ones).

- [x] At least 15 stars (GitHub project)
- [x] Support `Swift 5`
- [x] Updated **contents.json** instead of README
- [x] Lib is fully open sourced, written in Swift and not a wrapper over compiled lib
- [x] Description does not say "written in Swift" or variant 🤓
