### PR TITLE
Add EunNeun – Korean Particle Attachment Library

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -3437,6 +3437,12 @@
       "homepage":"https://github.com/rxwei/Parsey"
     },
     {
+      "title":"EunNeun",
+      "category":"text",
+      "description":"Automatically chooses the correct Korean particle (은/는, 이/가, 을/를, etc.) for a given word or sentence.",
+      "homepage":"https://github.com/halococo/EunNeun"
+    },
+    {
       "title":"PhoneNumberKit",
       "category":"phone-numbers",
       "description":"Framework for parsing, formatting and validating international phone numbers. Inspired by Google's libphonenumber.",


### PR DESCRIPTION
- Added EunNeun, a Swift library that automatically selects correct Korean particles, to the "text" category.
- 한국어 조사 자동 선택 기능을 제공하는 EunNeun 라이브러리를 text 카테고리에 추가했습니다.

<!-- Thanks for contributing to awesome-swift 😊 -->

<!-- Reminder: Please update contents.json instead of the README -->

<!-- Please fill out the short form below -->

- **Project Name**: EunNeun  
- **Project URL**: https://github.com/halococo/EunNeun  
- **Project Description**: Automatically selects the correct Korean particle (은/는, 이/가, 을/를, etc.) based on the final consonant of the last word in a string.  
- **Why it should be added to `awesome-swift`**: It provides seamless integration of Korean linguistic rules into any Swift app, improving localization and UX for Korean users.

- [x] At least 15 stars (GitHub project)  
- [x] Support `Swift 5`  
- [x] Updated **contents.json** instead of README  
- [x] Lib is fully open sourced, written in Swift and not a wrapper over compiled lib  
- [x] Description does not say "written in Swift" or variant 🤓