### PR TITLE
Add Azex Speech to Audio section

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ In parternship with:
 * [AudioKit](https://github.com/audiokit/AudioKit) - Powerful audio synthesis, processing and analysis, without the steep learning curve.
 * [AudioPlayer](https://github.com/delannoyk/AudioPlayer) - A wrapper around AVPlayer with some cool features.
 * [AudioPlayerSwift](https://github.com/tbaranes/AudioPlayerSwift) - AudioPlayer is a simple class for playing audio (basic and advanced usage) in iOS, OS X and tvOS apps.
+* [Azex Speech](https://github.com/azex-ai/speech) - Mac native voice input for Crypto & AI professionals with local ASR and 1800+ domain terms.
 * [Beethoven](https://github.com/vadymmarkov/Beethoven) - An audio processing library for pitch detection of musical signals.
 * [FDSoundActivatedRecorder](https://github.com/fulldecent/FDSoundActivatedRecorder) - Start recording when the user speaks.
 * [FDWaveformView](https://github.com/fulldecent/FDWaveformView) - An easy way to display an audio waveform in your app.


### PR DESCRIPTION
## Description

Adds [Azex Speech](https://github.com/azex-ai/speech) to the **Audio** section, in alphabetical order between AudioPlayerSwift and Beethoven.

## About the project

- **Swift 6 + SwiftUI**, macOS 14+
- Local on-device speech recognition via sherpa-onnx FireRedASR v2 CTC
- 1800+ Crypto/AI domain vocabulary terms bundled
- Pronunciation training module (voice calibration)
- Open source (Apache 2.0)
- macOS menu bar app with global hotkey, floating editable panel, and implicit learning from user corrections

## Entry added

```
* [Azex Speech](https://github.com/azex-ai/speech) - Mac native voice input for Crypto & AI professionals with local ASR and 1800+ domain terms.
```