### PR TITLE
Add Lockpaw to Security category

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -8616,6 +8616,13 @@
       "category":"app-routing",
       "description":"A minimal and flexible router for SwiftUI apps.",
       "homepage":"https://github.com/gabriel/swiftui-routes"
+    },
+    {
+      "title": "Lockpaw",
+      "category": "security",
+      "description": "A macOS menu bar app that locks the screen while letting background tasks keep running.",
+      "homepage": "https://github.com/sorkila/lockpaw",
+      "tags": ["macos", "menu-bar", "screen-lock", "privacy"]
     }
   ]
 }


### PR DESCRIPTION
## Add Lockpaw

[Lockpaw](https://github.com/sorkila/lockpaw) is a macOS menu bar app that locks the screen while letting background tasks keep running — like Tesla's Dog Mode, but for your Mac. It provides visual privacy and input blocking while agents, builds, and long-running tasks continue underneath.

**Why it should be included:**
- Native Swift/SwiftUI macOS app
- Open source (MIT license)
- 28 GitHub stars (meets the 15-star minimum)
- Actively maintained
- Supports Swift 5+
- Well documented with a [dedicated website](https://getlockpaw.com)
- Available via Homebrew (`brew install --cask lockpaw`)

**Category:** Security — Lockpaw provides screen privacy and input blocking, which fits naturally alongside other security tools.

**Link:** https://github.com/sorkila/lockpaw