### PR TITLE
Add EdgeRunner

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -1062,6 +1062,20 @@
       "homepage":"https://github.com/christopherkarani/Espresso"
     },
     {
+      "title":"EdgeRunner",
+      "category":"ai",
+      "description":"Fast, local LLM inference for Apple Silicon. Built in Swift and Metal from the ground up.",
+      "homepage":"https://github.com/christopherkarani/EdgeRunner",
+      "tags":[
+        "llm",
+        "inference",
+        "metal",
+        "gguf",
+        "apple-silicon",
+        "on-device-ai"
+      ]
+    },
+    {
       "title":"CenteredCollectionView",
       "category":"uicollectionview",
       "description":"A lightweight UICollectionViewLayout that pages and centers it's cells.",


### PR DESCRIPTION
## Summary

- Add [EdgeRunner](https://github.com/christopherkarani/EdgeRunner) to the **AI** section
- Fast, local LLM inference for Apple Silicon built in Swift and Metal from the ground up
- Supports GGUF models (Qwen3, etc.) with Metal-optimized kernels delivering ~230+ tok/s decode on M3 Max
- Placed right after Espresso (same author, complementary project — EdgeRunner does inference, Espresso compiles for ANE)

## Checklist

- [x] Entry added to `contents.json` only (no `README.md` changes)
- [x] Short, plain description starting with capital and ending with period
- [x] Fits AI category (LLM inference engine)
- [x] MIT license (allowed)
- [x] Swift 6.2+
- [x] 15+ GitHub stars
- [x] English README