### PR TITLE
Add Espresso to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Please take a quick look at the [contribution guidelines](.github/CONTRIBUTING.m
 * [CoreML-Models](https://github.com/likedan/Awesome-CoreML-Models) - A collection of unique Core ML Models.
 * [MLKit](https://github.com/Somnibyte/MLKit) - A simple machine learning framework.
 * [Swift-AI](https://github.com/Swift-AI/Swift-AI) - The machine learning library.
+* [Espresso](https://github.com/christopherkarani/Espresso) - Compile transformers directly to Apple Neural Engine. 4.76x faster than CoreML. Pure Swift, zero dependencies.
 
 ### Algorithm
 [back to top](#readme) 


### PR DESCRIPTION
Espresso compiles transformers directly to Apple Neural Engine via MIL, achieving **4.76x faster inference than CoreML**.

- Pure Swift, zero dependencies
- MIT licensed
- GPT-2 and Llama support
- [GitHub](https://github.com/christopherkarani/Espresso)

Thanks for maintaining this awesome list!