### PR TITLE
Update stale links in contents.json

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -825,7 +825,7 @@
       "title":"Swift & SwiftUI Tutorials",
       "category":"third-party-guides",
       "description":"SwiftUI learning with Ease.",
-      "homepage":"https://janeshswift.com"
+      "homepage":"http://ww1.janeshswift.com"
     },
     {
       "title":"30 Days of Swift",
@@ -855,7 +855,7 @@
       "title":"SwiftDoc",
       "category":"third-party-guides",
       "description":"Auto-generated documentation.",
-      "homepage":"https://swiftdoc.org/"
+      "homepage":"https://sosumi.ai/"
     },
     {
       "title":"SwiftGuide CN",
@@ -2344,7 +2344,7 @@
       "title":"SwiftWebImage",
       "category":"images",
       "description":"🚀SwiftUI Image downloader with performant LRU mem/disk cache.",
-      "homepage":"https://github.com/geekaurora/SwiftWebImage"
+      "homepage":"https://github.com/HotWordland/SwiftWebImage"
     },
     {
       "title":"Kingfisher",
@@ -6722,7 +6722,7 @@
       "title":"CleanArchitectureRxSwift",
       "category":"patterns",
       "description":"Example of Clean Architecture of iOS app using RxSwift.",
-      "homepage":"https://github.com/sergdort/CleanArchitectureRxSwift"
+      "homepage":"https://github.com/sergdort/ModernCleanArchitectureSwiftUI"
     },
     {
       "title":"LinkedInSignIn",
@@ -6740,7 +6740,7 @@
       "title":"HaishinKit",
       "category":"streaming",
       "description":"Camera and Microphone streaming library via RTMP, HLS for iOS, macOS, tvOS.",
-      "homepage":"https://github.com/shogo4405/HaishinKit.swift"
+      "homepage":"https://github.com/HaishinKit/HaishinKit.swift"
     },
     {
       "title":"XCTest",
@@ -6999,7 +6999,7 @@
       "title":"Real-time Chat with Firebase",
       "category":"chat",
       "description":"Functional real-time chat app with Firebase Firestore using MessageKit.",
-      "homepage":"https://github.com/instamobile/messenger-iOS-chat-swift-firestore"
+      "homepage":"https://github.com/dopebase/messenger-iOS-chat-swift-firestore"
     },
     {
       "title":"CollapsibleTableSectionViewController",
@@ -7949,7 +7949,7 @@
       "title":"TextBuilder",
       "category":"text",
       "description":"Like a SwiftUI ViewBuilder, but for Text.",
-      "homepage":"https://github.com/davdroman/TextBuilder"
+      "homepage":"https://github.com/davdroman/swiftui-text-builder"
     },
     {
       "title":"TPInAppReceipt",


### PR DESCRIPTION
## Summary
- update stale and redirected homepage links in `contents.json`
- replace dead GitHub links with current repository locations
- keep the existing entries unchanged apart from the homepage URLs