### PR TITLE
Add ZMarkupParser

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -2307,7 +2307,7 @@
     }, {
       "title": "ZMarkupParser",
       "category": "html",
-      "description": "A pure-Swift library that helps you convert HTML strings into NSAttributedString with customized styles and tags.",
+      "description": "Helps you convert HTML strings into NSAttributedString with customized styles and tags.",
       "homepage": "https://github.com/ZhgChgLi/ZMarkupParser"
     }, {
       "title": "CocoaMQTT",

--- a/contents.json
+++ b/contents.json
@@ -2305,6 +2305,11 @@
       "description": "Headless browser.",
       "homepage": "https://github.com/mkoehnke/WKZombie"
     }, {
+      "title": "ZMarkupParser",
+      "category": "html",
+      "description": "A pure-Swift library that helps you convert HTML strings into NSAttributedString with customized styles and tags.",
+      "homepage": "https://github.com/ZhgChgLi/ZMarkupParser"
+    }, {
       "title": "CocoaMQTT",
       "category": "messaging-protocol",
       "description": "MQTT for iOS and OS X.",


### PR DESCRIPTION
- **Project Name**: ZMarkupParser
- **Project URL**: https://github.com/ZhgChgLi/ZMarkupParser
- **Project Description**: Helps you convert HTML strings into NSAttributedString with customized styles and tags.
- **Why it should be added to `awesome-swift`**:
Currently, there is no similar library on GitHub that can map HTML tags to customized styles.
This library is highly extendable, high-performing, and more compatible than the original NSAttributedString HTML. Additionally, it can automatically correct bad HTML tags.

- [X] At least 15 stars (GitHub project)
- [X] Support `Swift 5`
- [X] Updated **contents.json** instead of README
- [X] Lib is fully open sourced, written in Swift and not a wrapper over compiled lib
- [X] Description does not say "written in Swift" or variant 🤓
