### PR TITLE
Add MemberwiseInit

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -6132,6 +6132,12 @@
       "description": "Enhancing Date handling by enabling type-level customization of date components",
       "homepage": "https://github.com/Ryu0118/swift-typed-date",
       "tags": ["swift", "date", "iOS", "macOS", "tvOS"]
+    }, {
+      "title": "MemberwiseInit",
+      "category": "misc",
+      "description": "`@MemberwiseInit` is a Swift Macro that can more often provide your intended `init`, while following the same safe-by-default semantics of Swift’s memberwise initializers.",
+      "homepage": "https://github.com/gohanlon/swift-memberwise-init-macro",
+      "tags": ["swift", "macro", "init", "initializers"]
     }
   ]
 }


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-swift 😊 -->

<!-- Reminder: Please update contents.json instead of the README -->

<!-- Please fill out the short form below -->

- **Project Name**: MemberwiseInit
- **Project URL**: https://github.com/gohanlon/swift-memberwise-init-macro
- **Project Description**: A Swift Macro that can more often provide your intended `init`, while following the same safe-by-default semantics of Swift’s memberwise initializers.
- **Why it should be added to `awesome-swift`**: MemberwiseInit is a comprehensive tool for creating more expressive, automatically provided initializers. I've used it to remove thousands of lines of boilerplate. It's ~1,000 lines long, and has ~5,000 lines of tests giving practically 100% coverage.
- [x] At least 15 stars (GitHub project)
- [x] Support `Swift 5`
- [x] Updated **contents.json** instead of README
- [x] Lib is fully open sourced, written in Swift and not a wrapper over compiled lib
- [x] Description does not say "written in Swift" or variant 🤓
