### PR TITLE
Add SwiftGodot

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -7723,6 +7723,13 @@
       "description": "FlagAndCountryCode provides phone codes and flags for every country. Works on UIKit and SwiftUI",
       "homepage": "https://github.com/exyte/FlagAndCountryCode",
       "tags": ["swift", "flag", "phone", "country-code"]
+    },
+    {
+      "title": "SwiftFiddle",
+      "category": "repl",
+      "description": "Playground for making, sharing, and embedding Swift code.",
+      "homepage": "https://swiftfiddle.com",
+      "tags": ["swift", "repl", "playground"] 
     }
   ]
 }

--- a/contents.json
+++ b/contents.json
@@ -7730,6 +7730,13 @@
       "description": "Playground for making, sharing, and embedding Swift code.",
       "homepage": "https://swiftfiddle.com",
       "tags": ["swift", "repl", "playground"] 
+    },
+    {
+      "title": "SwiftGodot",
+      "category": "game-engine",
+      "description": "Swift bindings for the Godot game engine to build extensions or act as an api with SwiftGodotKit.",
+      "homepage": "https://migueldeicaza.github.io/SwiftGodotDocs/tutorials/swiftgodot-tutorials/",
+      "tags":["swift", "game-engine", "bindings"]
     }
   ]
 }


### PR DESCRIPTION
- **SwiftGodot**:
- **https://migueldeicaza.github.io/SwiftGodotDocs/tutorials/swiftgodot-tutorials/**:
- **Swift bindings for the Godot game engine to build extensions or act as an api with SwiftGodotKit.**:
- **Why it should be added to `awesome-swift`**:
- [x] At least 15 stars (GitHub project)
- [x] Support `Swift 5`
- [x] Updated **contents.json** instead of README
- [x] Lib is fully open sourced, written in Swift and not a wrapper over compiled lib
- [x] Description does not say "written in Swift" or variant 🤓
