### PR TITLE
Add Mocker

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,7 @@ In parternship with:
 * [Commander](https://github.com/kylef/Commander) :penguin: - Compose beautiful command line interfaces.
 * [Guaka](https://github.com/nsomar/Guaka) :penguin: - The smart and beautiful (POSIX compliant) command line framework.
 * [LineNoise](https://github.com/andybest/linenoise-swift) :penguin: - A zero-dependency replacement for readline.
+* [Mocker](https://github.com/us/mocker) - Docker-compatible container CLI for macOS, built on Apple's Containerization framework.
 * [nef](https://github.com/bow-swift/nef) - A set of command line tools that lets you have compile time verification of your documentation written as Xcode Playground.
 * [Progress.swift](https://github.com/jkandzi/Progress.swift) :penguin: - Add beautiful progress bars to your command line.
 * [Swift Argument Parser](https://github.com/apple/swift-argument-parser) - Straightforward, type-safe argument parsing for Swift.

--- a/contents.json
+++ b/contents.json
@@ -1482,6 +1482,17 @@
       ]
     },
     {
+      "title":"Mocker",
+      "category":"command-line",
+      "description":"Docker-compatible container CLI for macOS, built on Apple's Containerization framework.",
+      "homepage":"https://github.com/us/mocker",
+      "tags":[
+        "macOS",
+        "docker",
+        "containers"
+      ]
+    },
+    {
       "title":"nef",
       "category":"command-line",
       "description":"A set of command line tools that lets you have compile time verification of your documentation written as Xcode Playground.",


### PR DESCRIPTION
[Mocker](https://github.com/us/mocker) is a Docker-compatible container CLI for macOS, built on Apple's Containerization framework.

- **Language:** Swift
- **License:** AGPL-3.0
- **Platform:** macOS (Apple Silicon)

It provides a familiar Docker-like CLI experience (`mocker run`, `mocker build`, `mocker compose`, etc.) using native macOS virtualization, offering near-native performance without requiring Docker Desktop.

Added to the **Command Line** section alphabetically, and updated `contents.json` accordingly.