### PR TITLE
Rename The Atomic Architecture to SwiftUI Atom Properties

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -6217,7 +6217,7 @@
       "title": "SwiftUI Atom Properties",
       "category": "patterns",
       "description": "A Reactive Data-Binding and Dependency Injection Library for SwiftUI x Concurrency.",
-      "homepage": "https://github.com/ra1028/swiftui-atom-properties.git",
+      "homepage": "https://github.com/ra1028/swiftui-atom-properties",
       "tags": ["swift", "swiftui", "architecture"]
     }, {
       "title": "SwiftDraw",

--- a/contents.json
+++ b/contents.json
@@ -6214,10 +6214,10 @@
 	    "homepage": "https://github.com/pointfreeco/swift-composable-architecture",
 	    "tags": ["swift", "ios"]
     }, {
-      "title": "The Atomic Architecture",
+      "title": "SwiftUI Atom Properties",
       "category": "patterns",
-      "description": "A declarative state management and dependency injection library for SwiftUI x Concurrency.",
-      "homepage": "https://github.com/ra1028/swiftui-atomic-architecture",
+      "description": "A Reactive Data-Binding and Dependency Injection Library for SwiftUI x Concurrency.",
+      "homepage": "https://github.com/ra1028/swiftui-atom-properties.git",
       "tags": ["swift", "swiftui", "architecture"]
     }, {
       "title": "SwiftDraw",


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-swift 😊 -->

<!-- Reminder: Please update contents.json instead of the README -->

<!-- Please fill out the short form below -->

This PR is not adding a new library but is renaming the existing one. Let me know if I should add it as another one and create an issue to remove the existing one.

- **Project Name**: SwiftUI Atom Properties
- **Project URL**: https://github.com/ra1028/swiftui-atom-properties.git
- **Project Description**: This library was already added to awesome-swift with #1746, but it's renamed to the new project name, so this PR reflects it.
- [x] At least 15 stars (GitHub project)
- [x] Support `Swift 5`
- [x] Updated **contents.json** instead of README
- [x] Lib is fully open sourced, written in Swift and not a wrapper over compiled lib
- [x] Description does not say "written in Swift" or variant 🤓
