### PR TITLE
Add MuscleMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1337,6 +1337,7 @@ In parternship with:
 * [MPParallaxView](https://github.com/DroidsOnRoids/MPParallaxView) - Apple TV Parallax effect.
 * [MultiSelectSegmentedControl](https://github.com/yonat/MultiSelectSegmentedControl) - UISegmentedControl remake that supports selecting multiple segments, vertical stacking, combining text and images.
 * [MultiSlider](https://github.com/yonat/MultiSlider) - UISlider clone with multiple thumbs and values, range highlight, optional snap intervals, optional value labels, either vertical or horizontal.
+* [MuscleMap](https://github.com/melihcolpan/MuscleMap) - A SwiftUI SDK for rendering interactive human body muscle maps with highlights, heatmaps, gestures, and UIKit support.
 * [MXParallaxHeader](https://github.com/maxep/MXParallaxHeader) - Simple parallax header for UIScrollView.
 * [MZFormSheetPresentationController](https://github.com/m1entus/MZFormSheetPresentationController) - Provides an alternative to the native iOS UIModalPresentationFormSheet, adding support for iPhone and additional opportunities to setup controller size and feel form sheet.
 * [NeumorphismKit](https://github.com/y-okudera/NeumorphismKit) - Neumorphism framework for UIKit.


### PR DESCRIPTION
Add [MuscleMap](https://github.com/melihcolpan/MuscleMap) to the **UI** section.

MuscleMap is a SwiftUI SDK for rendering interactive human body muscle maps. Features:

- Male & female body models (front & back)
- Muscle highlighting with solid colors, linear/radial gradients
- Heatmap color scales (workout, thermal, medical, monochrome)
- Tap, long-press, and drag gestures
- Pulse animations, zoom, tooltips
- Muscle sub-groups (e.g. upper/lower chest)
- UIKit wrappers (MuscleMapView, HeatmapLegendUIView)
- Accessibility (VoiceOver) & localization (11 languages)
- DocC documentation
- iOS 17+, macOS 14+, Swift 5.9, zero dependencies