### PR TITLE
Add Claude Code Server-Side Swift Skills

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -1,1021 +1,1684 @@
 {
-  "title":"Awesome Swift",
-  "header":"# Awesome Swift\n \n<!-- \n\nPLEASE DO NOT UPDATE THIS FILE, UPDATE CONTENTS.JSON INSTEAD. THANK YOU :-)\n\n -->\n\n",
-  "header_contributing":"Please take a quick look at the [contribution guidelines](.github/CONTRIBUTING.md) first. If you see a package or project here that is no longer maintained or is not a good fit, please submit a pull request to improve this file. Thank you to all [contributors](https://github.com/matteocrippa/awesome-swift/graphs/contributors); you rock!!",
-  "ios_app_link":"https://itunes.apple.com/us/app/awesome-for-swift-cheatsheet/id1078115427",
-  "categories":[
+  "title": "Awesome Swift",
+  "header": "# Awesome Swift\n \n<!-- \n\nPLEASE DO NOT UPDATE THIS FILE, UPDATE CONTENTS.JSON INSTEAD. THANK YOU :-)\n\n -->\n\n",
+  "header_contributing": "Please take a quick look at the [contribution guidelines](.github/CONTRIBUTING.md) first. If you see a package or project here that is no longer maintained or is not a good fit, please submit a pull request to improve this file. Thank you to all [contributors](https://github.com/matteocrippa/awesome-swift/graphs/contributors); you rock!!",
+  "ios_app_link": "https://itunes.apple.com/us/app/awesome-for-swift-cheatsheet/id1078115427",
+  "categories": [
     {
-      "title":"Guides",
-      "id":"guides",
-      "description":"An awesome list of Swift related guides."
+      "title": "Guides",
+      "id": "guides",
+      "description": "An awesome list of Swift related guides."
     },
     {
-      "title":"Official Guides",
-      "id":"official-guides",
-      "parent":"guides"
+      "title": "Official Guides",
+      "id": "official-guides",
+      "parent": "guides"
     },
     {
-      "title":"SDK",
-      "id":"sdk",
-      "parent":"libs"
+      "title": "SDK",
+      "id": "sdk",
+      "parent": "libs"
     },
     {
-      "title":"Third party Guides",
-      "id":"third-party-guides",
-      "parent":"guides"
+      "title": "Third party Guides",
+      "id": "third-party-guides",
+      "parent": "guides"
     },
     {
-      "title":"Newsletter",
-      "id":"newsletter",
-      "parent":"guides"
+      "title": "Newsletter",
+      "id": "newsletter",
+      "parent": "guides"
     },
     {
-      "title":"Calendar",
-      "id":"calendar",
-      "parent":"ui"
+      "title": "Calendar",
+      "id": "calendar",
+      "parent": "ui"
     },
     {
-      "title":"Cards",
-      "id":"cards",
-      "parent":"ui"
+      "title": "Cards",
+      "id": "cards",
+      "parent": "ui"
     },
     {
-      "title":"Style Guides",
-      "id":"style-guides",
-      "parent":"guides"
+      "title": "Style Guides",
+      "id": "style-guides",
+      "parent": "guides"
     },
     {
-      "title":"Boilerplates",
-      "id":"boilerplates"
+      "title": "Boilerplates",
+      "id": "boilerplates"
     },
     {
-      "title":"REPL",
-      "id":"repl"
+      "title": "REPL",
+      "id": "repl"
     },
     {
-      "title":"Cache",
-      "id":"cache",
-      "parent":"libs"
+      "title": "Cache",
+      "id": "cache",
+      "parent": "libs"
     },
     {
-      "title":"Editor Support",
-      "id":"editor-support",
-      "description":"Support for your favorite editors."
+      "title": "Editor Support",
+      "id": "editor-support",
+      "description": "Support for your favorite editors."
     },
     {
-      "title":"Emacs",
-      "id":"emacs",
-      "parent":"editor-support"
+      "title": "Emacs",
+      "id": "emacs",
+      "parent": "editor-support"
     },
     {
-      "title":"Vim",
-      "id":"vim",
-      "parent":"editor-support"
+      "title": "Vim",
+      "id": "vim",
+      "parent": "editor-support"
     },
     {
-      "title":"Google Colaboratory",
-      "id":"google-colaboratory",
-      "parent":"editor-support"
+      "title": "Google Colaboratory",
+      "id": "google-colaboratory",
+      "parent": "editor-support"
     },
     {
-      "title":"Benchmark",
-      "id":"benchmark"
+      "title": "Benchmark",
+      "id": "benchmark"
     },
     {
-      "title":"Converters",
-      "id":"converters"
+      "title": "Converters",
+      "id": "converters"
     },
     {
-      "title":"Other Awesome Lists",
-      "id":"other-awesome-lists",
-      "description":"Check out apps on these projects:"
+      "title": "Other Awesome Lists",
+      "id": "other-awesome-lists",
+      "description": "Check out apps on these projects:"
     },
     {
-      "title":"Dependency Managers",
-      "id":"dependency-managers",
-      "description":"Dependency manager software for Swift."
+      "title": "Dependency Managers",
+      "id": "dependency-managers",
+      "description": "Dependency manager software for Swift."
     },
     {
-      "title":"Patterns",
-      "id":"patterns"
+      "title": "Patterns",
+      "id": "patterns"
     },
     {
-      "title":"Misc",
-      "id":"misc",
-      "description":"Miscellaneous Swift related projects"
+      "title": "Misc",
+      "id": "misc",
+      "description": "Miscellaneous Swift related projects"
     },
     {
-      "title":"Libs",
-      "id":"libs",
-      "description":"Here you can find a list of snippets and libs for your Swift projects."
+      "title": "Libs",
+      "id": "libs",
+      "description": "Here you can find a list of snippets and libs for your Swift projects."
     },
     {
-      "title":"Accessibility",
-      "id":"accessibility",
-      "parent":"libs"
+      "title": "Accessibility",
+      "id": "accessibility",
+      "parent": "libs"
     },
     {
-      "title":"Analytics",
-      "id":"analytics",
-      "parent":"libs",
-      "description":"Analytics related libraries to easily track your app usage"
+      "title": "Analytics",
+      "id": "analytics",
+      "parent": "libs",
+      "description": "Analytics related libraries to easily track your app usage"
     },
     {
-      "title":"AI",
-      "id":"ai",
-      "parent":"libs",
-      "description":"Libs for AI based projects (Machine Learning, Neural Networks etc)."
+      "title": "AI",
+      "id": "ai",
+      "parent": "libs",
+      "description": "Libs for AI based projects (Machine Learning, Neural Networks etc)."
     },
     {
-      "title":"Augmented Reality",
-      "id":"augmented-reality",
-      "parent":"libs"
+      "title": "Augmented Reality",
+      "id": "augmented-reality",
+      "parent": "libs"
     },
     {
-      "title":"Algorithm",
-      "id":"algorithm",
-      "parent":"libs"
+      "title": "Algorithm",
+      "id": "algorithm",
+      "parent": "libs"
     },
     {
-      "title":"Currency",
-      "id":"currency",
-      "parent":"libs"
+      "title": "Currency",
+      "id": "currency",
+      "parent": "libs"
     },
     {
-      "title":"Animation",
-      "id":"animation",
-      "parent":"libs",
-      "description":"Libs to help with animation"
+      "title": "Animation",
+      "id": "animation",
+      "parent": "libs",
+      "description": "Libs to help with animation"
     },
     {
-      "title":"App Routing",
-      "id":"app-routing",
-      "parent":"libs",
-      "description":"Internal app routing systems."
+      "title": "App Routing",
+      "id": "app-routing",
+      "parent": "libs",
+      "description": "Internal app routing systems."
     },
     {
-      "title":"App Store",
-      "id":"app-store",
-      "parent":"libs",
-      "description":"Libs to help with apple app store, in app purchases and receipt validation."
+      "title": "App Store",
+      "id": "app-store",
+      "parent": "libs",
+      "description": "Libs to help with apple app store, in app purchases and receipt validation."
     },
     {
-      "title":"Audio",
-      "id":"audio",
-      "parent":"libs",
-      "description":"Libs to work with audio"
+      "title": "Audio",
+      "id": "audio",
+      "parent": "libs",
+      "description": "Libs to work with audio"
     },
     {
-      "title":"Authentication",
-      "id":"authentication",
-      "parent":"libs",
-      "description":"Easy way to manage auth in your apps."
+      "title": "Authentication",
+      "id": "authentication",
+      "parent": "libs",
+      "description": "Easy way to manage auth in your apps."
     },
     {
-      "title":"API",
-      "id":"api",
-      "parent":"libs",
-      "description":"Quick libs to get access to third party API services"
+      "title": "API",
+      "id": "api",
+      "parent": "libs",
+      "description": "Quick libs to get access to third party API services"
     },
     {
-      "title":"Natural Language Processing",
-      "id":"natural-language-processing",
-      "parent":"libs"
+      "title": "Natural Language Processing",
+      "id": "natural-language-processing",
+      "parent": "libs"
     },
     {
-      "title":"Bots",
-      "id":"bots",
-      "parent":"libs",
-      "description":"Libs to build bot"
+      "title": "Bots",
+      "id": "bots",
+      "parent": "libs",
+      "description": "Libs to build bot"
     },
     {
-      "title":"Bluetooth",
-      "id":"bluetooth",
-      "parent":"hardware",
-      "description":"Wrappers around CoreBluetooth"
+      "title": "Bluetooth",
+      "id": "bluetooth",
+      "parent": "hardware",
+      "description": "Wrappers around CoreBluetooth"
     },
     {
-      "title":"Camera",
-      "id":"camera",
-      "parent":"hardware",
-      "description":"Awesome camera libs"
+      "title": "Camera",
+      "id": "camera",
+      "parent": "hardware",
+      "description": "Awesome camera libs"
     },
     {
-      "title":"Chat",
-      "id":"chat",
-      "parent":"libs",
-      "description":"Libs to get access to build chat app"
+      "title": "Chat",
+      "id": "chat",
+      "parent": "libs",
+      "description": "Libs to get access to build chat app"
     },
     {
-      "title":"Colors",
-      "id":"colors",
-      "parent":"libs",
-      "description":"Interesting snippets related to color management and utility."
+      "title": "Colors",
+      "id": "colors",
+      "parent": "libs",
+      "description": "Interesting snippets related to color management and utility."
     },
     {
-      "title":"Command Line",
-      "id":"command-line",
-      "parent":"libs",
-      "description":"Create command line applications."
+      "title": "Command Line",
+      "id": "command-line",
+      "parent": "libs",
+      "description": "Create command line applications."
     },
     {
-      "title":"Concurrency",
-      "id":"concurrency",
-      "parent":"libs",
-      "description":"Easier ways to work with concurrency."
+      "title": "Concurrency",
+      "id": "concurrency",
+      "parent": "libs",
+      "description": "Easier ways to work with concurrency."
     },
     {
-      "title":"Data Management",
-      "id":"data-management",
-      "parent":"libs"
+      "title": "Data Management",
+      "id": "data-management",
+      "parent": "libs"
     },
     {
-      "title":"Device",
-      "id":"device",
-      "parent":"libs",
-      "description":"A collection of libs to recognize your device."
+      "title": "Device",
+      "id": "device",
+      "parent": "libs",
+      "description": "A collection of libs to recognize your device."
     },
     {
-      "title":"CBOR",
-      "id":"cbor",
-      "parent":"data-management",
-      "description":"Concise Binary Object Representation."
+      "title": "CBOR",
+      "id": "cbor",
+      "parent": "data-management",
+      "description": "Concise Binary Object Representation."
     },
     {
-      "title":"Core Data",
-      "id":"core-data",
-      "parent":"data-management",
-      "description":"No more pain with Core Data, here are some interesting libs to handle data management."
+      "title": "Core Data",
+      "id": "core-data",
+      "parent": "data-management",
+      "description": "No more pain with Core Data, here are some interesting libs to handle data management."
     },
     {
-      "title":"CSV",
-      "id":"csv",
-      "parent":"data-management",
-      "description":"Helpful libraries to parse from and serialize to comma-separated value representations."
+      "title": "CSV",
+      "id": "csv",
+      "parent": "data-management",
+      "description": "Helpful libraries to parse from and serialize to comma-separated value representations."
     },
     {
-      "title":"Multi Database",
-      "id":"multi-database",
-      "parent":"data-management",
-      "description":"Data management layers that involve multiple sources."
+      "title": "Multi Database",
+      "id": "multi-database",
+      "parent": "data-management",
+      "description": "Data management layers that involve multiple sources."
     },
     {
-      "title":"PDF",
-      "id":"pdf",
-      "parent":"libs"
+      "title": "PDF",
+      "id": "pdf",
+      "parent": "libs"
     },
     {
-      "title":"Realm",
-      "id":"realm",
-      "parent":"data-management"
+      "title": "Realm",
+      "id": "realm",
+      "parent": "data-management"
     },
     {
-      "title":"Firebase",
-      "id":"firebase",
-      "parent":"data-management"
+      "title": "Firebase",
+      "id": "firebase",
+      "parent": "data-management"
     },
     {
-      "title":"Files",
-      "id":"files",
-      "parent":"libs"
+      "title": "Files",
+      "id": "files",
+      "parent": "libs"
     },
     {
-      "title":"JSON",
-      "id":"json",
-      "parent":"data-management",
-      "description":"Struggling using json data? Here are some interesting ways to handle it."
+      "title": "JSON",
+      "id": "json",
+      "parent": "data-management",
+      "description": "Struggling using json data? Here are some interesting ways to handle it."
     },
     {
-      "title":"TOML",
-      "id":"toml",
-      "parent":"data-management",
-      "description":"Tom's Obvious, Minimal Language."
+      "title": "TOML",
+      "id": "toml",
+      "parent": "data-management",
+      "description": "Tom's Obvious, Minimal Language."
     },
     {
-      "title":"Key Value Store",
-      "id":"key-value-store",
-      "parent":"data-management"
+      "title": "Key Value Store",
+      "id": "key-value-store",
+      "parent": "data-management"
     },
     {
-      "title":"MongoDB",
-      "id":"mongodb",
-      "parent":"data-management"
+      "title": "MongoDB",
+      "id": "mongodb",
+      "parent": "data-management"
     },
     {
-      "title":"ORM",
-      "id":"orm",
-      "parent":"data-management"
+      "title": "ORM",
+      "id": "orm",
+      "parent": "data-management"
     },
     {
-      "title":"SQLite",
-      "id":"sqlite",
-      "parent":"data-management",
-      "description":"Are you interested in storing your app data using SQLite? Here are some interesting resources."
+      "title": "SQLite",
+      "id": "sqlite",
+      "parent": "data-management",
+      "description": "Are you interested in storing your app data using SQLite? Here are some interesting resources."
     },
     {
-      "title":"SQL drivers",
-      "id":"sql-drivers",
-      "parent":"data-management"
+      "title": "SQL drivers",
+      "id": "sql-drivers",
+      "parent": "data-management"
     },
     {
-      "title":"XML",
-      "id":"xml",
-      "parent":"data-management",
-      "description":"If you prefer to manage XML data formatted entries, here are some helpful libs"
+      "title": "XML",
+      "id": "xml",
+      "parent": "data-management",
+      "description": "If you prefer to manage XML data formatted entries, here are some helpful libs"
     },
     {
-      "title":"YAML",
-      "id":"yaml",
-      "parent":"data-management"
+      "title": "YAML",
+      "id": "yaml",
+      "parent": "data-management"
     },
     {
-      "title":"ZIP",
-      "id":"zip",
-      "parent":"data-management"
+      "title": "ZIP",
+      "id": "zip",
+      "parent": "data-management"
     },
     {
-      "title":"Other Data",
-      "id":"other-data",
-      "parent":"data-management",
-      "description":"Other ways to persist data"
+      "title": "Other Data",
+      "id": "other-data",
+      "parent": "data-management",
+      "description": "Other ways to persist data"
     },
     {
-      "title":"Date",
-      "id":"date",
-      "parent":"libs",
-      "description":"Handle date formatting easily."
+      "title": "Date",
+      "id": "date",
+      "parent": "libs",
+      "description": "Handle date formatting easily."
     },
     {
-      "title":"Dependency Injection",
-      "id":"dependency-injection",
-      "parent":"libs",
-      "description":"Dependency injection libs"
+      "title": "Dependency Injection",
+      "id": "dependency-injection",
+      "parent": "libs",
+      "description": "Dependency injection libs"
     },
     {
-      "title":"Documentation",
-      "id":"documentation",
-      "parent":"libs",
-      "description":"Generate documentation for Swift code"
+      "title": "Documentation",
+      "id": "documentation",
+      "parent": "libs",
+      "description": "Generate documentation for Swift code"
     },
     {
-      "title":"Embedded Systems",
-      "id":"embedded-systems",
-      "parent":"libs",
-      "description":"Build your embedded Linux projects on a RaspberryPi, BeagleBone, C.H.I.P. and other boards."
+      "title": "Embedded Systems",
+      "id": "embedded-systems",
+      "parent": "libs",
+      "description": "Build your embedded Linux projects on a RaspberryPi, BeagleBone, C.H.I.P. and other boards."
     },
     {
-      "title":"Peripherals",
-      "id":"peripherals",
-      "parent":"embedded-systems",
-      "description":"Interact with specific external peripherals."
+      "title": "Peripherals",
+      "id": "peripherals",
+      "parent": "embedded-systems",
+      "description": "Interact with specific external peripherals."
     },
     {
-      "title":"Events",
-      "id":"events",
-      "parent":"libs",
-      "description":"Alternatives to NSNotificationCenter, Key-Value-Observation, or delegation."
+      "title": "Events",
+      "id": "events",
+      "parent": "libs",
+      "description": "Alternatives to NSNotificationCenter, Key-Value-Observation, or delegation."
     },
     {
-      "title":"Fonts",
-      "id":"fonts",
-      "parent":"libs",
-      "description":"A collection of font related snippets."
+      "title": "Fonts",
+      "id": "fonts",
+      "parent": "libs",
+      "description": "A collection of font related snippets."
     },
     {
-      "title":"Games",
-      "id":"games",
-      "parent":"libs"
+      "title": "Games",
+      "id": "games",
+      "parent": "libs"
     },
     {
-      "title":"Gesture",
-      "id":"gesture",
-      "parent":"libs"
+      "title": "Gesture",
+      "id": "gesture",
+      "parent": "libs"
     },
     {
-      "title":"Hardware",
-      "id":"hardware",
-      "parent":"libs",
-      "description":"A category dedicated to hardware related libs"
+      "title": "Hardware",
+      "id": "hardware",
+      "parent": "libs",
+      "description": "A category dedicated to hardware related libs"
     },
     {
-      "title":"Haptic Feedback",
-      "id":"haptic-feedback",
-      "parent":"hardware",
-      "description":"Libraries that involve the use of Haptic Feedback"
+      "title": "Haptic Feedback",
+      "id": "haptic-feedback",
+      "parent": "hardware",
+      "description": "Libraries that involve the use of Haptic Feedback"
     },
     {
-      "title":"iBeacon",
-      "id":"ibeacon",
-      "parent":"hardware",
-      "description":"Interested in using iBeacon in your Swift project? Here some interesting resources."
+      "title": "iBeacon",
+      "id": "ibeacon",
+      "parent": "hardware",
+      "description": "Interested in using iBeacon in your Swift project? Here some interesting resources."
     },
     {
-      "title":"Images",
-      "id":"images",
-      "parent":"libs",
-      "description":"An interesting list of image related libs.."
+      "title": "Images",
+      "id": "images",
+      "parent": "libs",
+      "description": "An interesting list of image related libs.."
     },
     {
-      "title":"Keyboard",
-      "id":"keyboard",
-      "parent":"libs",
-      "description":"Do you want to create your own customized keyboard? Here are some interesting resources"
+      "title": "Keyboard",
+      "id": "keyboard",
+      "parent": "libs",
+      "description": "Do you want to create your own customized keyboard? Here are some interesting resources"
     },
     {
-      "title":"Key Value Coding",
-      "id":"key-value-coding",
-      "parent":"libs",
-      "description":"Libraries for key-value coding"
+      "title": "Key Value Coding",
+      "id": "key-value-coding",
+      "parent": "libs",
+      "description": "Libraries for key-value coding"
     },
     {
-      "title":"Kit",
-      "id":"kit",
-      "parent":"libs",
-      "description":"Libraries for coding with a simplified API"
+      "title": "Kit",
+      "id": "kit",
+      "parent": "libs",
+      "description": "Libraries for coding with a simplified API"
     },
     {
-      "title":"Layout",
-      "id":"layout",
-      "parent":"libs",
-      "description":"Libs to help you with layout."
+      "title": "Layout",
+      "id": "layout",
+      "parent": "libs",
+      "description": "Libs to help you with layout."
     },
     {
-      "title":"Auto Layout",
-      "id":"auto-layout",
-      "parent":"layout",
-      "description":"Bored of using storyboard? Give a try to declarative auto layout libs."
+      "title": "Auto Layout",
+      "id": "auto-layout",
+      "parent": "layout",
+      "description": "Bored of using storyboard? Give a try to declarative auto layout libs."
     },
     {
-      "title":"Localization",
-      "id":"localization",
-      "parent":"libs",
-      "description":"Frameworks that helps with localizing your app"
+      "title": "Localization",
+      "id": "localization",
+      "parent": "libs",
+      "description": "Frameworks that helps with localizing your app"
     },
     {
-      "title":"Logging",
-      "id":"logging",
-      "parent":"libs",
-      "description":"Utilities for writing to and reading from the device log"
+      "title": "Logging",
+      "id": "logging",
+      "parent": "libs",
+      "description": "Utilities for writing to and reading from the device log"
     },
     {
-      "title":"Chart",
-      "id":"chart",
-      "parent":"libs"
+      "title": "Chart",
+      "id": "chart",
+      "parent": "libs"
     },
     {
-      "title":"Maps",
-      "id":"maps",
-      "parent":"libs"
+      "title": "Maps",
+      "id": "maps",
+      "parent": "libs"
     },
     {
-      "title":"Location",
-      "id":"location",
-      "parent":"libs"
+      "title": "Location",
+      "id": "location",
+      "parent": "libs"
     },
     {
-      "title":"Barcode",
-      "id":"barcode",
-      "parent":"camera",
-      "description":"Barcode, QR-code, other code readers"
+      "title": "Barcode",
+      "id": "barcode",
+      "parent": "camera",
+      "description": "Barcode, QR-code, other code readers"
     },
     {
-      "title":"Math",
-      "id":"math",
-      "parent":"libs"
+      "title": "Math",
+      "id": "math",
+      "parent": "libs"
     },
     {
-      "title":"Network",
-      "id":"network",
-      "parent":"libs",
-      "description":"A list of libs that allow you to decrease the amount of time spent dealing with http requests."
+      "title": "Network",
+      "id": "network",
+      "parent": "libs",
+      "description": "A list of libs that allow you to decrease the amount of time spent dealing with http requests."
     },
     {
-      "title":"HTML",
-      "id":"html",
-      "parent":"network",
-      "description":"Need to manipulate contents from html easily?"
+      "title": "HTML",
+      "id": "html",
+      "parent": "network",
+      "description": "Need to manipulate contents from html easily?"
     },
     {
-      "title":"Messaging Protocol",
-      "id":"messaging-protocol",
-      "parent":"network"
+      "title": "Messaging Protocol",
+      "id": "messaging-protocol",
+      "parent": "network"
     },
     {
-      "title":"Socket",
-      "id":"socket",
-      "parent":"network"
+      "title": "Socket",
+      "id": "socket",
+      "parent": "network"
     },
     {
-      "title":"Webserver",
-      "id":"webserver",
-      "parent":"network",
-      "description":"Would you like host a webserver in your device? Here you can find how to do it."
+      "title": "Webserver",
+      "id": "webserver",
+      "parent": "network",
+      "description": "Would you like host a webserver in your device? Here you can find how to do it."
     },
     {
-      "title":"OCR",
-      "id":"ocr",
-      "parent":"libs"
+      "title": "OCR",
+      "id": "ocr",
+      "parent": "libs"
     },
     {
-      "title":"Optimization",
-      "id":"optimization",
-      "parent":"libs"
+      "title": "Optimization",
+      "id": "optimization",
+      "parent": "libs"
     },
     {
-      "title":"Quality",
-      "id":"quality",
-      "parent":"libs"
+      "title": "Quality",
+      "id": "quality",
+      "parent": "libs"
     },
     {
-      "title":"Security",
-      "id":"security",
-      "parent":"libs"
+      "title": "Security",
+      "id": "security",
+      "parent": "libs"
     },
     {
-      "title":"Cryptography",
-      "id":"cryptography",
-      "parent":"security",
-      "description":"Deal with cryptography method easily"
+      "title": "Cryptography",
+      "id": "cryptography",
+      "parent": "security",
+      "description": "Deal with cryptography method easily"
     },
     {
-      "title":"Keychain",
-      "id":"keychain",
-      "parent":"security"
+      "title": "Keychain",
+      "id": "keychain",
+      "parent": "security"
     },
     {
-      "title":"Sensors",
-      "id":"sensors",
-      "parent":"hardware",
-      "description":"Manage your device sensors in a faster and easier way"
+      "title": "Sensors",
+      "id": "sensors",
+      "parent": "hardware",
+      "description": "Manage your device sensors in a faster and easier way"
     },
     {
-      "title":"Styling",
-      "id":"styling",
-      "parent":"libs"
+      "title": "Styling",
+      "id": "styling",
+      "parent": "libs"
     },
     {
-      "title":"System",
-      "id":"system",
-      "parent":"libs"
+      "title": "System",
+      "id": "system",
+      "parent": "libs"
     },
     {
-      "title":"Testing",
-      "id":"testing",
-      "parent":"libs",
-      "description":"A collection of testing frameworks."
+      "title": "Testing",
+      "id": "testing",
+      "parent": "libs",
+      "description": "A collection of testing frameworks."
     },
     {
-      "title":"Mock",
-      "id":"mock",
-      "parent":"testing"
+      "title": "Mock",
+      "id": "mock",
+      "parent": "testing"
     },
     {
-      "title":"Text",
-      "id":"text",
-      "parent":"libs",
-      "description":"A collection of text projects."
+      "title": "Text",
+      "id": "text",
+      "parent": "libs",
+      "description": "A collection of text projects."
     },
     {
-      "title":"Validation",
-      "id":"validation",
-      "parent":"libs",
-      "description":"A collection of validation libs."
+      "title": "Validation",
+      "id": "validation",
+      "parent": "libs",
+      "description": "A collection of validation libs."
     },
     {
-      "title":"Phone Numbers",
-      "id":"phone-numbers",
-      "parent":"validation",
-      "description":"Libs to manage phone numbers."
+      "title": "Phone Numbers",
+      "id": "phone-numbers",
+      "parent": "validation",
+      "description": "Libs to manage phone numbers."
     },
     {
-      "title":"Thread",
-      "id":"thread",
-      "parent":"libs",
-      "description":"Threading, task-based or asynchronous programming, Grand Central Dispatch (GCD) wrapper"
+      "title": "Thread",
+      "id": "thread",
+      "parent": "libs",
+      "description": "Threading, task-based or asynchronous programming, Grand Central Dispatch (GCD) wrapper"
     },
     {
-      "title":"UI",
-      "id":"ui",
-      "parent":"libs",
-      "description":"A collection of pre-packaged transitions & cool ui stuffs."
+      "title": "UI",
+      "id": "ui",
+      "parent": "libs",
+      "description": "A collection of pre-packaged transitions & cool ui stuffs."
     },
     {
-      "title":"3D Touch",
-      "id":"3d-touch",
-      "parent":"hardware",
-      "description":"Easy handle new 3D Touch / Force Touch feature thanks to these libs."
+      "title": "3D Touch",
+      "id": "3d-touch",
+      "parent": "hardware",
+      "description": "Easy handle new 3D Touch / Force Touch feature thanks to these libs."
     },
     {
-      "title":"Alert",
-      "id":"alert",
-      "parent":"ui",
-      "description":"Libs to display alert, action sheet, notification, popup."
+      "title": "Alert",
+      "id": "alert",
+      "parent": "ui",
+      "description": "Libs to display alert, action sheet, notification, popup."
     },
     {
-      "title":"Blur",
-      "id":"blur",
-      "parent":"ui"
+      "title": "Blur",
+      "id": "blur",
+      "parent": "ui"
     },
     {
-      "title":"Button",
-      "id":"button",
-      "parent":"ui"
+      "title": "Button",
+      "id": "button",
+      "parent": "ui"
     },
     {
-      "title":"Tab",
-      "id":"tab",
-      "parent":"ui"
+      "title": "Tab",
+      "id": "tab",
+      "parent": "ui"
     },
     {
-      "title":"TextField",
-      "id":"textfield",
-      "parent":"ui"
+      "title": "TextField",
+      "id": "textfield",
+      "parent": "ui"
     },
     {
-      "title":"Form",
-      "id":"form",
-      "parent":"ui"
+      "title": "Form",
+      "id": "form",
+      "parent": "ui"
     },
     {
-      "title":"Label",
-      "id":"label",
-      "parent":"ui"
+      "title": "Label",
+      "id": "label",
+      "parent": "ui"
     },
     {
-      "title":"Switch",
-      "id":"switch",
-      "parent":"ui"
+      "title": "Switch",
+      "id": "switch",
+      "parent": "ui"
     },
     {
-      "title":"Walkthrough",
-      "id":"walkthrough",
-      "parent":"ui"
+      "title": "Walkthrough",
+      "id": "walkthrough",
+      "parent": "ui"
     },
     {
-      "title":"HUD",
-      "id":"hud",
-      "parent":"ui"
+      "title": "HUD",
+      "id": "hud",
+      "parent": "ui"
     },
     {
-      "title":"Menu",
-      "id":"menu",
-      "parent":"ui"
+      "title": "Menu",
+      "id": "menu",
+      "parent": "ui"
     },
     {
-      "title":"Payment",
-      "id":"payment",
-      "parent":"ui"
+      "title": "Payment",
+      "id": "payment",
+      "parent": "ui"
     },
     {
-      "title":"Permissions",
-      "id":"permissions",
-      "parent":"ui"
+      "title": "Permissions",
+      "id": "permissions",
+      "parent": "ui"
     },
     {
-      "title":"StackView",
-      "id":"stackview",
-      "parent":"ui"
+      "title": "StackView",
+      "id": "stackview",
+      "parent": "ui"
     },
     {
-      "title":"Transition",
-      "id":"transition",
-      "parent":"ui"
+      "title": "Transition",
+      "id": "transition",
+      "parent": "ui"
     },
     {
-      "title":"UICollectionView",
-      "id":"uicollectionview",
-      "parent":"ui"
+      "title": "UICollectionView",
+      "id": "uicollectionview",
+      "parent": "ui"
     },
     {
-      "title":"UITableView",
-      "id":"uitableview",
-      "parent":"ui"
+      "title": "UITableView",
+      "id": "uitableview",
+      "parent": "ui"
     },
     {
-      "title":"Template",
-      "id":"template",
-      "parent":"ui"
+      "title": "Template",
+      "id": "template",
+      "parent": "ui"
     },
     {
-      "title":"3D",
-      "id":"ui-3d",
-      "parent":"ui"
+      "title": "3D",
+      "id": "ui-3d",
+      "parent": "ui"
     },
     {
-      "title":"Scroll Bars",
-      "id":"scroll-bars",
-      "parent":"ui"
+      "title": "Scroll Bars",
+      "id": "scroll-bars",
+      "parent": "ui"
     },
     {
-      "title":"Utility",
-      "id":"utility",
-      "parent":"libs",
-      "description":"Some interesting utilities to help you in your projects"
+      "title": "Utility",
+      "id": "utility",
+      "parent": "libs",
+      "description": "Some interesting utilities to help you in your projects"
     },
     {
-      "title":"Version Manager",
-      "id":"version-manager",
-      "parent":"libs"
+      "title": "Version Manager",
+      "id": "version-manager",
+      "parent": "libs"
     },
     {
-      "title":"Video",
-      "id":"video",
-      "parent":"libs"
+      "title": "Video",
+      "id": "video",
+      "parent": "libs"
     },
     {
-      "title":"Streaming",
-      "id":"streaming",
-      "parent":"libs"
+      "title": "Streaming",
+      "id": "streaming",
+      "parent": "libs"
     },
     {
-      "title":"Pagination",
-      "id":"pagination",
-      "parent":"ui"
+      "title": "Pagination",
+      "id": "pagination",
+      "parent": "ui"
     },
     {
-      "title":"Email",
-      "id":"email",
-      "parent":"libs"
+      "title": "Email",
+      "id": "email",
+      "parent": "libs"
     },
     {
-      "title":"Scripting",
-      "id":"scripting",
-      "parent":"libs"
+      "title": "Scripting",
+      "id": "scripting",
+      "parent": "libs"
     },
     {
-      "title":"Game Engine",
-      "id":"game-engine",
-      "parent":"libs"
+      "title": "Game Engine",
+      "id": "game-engine",
+      "parent": "libs"
     },
     {
-      "title":"2D",
-      "id":"game-engine-2d",
-      "parent":"game-engine"
+      "title": "2D",
+      "id": "game-engine-2d",
+      "parent": "game-engine"
     },
     {
-      "title":"Serverless",
-      "id":"serverless"
+      "title": "Serverless",
+      "id": "serverless"
     },
     {
-      "title":"GraphQL",
-      "id":"graphql",
-      "parent":"data-management"
+      "title": "GraphQL",
+      "id": "graphql",
+      "parent": "data-management"
     },
     {
-      "title":"SOAP",
-      "id":"soap",
-      "parent":"network"
+      "title": "SOAP",
+      "id": "soap",
+      "parent": "network"
     },
     {
-      "title":"SVG",
-      "id":"svg",
-      "parent":"libs"
+      "title": "SVG",
+      "id": "svg",
+      "parent": "libs"
     }
   ],
-  "projects":[
+  "projects": [
     {
-      "title":"SwiftAudioPlayer",
-      "category":"audio",
-      "description":"Simple audio player for iOS that streams and performs realtime audio manipulations with AVAudioEngine.",
-      "homepage":"https://github.com/tanhakabir/SwiftAudioPlayer"
+      "title": "30 Days of Swift",
+      "category": "third-party-guides",
+      "description": "A cool 30 days tutorial.",
+      "homepage": "https://github.com/allenwong/30DaysofSwift"
     },
     {
-      "title":"ModelAssistant",
-      "category":"multi-database",
-      "description":"Elegant library to manage the interactions between view and model.",
-      "homepage":"https://github.com/ssamadgh/ModelAssistant",
-      "tags":[
+      "title": "About Swift",
+      "category": "third-party-guides",
+      "description": "A playground about the Swift language.",
+      "homepage": "https://github.com/NicolaLancellotti/about-swift"
+    },
+    {
+      "title": "Accio",
+      "category": "dependency-managers",
+      "description": "A SwiftPM based dependency manager for iOS & Co. with improvements over Carthage.",
+      "homepage": "https://github.com/JamitLabs/Accio"
+    },
+    {
+      "title": "ActiveLabel",
+      "category": "label",
+      "description": "UILabel drop-in replacement supporting Hashtags (#), Mentions (@) and URLs (http://).",
+      "homepage": "https://github.com/optonaut/ActiveLabel.swift"
+    },
+    {
+      "title": "ActivityIndicatorView",
+      "category": "ui",
+      "description": "A number of preset loading indicators created with SwiftUI.",
+      "homepage": "https://github.com/exyte/ActivityIndicatorView"
+    },
+    {
+      "title": "Adaptive Tab Bar",
+      "category": "tab",
+      "description": "Adaptive tab bar.",
+      "homepage": "https://github.com/Ramotion/adaptive-tab-bar"
+    },
+    {
+      "title": "Advance",
+      "category": "animation",
+      "description": "A powerful animation framework for iOS, tvOS, and OS X.",
+      "homepage": "https://github.com/timdonnelly/Advance"
+    },
+    {
+      "title": "AEConsole",
+      "category": "logging",
+      "description": "Customizable Console UI overlay with debug log on top of your iOS App.",
+      "homepage": "https://github.com/tadija/AEConsole"
+    },
+    {
+      "title": "AECoreDataUI",
+      "category": "ui",
+      "description": "Core Data driven UI.",
+      "homepage": "https://github.com/tadija/AERecord",
+      "swift": 4
+    },
+    {
+      "title": "AERecord",
+      "category": "core-data",
+      "description": "Super awesome Core Data wrapper library for iOS.",
+      "homepage": "https://github.com/tadija/AERecord"
+    },
+    {
+      "title": "AEXML",
+      "category": "xml",
+      "description": "xml wrapper.",
+      "homepage": "https://github.com/tadija/AEXML"
+    },
+    {
+      "title": "AGCircularPicker",
+      "category": "ui",
+      "description": "Helpful component for creating a controller aimed to manage any calculated parameter.",
+      "homepage": "https://github.com/agilie/AGCircularPicker",
+      "tags": [
+        "iOS",
         "swift",
-        "uitableview",
-        "uicollectionview",
+        "color",
+        "circular-picker",
+        "picker"
+      ]
+    },
+    {
+      "title": "Agrume",
+      "category": "images",
+      "description": "A lemony fresh iOS image viewer.",
+      "homepage": "https://github.com/JanGorman/Agrume"
+    },
+    {
+      "title": "AHDownloadButton",
+      "category": "button",
+      "description": "Customizable download button with progress and transition animations. It is based on Apple's App Store download button.",
+      "homepage": "https://github.com/amerhukic/AHDownloadButton"
+    },
+    {
+      "title": "Airbnb",
+      "category": "style-guides",
+      "description": "Airbnb's Official Style Guide.",
+      "homepage": "https://github.com/airbnb/swift"
+    },
+    {
+      "title": "AKSwiftSlideMenu",
+      "category": "menu",
+      "description": "Slide Menu (Drawer).",
+      "homepage": "https://github.com/ashishkakkad8/AKSwiftSlideMenu"
+    },
+    {
+      "title": "Alamofire",
+      "category": "network",
+      "description": "Elegant networking.",
+      "homepage": "https://github.com/Alamofire/Alamofire",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "AlamofireImage",
+      "category": "images",
+      "description": "AlamofireImage is an image component library for Alamofire.",
+      "homepage": "https://github.com/Alamofire/AlamofireImage"
+    },
+    {
+      "title": "AlamofireObjectMapper",
+      "category": "json",
+      "description": "An Alamofire extension which converts JSON response data into objects using ObjectMapper.",
+      "homepage": "https://github.com/tristanhimmelman/AlamofireObjectMapper"
+    },
+    {
+      "title": "Alembic",
+      "category": "json",
+      "description": "Functional JSON parsing, mapping to objects, and serialize to JSON.",
+      "homepage": "https://github.com/ra1028/Alembic"
+    },
+    {
+      "title": "Alertift",
+      "category": "alert",
+      "description": "Modern, easy UIAlertController wrapper.",
+      "homepage": "https://github.com/sgr-ksmt/Alertift"
+    },
+    {
+      "title": "Alerts Pickers",
+      "category": "alert",
+      "description": "Advanced usage of UIAlertController with TextField, DatePicker, PickerView, TableView and CollectionView.",
+      "homepage": "https://github.com/dillidon/alerts-and-pickers"
+    },
+    {
+      "title": "AlexaSkillsKit",
+      "category": "utility",
+      "description": "Develop custom Alexa Skills.",
+      "homepage": "https://github.com/choefele/AlexaSkillsKit"
+    },
+    {
+      "title": "Algorithm",
+      "category": "algorithm",
+      "description": "A toolset for writing algorithms and probability models.",
+      "homepage": "https://github.com/CosmicMind/Algorithm"
+    },
+    {
+      "title": "ALRT",
+      "category": "alert",
+      "description": "An easier constructor for UIAlertController. Present an alert from anywhere.",
+      "homepage": "https://github.com/mshrwtnb/alrt"
+    },
+    {
+      "title": "Ambassador",
+      "category": "webserver",
+      "description": "Super lightweight web framework based on SWSGI.",
+      "homepage": "https://github.com/envoy/Ambassador"
+    },
+    {
+      "title": "AMScrollingNavbar",
+      "category": "ui",
+      "description": "Scrollable UINavigationBar that follows the scrolling of a UIScrollView.",
+      "homepage": "https://github.com/andreamazz/AMScrollingNavbar",
+      "swift": 4
+    },
+    {
+      "title": "Animated Tab Bar",
+      "category": "tab",
+      "description": "RAMAnimatedTabBarController is a module for adding animation to tab bar items.",
+      "homepage": "https://github.com/Ramotion/animated-tab-bar"
+    },
+    {
+      "title": "AnimatedCardInput",
+      "category": "payment",
+      "description": "Customisable and easy to use Credit Card UI.",
+      "homepage": "https://github.com/netguru/AnimatedCardInput"
+    },
+    {
+      "title": "AnimatedGradient",
+      "category": "animation",
+      "description": "Animated linear gradient library written with SwiftUI",
+      "homepage": "https://github.com/exyte/AnimatedGradient",
+      "tags": [
+        "swiftui",
+        "gradient",
+        "animation"
+      ]
+    },
+    {
+      "title": "AnimatedTabBar",
+      "category": "layout",
+      "description": "A tabbar with a number of preset animations.",
+      "homepage": "https://github.com/exyte/AnimatedTabBar"
+    },
+    {
+      "title": "AnyDate",
+      "category": "date",
+      "description": "Date & Time API inspired from Java 8 DateTime API.",
+      "homepage": "https://github.com/Kawoou/AnyDate"
+    },
+    {
+      "title": "AnyLint",
+      "category": "quality",
+      "description": "Lint anything by combining the power of Swift & regular expressions.",
+      "homepage": "https://github.com/FlineDev/AnyLint",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "API Design Guidelines",
+      "category": "official-guides",
+      "description": "Official Swift API design guidelines.",
+      "homepage": "https://www.swift.org/documentation/api-design-guidelines/"
+    },
+    {
+      "title": "APIKit",
+      "category": "network",
+      "description": "Library for building type-safe web API client.",
+      "homepage": "https://github.com/ishkawa/APIKit"
+    },
+    {
+      "title": "APNGKit",
+      "category": "images",
+      "description": "High performance and delightful way to play with APNG format in iOS.",
+      "homepage": "https://github.com/onevcat/APNGKit"
+    },
+    {
+      "title": "App Architecture",
+      "category": "patterns",
+      "description": "A sample Code of the App Architecture Book.",
+      "homepage": "https://github.com/objcio/app-architecture"
+    },
+    {
+      "title": "Apphud",
+      "category": "app-store",
+      "description": "Lightweight library to easily handle auto-renewable subscriptions with no backend required.",
+      "homepage": "https://github.com/apphud/ApphudSDK",
+      "tags": [
+        "swift",
+        "StoreKit"
+      ]
+    },
+    {
+      "title": "Apple eBook",
+      "category": "official-guides",
+      "description": "Official Apple eBook for Swift beginners.",
+      "homepage": "https://books.apple.com/us/book/the-swift-programming-language-swift-5-7/id881256329"
+    },
+    {
+      "title": "ApplyStyleKit",
+      "category": "utility",
+      "description": "Elegantly, Apply style to UIKit using Method Chain.",
+      "homepage": "https://github.com/shindyu/ApplyStyleKit",
+      "tags": [
+        "swift",
+        "methodchain",
+        "design",
         "ios"
       ]
     },
     {
-      "title":"Cards XI",
-      "category":"transition",
-      "description":"Awesome iOS 11 AppStore's Card Views.",
-      "homepage":"https://github.com/PaoloCuscela/Cards"
+      "title": "AppReview",
+      "category": "app-store",
+      "description": "A tiny library to request review on the AppStore via SKStoreReviewController.",
+      "homepage": "https://github.com/mezhevikin/AppReview"
     },
     {
-      "title":"Apple eBook",
-      "category":"official-guides",
-      "description":"Official Apple eBook for Swift beginners.",
-      "homepage":"https://books.apple.com/us/book/the-swift-programming-language-swift-5-7/id881256329"
+      "title": "AppVersionMonitor",
+      "category": "version-manager",
+      "description": "Monitor iOS app version easily.",
+      "homepage": "https://github.com/eure/AppVersionMonitor"
     },
     {
-      "title":"API Design Guidelines",
-      "category":"official-guides",
-      "description":"Official Swift API design guidelines.",
-      "homepage":"https://www.swift.org/documentation/api-design-guidelines/"
+      "title": "Appz",
+      "category": "app-routing",
+      "description": "Launch external apps and deeplink with ease.",
+      "homepage": "https://github.com/SwiftKitz/Appz"
     },
     {
-      "title":"Introducing SwiftUI",
-      "category":"official-guides",
-      "description":"Official SwiftUI tutorial with 4+ hours of content and interactive tutorials.",
-      "homepage":"https://developer.apple.com/tutorials/swiftui"
-    },
-    {
-      "title":"Swift Education",
-      "category":"third-party-guides",
-      "description":"A community of educators sharing materials for teaching Swift and app development.",
-      "homepage":"https://github.com/swifteducation"
-    },
-    {
-      "title":"Swift & SwiftUI Tutorials",
-      "category":"third-party-guides",
-      "description":"SwiftUI learning with Ease.",
-      "homepage":"http://ww1.janeshswift.com"
-    },
-    {
-      "title":"30 Days of Swift",
-      "category":"third-party-guides",
-      "description":"A cool 30 days tutorial.",
-      "homepage":"https://github.com/allenwong/30DaysofSwift"
-    },
-    {
-      "title":"Awesome Swift Education",
-      "category":"third-party-guides",
-      "description":"An organized list of essential Swift Language Topics.",
-      "homepage":"https://github.com/hsavit1/Awesome-Swift-Education"
-    },
-    {
-      "title":"Developing iOS Apps with Swift",
-      "category":"third-party-guides",
-      "description":"Stanford course by Paul Hegarty.",
-      "homepage":"https://podcasts.apple.com/us/podcast/developing-ios-11-apps-with-swift/id1315130780"
-    },
-    {
-      "title":"Hacking With Swift",
-      "category":"third-party-guides",
-      "description":"Complete training course that teaches app development through 30 hands-on projects, for free.",
-      "homepage":"https://www.hackingwithswift.com"
-    },
-    {
-      "title":"SwiftDoc",
-      "category":"third-party-guides",
-      "description":"Auto-generated documentation.",
-      "homepage":"https://sosumi.ai/"
-    },
-    {
-      "title":"SwiftGuide CN",
-      "category":"third-party-guides",
-      "description":"A Chinese written guide.",
-      "homepage":"https://github.com/ipader/SwiftGuide"
-    },
-    {
-      "title":"Ray Wenderlich Tutorials, Videos, Podcasts and books",
-      "category":"third-party-guides",
-      "description":"High quality programming tutorials.",
-      "homepage":"https://www.kodeco.com"
-    },
-    {
-      "title":"Raywenderlich",
-      "category":"style-guides",
-      "description":"Raywenderlich guide, a must read.",
-      "homepage":"https://github.com/kodecocodes/swift-style-guide"
-    },
-    {
-      "title":"Airbnb",
-      "category":"style-guides",
-      "description":"Airbnb's Official Style Guide.",
-      "homepage":"https://github.com/airbnb/swift"
-    },
-    {
-      "title":"LinkedIn",
-      "category":"style-guides",
-      "description":"LinkedIn's Official Style Guide.",
-      "homepage":"https://github.com/linkedin/swift-style-guide"
-    },
-    {
-      "title":"swift-mode",
-      "category":"emacs",
-      "description":"Emacs support, including partial flycheck error support.",
-      "homepage":"https://github.com/swift-emacs/swift-mode"
-    },
-    {
-      "title":"swift-vim",
-      "category":"vim",
-      "description":"Vim runtime files.",
-      "homepage":"https://github.com/keith/swift.vim"
-    },
-    {
-      "title":"swift-colab",
-      "category":"google-colaboratory",
-      "description":"Run Swift in a browser.",
-      "homepage":"https://github.com/philipturner/swift-colab"
-    },
-    {
-      "title":"vim-polyglot",
-      "category":"vim",
-      "description":"Language pack for vim that includes vim-swift.",
-      "homepage":"https://github.com/sheerun/vim-polyglot"
-    },
-    {
-      "title":"open-source-ios-apps",
-      "category":"other-awesome-lists",
-      "description":"A collaborative list of open-source iOS Apps.",
-      "homepage":"https://github.com/dkhamsing/open-source-ios-apps"
-    },
-    {
-      "title":"open-source-mac-os-apps",
-      "category":"other-awesome-lists",
-      "description":"Awesome list of open source applications for macOS.",
-      "homepage":"https://github.com/serhii-londar/open-source-mac-os-apps"
-    },
-    {
-      "title":"awesome-macOS",
-      "category":"other-awesome-lists",
-      "description":"A curated list of awesome applications, softwares, tools and shiny things for macOS.",
-      "homepage":"https://github.com/iCHAIT/awesome-macOS"
-    },
-    {
-      "title":"Accio",
-      "category":"dependency-managers",
-      "description":"A SwiftPM based dependency manager for iOS & Co. with improvements over Carthage.",
-      "homepage":"https://github.com/JamitLabs/Accio"
-    },
-    {
-      "title":"Carthage",
-      "category":"dependency-managers",
-      "description":"A new dependency manager.",
-      "homepage":"https://github.com/Carthage/Carthage"
-    },
-    {
-      "title":"CocoaPods",
-      "category":"dependency-managers",
-      "description":"The most used dependency manager.",
-      "homepage":"https://github.com/CocoaPods/CocoaPods"
-    },
-    {
-      "title":"swift-package-manager",
-      "category":"dependency-managers",
-      "description":"SPM is the Package Manager for the Swift Programming Language.",
-      "homepage":"https://github.com/swiftlang/swift-package-manager"
-    },
-    {
-      "title":"Design-Patterns-In-Swift",
-      "category":"patterns",
-      "description":"Design Patterns.",
-      "homepage":"https://github.com/ochococo/Design-Patterns-In-Swift"
-    },
-    {
-      "title":"Swiftbrew",
-      "category":"misc",
-      "description":"Homebrew for Swift packages.",
-      "homepage":"https://github.com/swiftbrew/Swiftbrew"
-    },
-    {
-      "title":"SwiftGen",
-      "category":"misc",
-      "description":"A suite of tools to auto-generate code for various assets of your project.",
-      "homepage":"https://github.com/SwiftGen/SwiftGen"
-    },
-    {
-      "title":"SwiftPlate",
-      "category":"misc",
-      "description":"Easily generate cross platform framework projects from the command line.",
-      "homepage":"https://github.com/JohnSundell/SwiftPlate"
-    },
-    {
-      "title":"Tuist",
-      "category":"misc",
-      "description":"An open source command line tool to create, maintain and interact with your Xcode projects at scale.",
-      "homepage":"https://github.com/tuist/tuist"
-    },
-    {
-      "title":"xcbeautify",
-      "category":"misc",
-      "description":"Little beautifier tool for xcodebuild.",
-      "homepage":"https://github.com/cpisciotta/xcbeautify"
-    },
-    {
-      "title":"xcodeproj",
-      "category":"misc",
-      "description":"A library to read, update and write Xcode projects and workspaces.",
-      "homepage":"https://github.com/tuist/xcodeproj"
-    },
-    {
-      "title":"SwiftKit",
-      "category":"misc",
-      "description":"Start your next Open-Source Swift Framework 📦.",
-      "homepage":"https://github.com/SvenTiigi/SwiftKit",
-      "tags":[
-        "cli",
+      "title": "Aptabase",
+      "category": "analytics",
+      "description": "Open Source, Privacy-First and Simple Analytics for Swift Apps.",
+      "homepage": "https://github.com/aptabase/aptabase",
+      "tags": [
+        "analytics",
         "swift",
-        "generate",
-        "framework",
-        "xcode",
-        "script",
-        "brew"
+        "iOS",
+        "macOS",
+        "tvOS"
       ]
     },
     {
-      "title":"Capable",
-      "category":"accessibility",
-      "description":"Keep track of accessibility settings, leverage high contrast colors, and use scalable fonts to enable users with disabilities to use your app.",
-      "homepage":"https://github.com/chrs1885/Capable",
-      "tags":[
+      "title": "Arale",
+      "category": "ui",
+      "description": "A custom stretchable header view for UIScrollView or any its subclasses with UIActivityIndicatorView support for content reloading.",
+      "homepage": "https://github.com/supercomputra/Arale"
+    },
+    {
+      "title": "AREK",
+      "category": "permissions",
+      "description": "AREK is a clean and easy to use wrapper over any kind of iOS permission.",
+      "homepage": "https://github.com/ennioma/arek"
+    },
+    {
+      "title": "Argo",
+      "category": "json",
+      "description": "JSON parsing library.",
+      "homepage": "https://github.com/thoughtbot/Argo"
+    },
+    {
+      "title": "ARHeadsetKit",
+      "category": "augmented-reality",
+      "description": "High-level framework for using $5 Google Cardboard to replicate Microsoft Hololens.",
+      "homepage": "https://github.com/philipturner/ARHeadsetKit",
+      "tags": [
+        "macOS",
+        "swiftui",
+        "iOS",
+        "metal",
+        "virtual reality",
+        "GPGPU",
+        "google cardboard"
+      ]
+    },
+    {
+      "title": "Arithmosophi",
+      "category": "math",
+      "description": "Set of protocols for Arithmetic and Logical operations.",
+      "homepage": "https://github.com/phimage/Arithmosophi"
+    },
+    {
+      "title": "ARKit-CoreLocation",
+      "category": "augmented-reality",
+      "description": "Combines the high accuracy of AR with the scale of GPS data.",
+      "homepage": "https://github.com/AndrewHartAR/ARKit-CoreLocation"
+    },
+    {
+      "title": "ARKit-Navigation",
+      "category": "augmented-reality",
+      "description": "Navigation in augmented reality with MapKit.",
+      "homepage": "https://github.com/chriswebb09/ARKitNavigationDemo"
+    },
+    {
+      "title": "Arrow",
+      "category": "json",
+      "description": "Elegant JSON Parsing.",
+      "homepage": "https://github.com/freshOS/Arrow"
+    },
+    {
+      "title": "ARVideoKit",
+      "category": "augmented-reality",
+      "description": "Capture & record ARKit videos, photos, Live Photos, and GIFs.",
+      "homepage": "https://github.com/AFathi/ARVideoKit",
+      "tags": [
+        "AR",
+        "augmented",
+        "reality",
+        "video"
+      ]
+    },
+    {
+      "title": "ASCollectionView",
+      "category": "uicollectionview",
+      "description": "Lightweight custom collection view inspired by Airbnb.",
+      "homepage": "https://github.com/abdullahselek/ASCollectionView",
+      "tags": [
+        "ios",
+        "customcollectionview",
+        "custom ui"
+      ]
+    },
+    {
+      "title": "Ashen",
+      "category": "command-line",
+      "description": "A framework for writing terminal applications in Swift. Based on The Elm Architecture.",
+      "homepage": "https://github.com/colinta/Ashen",
+      "tags": [
+        "macOS"
+      ]
+    },
+    {
+      "title": "Async",
+      "category": "thread",
+      "description": "Syntactic sugar for Grand Central Dispatch.",
+      "homepage": "https://github.com/duemunk/Async"
+    },
+    {
+      "title": "async+",
+      "category": "concurrency",
+      "description": "A chainable interface for Swift 5.5's async/await.",
+      "homepage": "https://github.com/async-plus/async-plus",
+      "tags": [
+        "linux",
+        "macOS",
+        "iOS",
+        "tvOS",
+        "watchOS",
+        "5.5"
+      ]
+    },
+    {
+      "title": "AsyncLocationKit",
+      "category": "location",
+      "description": "Wrapper for Apple CoreLocation framework with Modern Concurrency Swift (async/await).",
+      "homepage": "https://github.com/AsyncSwift/AsyncLocationKit"
+    },
+    {
+      "title": "AsyncNinja",
+      "category": "concurrency",
+      "description": "A complete set of concurrency and reactive programming primitives.",
+      "homepage": "https://github.com/AsyncNinja/AsyncNinja",
+      "tags": [
+        "swift",
+        "concurrency",
+        "future",
+        "channel",
+        "async",
+        "functional",
+        "reactive"
+      ]
+    },
+    {
+      "title": "AsyncQueue",
+      "category": "concurrency",
+      "description": "A library of queues that enable sending ordered tasks from synchronous to asynchronous contexts.",
+      "homepage": "https://github.com/dfed/swift-async-queue",
+      "tags": [
+        "linux",
+        "macOS",
+        "iOS",
+        "tvOS",
+        "watchOS",
+        "visionOS",
+        "6.0"
+      ]
+    },
+    {
+      "title": "ATGMediaBrowser",
+      "category": "images",
+      "description": "Image slide-show viewer with multiple predefined transition styles, and with ability to create new transitions with ease.",
+      "homepage": "https://github.com/altayer-digital/ATGMediaBrowser"
+    },
+    {
+      "title": "ATGValidator",
+      "category": "validation",
+      "description": "Rule based validation framework with form and card validation support for iOS.",
+      "homepage": "https://github.com/altayer-digital/ATGValidator"
+    },
+    {
+      "title": "Atributika",
+      "category": "label",
+      "description": "TConvert text with HTML tags, links, hashtags, mentions into NSAttributedString. Make them clickable with UILabel drop-in replacement.",
+      "homepage": "https://github.com/psharanda/Atributika",
+      "tags": [
+        "html",
+        "attributedstring",
+        "link",
+        "tag",
+        "hashtag",
+        "clickable"
+      ]
+    },
+    {
+      "title": "Attributed",
+      "category": "text",
+      "description": "Modern µframework for attributed strings.",
+      "homepage": "https://github.com/Nirma/Attributed"
+    },
+    {
+      "title": "AttributedTextView",
+      "category": "text",
+      "description": "Easiest way to create an attributed UITextView with support for multiple links, hashtags and mentions.",
+      "homepage": "https://github.com/evermeer/AttributedTextView"
+    },
+    {
+      "title": "AudioKit",
+      "category": "audio",
+      "description": "Powerful audio synthesis, processing and analysis, without the steep learning curve.",
+      "homepage": "https://github.com/audiokit/AudioKit"
+    },
+    {
+      "title": "AudioPlayer",
+      "category": "audio",
+      "description": "A wrapper around AVPlayer with some cool features.",
+      "homepage": "https://github.com/delannoyk/AudioPlayer"
+    },
+    {
+      "title": "AudioPlayerSwift",
+      "category": "audio",
+      "description": "AudioPlayer is a simple class for playing audio (basic and advanced usage) in iOS, OS X and tvOS apps.",
+      "homepage": "https://github.com/tbaranes/AudioPlayerSwift"
+    },
+    {
+      "title": "AutoMockable",
+      "category": "mock",
+      "description": "A framework that leverages the type system to let you easily create mocked instances of your data types.",
+      "homepage": "https://github.com/vincent-pradeilles/AutoMocker"
+    },
+    {
+      "title": "AwaitKit",
+      "category": "thread",
+      "description": "The ES7 Async/Await control flow.",
+      "homepage": "https://github.com/yannickl/AwaitKit"
+    },
+    {
+      "title": "AwaitToast",
+      "category": "alert",
+      "description": "🍞 An async waiting toast with basic toast. Inspired by facebook posting toast.",
+      "homepage": "https://github.com/k-lpmg/AwaitToast"
+    },
+    {
+      "title": "Awesome iOS Interview",
+      "category": "other-awesome-lists",
+      "description": "List of the questions that helps you to prepare for the interview.",
+      "homepage": "https://github.com/dashvlas/awesome-ios-interview",
+      "tags": [
+        "interview",
+        "ios-developer",
+        "question list"
+      ]
+    },
+    {
+      "title": "Awesome Swift Education",
+      "category": "third-party-guides",
+      "description": "An organized list of essential Swift Language Topics.",
+      "homepage": "https://github.com/hsavit1/Awesome-Swift-Education"
+    },
+    {
+      "title": "awesome-macOS",
+      "category": "other-awesome-lists",
+      "description": "A curated list of awesome applications, softwares, tools and shiny things for macOS.",
+      "homepage": "https://github.com/iCHAIT/awesome-macOS"
+    },
+    {
+      "title": "AwesomeCache",
+      "category": "cache",
+      "description": "Manage cache easy.",
+      "homepage": "https://github.com/aschuch/AwesomeCache"
+    },
+    {
+      "title": "AwesomeSpotlightView",
+      "category": "walkthrough",
+      "description": "Create tutorial or coach tour.",
+      "homepage": "https://github.com/aleksandrshoshiashvili/AwesomeSpotlightView"
+    },
+    {
+      "title": "AXPhotoViewer",
+      "category": "images",
+      "description": "An iPhone/iPad photo gallery viewer, useful for viewing a large (or small!) number of photos.",
+      "homepage": "https://github.com/alexhillc/AXPhotoViewer"
+    },
+    {
+      "title": "AZCollectionViewController",
+      "category": "uicollectionview",
+      "description": "Easy way to integrate pagination with dummy views in CollectionView, make Instagram Discover withing minutes.",
+      "homepage": "https://github.com/AfrozZaheer/AZCollectionViewController"
+    },
+    {
+      "title": "AZTableViewController",
+      "category": "uitableview",
+      "description": "Elegant and easy way to integrate pagination with placeholder views.",
+      "homepage": "https://github.com/AfrozZaheer/AZTableViewController"
+    },
+    {
+      "title": "Azure Functions for Swift",
+      "category": "serverless",
+      "description": "Swift Worker for Azure Functions.",
+      "homepage": "https://github.com/SalehAlbuga/azure-functions-swift",
+      "tags": [
+        "linux",
+        "macOS",
+        "serverless",
+        "cloud",
+        "azure"
+      ]
+    },
+    {
+      "title": "BadgeHub",
+      "category": "ui",
+      "description": "Make any UIView a full fledged animated notification center. It is a way to quickly add a notification badge icon to a UIView.",
+      "homepage": "https://github.com/jogendra/BadgeHub",
+      "tags": [
+        "animation",
+        "badge"
+      ]
+    },
+    {
+      "title": "Ballcap",
+      "category": "firebase",
+      "description": "Ballcap is a database schema design framework for Cloud Firestore.",
+      "homepage": "https://github.com/1amageek/Ballcap-iOS"
+    },
+    {
+      "title": "Bamboo",
+      "category": "auto-layout",
+      "description": "Auto Layout (and manual layout) in one line.",
+      "homepage": "https://github.com/wordlessj/Bamboo"
+    },
+    {
+      "title": "BarcodeScanner",
+      "category": "barcode",
+      "description": "A simple and beautiful barcode scanner view controller.",
+      "homepage": "https://github.com/hyperoslo/BarcodeScanner"
+    },
+    {
+      "title": "BartyCrouch",
+      "category": "localization",
+      "description": "Incrementally update/translate your Strings files from Code and Storyboards/XIBs.",
+      "homepage": "https://github.com/FlineDev/BartyCrouch"
+    },
+    {
+      "title": "Basis",
+      "category": "utility",
+      "description": "Pure Declarative Programming.",
+      "homepage": "https://github.com/typelift/Basis"
+    },
+    {
+      "title": "BatteryView",
+      "category": "ui",
+      "description": "Simple battery shaped UIView.",
+      "homepage": "https://github.com/yonat/BatteryView"
+    },
+    {
+      "title": "Beak",
+      "category": "misc",
+      "description": "A command line interface for your Swift scripts.",
+      "homepage": "https://github.com/yonaskolb/Beak"
+    },
+    {
+      "title": "Beethoven",
+      "category": "audio",
+      "description": "An audio processing library for pitch detection of musical signals.",
+      "homepage": "https://github.com/vadymmarkov/Beethoven"
+    },
+    {
+      "title": "BetterCodable",
+      "category": "misc",
+      "description": "Level up your `Codable` structs through property wrappers. The goal of these property wrappers is to avoid implementing a custom `init(from decoder: Decoder)` throws and suffer through boilerplate.",
+      "homepage": "https://github.com/marksands/BetterCodable"
+    },
+    {
+      "title": "BetterSafariView",
+      "category": "ui",
+      "description": "A better way to present a SFSafariViewController or start a ASWebAuthenticationSession in SwiftUI.",
+      "homepage": "https://github.com/stleamist/BetterSafariView"
+    },
+    {
+      "title": "BFKit-Swift",
+      "category": "kit",
+      "description": "A collection of useful classes, structs and extensions to develop Apps faster.",
+      "homepage": "https://github.com/FabrizioBrancati/BFKit-Swift",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "BigInt",
+      "category": "math",
+      "description": "Arbitrary-precision arithmetic.",
+      "homepage": "https://github.com/attaswift/BigInt"
+    },
+    {
+      "title": "BlockiesSwift",
+      "category": "images",
+      "description": "Unique blocky identicons/profile picture generator.",
+      "homepage": "https://github.com/Boilertalk/BlockiesSwift",
+      "swift": 4,
+      "tags": [
+        "profile-picture",
+        "identicons",
+        "image",
+        "generator"
+      ]
+    },
+    {
+      "title": "BlueCap",
+      "category": "bluetooth",
+      "description": "Wrapper around CoreBluetooth and much more.",
+      "homepage": "https://github.com/troystribling/BlueCap"
+    },
+    {
+      "title": "BlueCryptor",
+      "category": "cryptography",
+      "description": "IBM's Cross Platform Crypto library.",
+      "homepage": "https://github.com/Kitura/BlueCryptor"
+    },
+    {
+      "title": "Bluejay",
+      "category": "bluetooth",
+      "description": "A simple framework for building reliable Bluetooth LE apps.",
+      "homepage": "https://github.com/steamclock/bluejay"
+    },
+    {
+      "title": "Blueprints",
+      "category": "uicollectionview",
+      "description": "A framework that is meant to make your life easier when working with collection view flow layouts.",
+      "homepage": "https://github.com/zenangst/Blueprints"
+    },
+    {
+      "title": "BlueRSA",
+      "category": "cryptography",
+      "description": "IBM's Cross Platform RSA Crypto library.",
+      "homepage": "https://github.com/Kitura/BlueRSA"
+    },
+    {
+      "title": "BlueSignals",
+      "category": "system",
+      "description": "IBM's Cross Platform OS signal handling library.",
+      "homepage": "https://github.com/Kitura/BlueSignals"
+    },
+    {
+      "title": "BlueSocket",
+      "category": "socket",
+      "description": "IBM's cross platform low level socket framework.",
+      "homepage": "https://github.com/Kitura/BlueSocket "
+    },
+    {
+      "title": "BlueSSLService",
+      "category": "socket",
+      "description": "SSL/TLS add-in for IBM's low level socket framework.",
+      "homepage": "https://github.com/Kitura/BlueSSLService"
+    },
+    {
+      "title": "BluetoothKit",
+      "category": "bluetooth",
+      "description": "Easily communicate between iOS/OSX devices using BLE.",
+      "homepage": "https://github.com/rhummelmose/BluetoothKit"
+    },
+    {
+      "title": "BMPlayer",
+      "category": "video",
+      "description": "A video player for iOS, based on AVPlayer, support the horizontal, vertical screen. support adjust volume, brigtness and seek by slide.",
+      "homepage": "https://github.com/BrikerMan/BMPlayer",
+      "tags": [
+        "swift",
+        "avplayer",
+        "video-player",
+        "ios-swift",
+        "carthage"
+      ]
+    },
+    {
+      "title": "Bond",
+      "category": "events",
+      "description": "Binding framework.",
+      "homepage": "https://github.com/DeclarativeHub/Bond"
+    },
+    {
+      "title": "BonMot",
+      "category": "text",
+      "description": "Beautiful, easy attributed strings for iOS.",
+      "homepage": "https://github.com/Rightpoint/BonMot"
+    },
+    {
+      "title": "BottomSheet",
+      "category": "ui",
+      "description": "Powerful Bottom Sheet component with content based size, interactive dismissal and navigation controller support.",
+      "homepage": "https://github.com/joomcode/BottomSheet",
+      "tags": [
+        "uikit",
+        "iOS",
+        "bottom-sheet"
+      ]
+    },
+    {
+      "title": "BouncyLayout",
+      "category": "uicollectionview",
+      "description": "Collection view layout that makes your cells bounce.",
+      "homepage": "https://github.com/roberthein/BouncyLayout"
+    },
+    {
+      "title": "Bow",
+      "category": "utility",
+      "description": "Companion library for Typed Functional Programming.",
+      "homepage": "https://github.com/bow-swift/bow"
+    },
+    {
+      "title": "BreakOutToRefresh",
+      "category": "ui",
+      "description": "A playable pull to refresh view using SpriteKit.",
+      "homepage": "https://github.com/dasdom/BreakOutToRefresh"
+    },
+    {
+      "title": "BrickKit",
+      "category": "layout",
+      "description": "Create complex and responsive layouts in a simple way.",
+      "homepage": "https://github.com/wayfair-archive/brickkit-ios"
+    },
+    {
+      "title": "Brightroom",
+      "category": "images",
+      "description": "An image editor and engine using CoreImage.",
+      "homepage": "https://github.com/FluidGroup/Brightroom"
+    },
+    {
+      "title": "BTree",
+      "category": "algorithm",
+      "description": "Fast sorted collections for Swift using in-memory B-trees.",
+      "homepage": "https://github.com/attaswift/BTree"
+    },
+    {
+      "title": "BubbleTransition",
+      "category": "transition",
+      "description": "Bubble transition in an easy way.",
+      "homepage": "https://github.com/andreamazz/BubbleTransition"
+    },
+    {
+      "title": "BulletinBoard",
+      "category": "ui",
+      "description": "Generates and manages contextual cards displayed at the bottom of the screen.",
+      "homepage": "https://github.com/alexaubry/BulletinBoard"
+    },
+    {
+      "title": "BWWalkthrough",
+      "category": "walkthrough",
+      "description": "A class to build custom walkthroughs for your iOS App.",
+      "homepage": "https://github.com/ariok/BWWalkthrough"
+    },
+    {
+      "title": "C4iOS",
+      "category": "kit",
+      "description": "Harnesses the power of native iOS programming with a simplified API.",
+      "homepage": "https://github.com/C4Labs/C4iOS"
+    },
+    {
+      "title": "Cabbage",
+      "category": "video",
+      "description": "A video composition framework build on top of AVFoundation.",
+      "homepage": "https://github.com/VideoFlint/Cabbage"
+    },
+    {
+      "title": "Cache",
+      "category": "cache",
+      "description": "Nothing but Cache.",
+      "homepage": "https://github.com/hyperoslo/Cache"
+    },
+    {
+      "title": "CacheAdvance",
+      "category": "other-data",
+      "description": "A performant cache for logging systems. CacheAdvance persists log events 30x faster than SQLite.",
+      "homepage": "https://github.com/dfed/CacheAdvance"
+    },
+    {
+      "title": "CachyKit",
+      "category": "cache",
+      "description": "A Caching Library that can cache JSON, Image, Zip or AnyObject with expiry date/TTYL and force refresh.",
+      "homepage": "https://github.com/Sadmansamee/CachyKit"
+    },
+    {
+      "title": "Cachyr",
+      "category": "cache",
+      "description": "A small key-value data cache for iOS, macOS and tvOS.",
+      "homepage": "https://github.com/nrkno/yr-cachyr"
+    },
+    {
+      "title": "Caishen",
+      "category": "payment",
+      "description": "A Payment Card UI & Validator for iOS.",
+      "homepage": "https://github.com/prolificinteractive/Caishen"
+    },
+    {
+      "title": "CalendarKit",
+      "category": "calendar",
+      "description": "Fully customizable calendar day view.",
+      "homepage": "https://github.com/richardtop/CalendarKit"
+    },
+    {
+      "title": "CalendarView",
+      "category": "calendar",
+      "description": "Calendar Component, It features both vertical and horizontal layout (and scrolling) and the display of native calendar events.",
+      "homepage": "https://github.com/mmick66/CalendarView"
+    },
+    {
+      "title": "CallbackURLKit",
+      "category": "utility",
+      "description": "Implementation of x-callback-url (Inter app communication).",
+      "homepage": "https://github.com/phimage/CallbackURLKit"
+    },
+    {
+      "title": "CameraBackground",
+      "category": "camera",
+      "description": "Show camera layer as a background to any UIView.",
+      "homepage": "https://github.com/yonat/CameraBackground"
+    },
+    {
+      "title": "CameraKit-iOS",
+      "category": "camera",
+      "description": "Massively increase camera performance and ease of use in your next project.",
+      "homepage": "https://github.com/CameraKit/camerakit-ios"
+    },
+    {
+      "title": "Capable",
+      "category": "accessibility",
+      "description": "Keep track of accessibility settings, leverage high contrast colors, and use scalable fonts to enable users with disabilities to use your app.",
+      "homepage": "https://github.com/chrs1885/Capable",
+      "tags": [
         "swift",
         "accessibility",
         "iOS",
@@ -1025,3903 +1688,104 @@
       ]
     },
     {
-      "title":"CoreML-Models",
-      "category":"ai",
-      "description":"A collection of unique Core ML Models.",
-      "homepage":"https://github.com/likedan/Awesome-CoreML-Models"
-    },
-    {
-      "title":"DL4S",
-      "category":"ai",
-      "description":"Automatic differentiation, fast tensor operations and dynamic neural networks from CNNs and RNNs to transformers.",
-      "homepage":"https://github.com/palle-k/DL4S",
-      "tags":[
-        "math",
-        "machine-learning",
-        "automatic-differentiation",
-        "neural-networks"
-      ]
-    },
-    {
-      "title":"Fazm",
-      "category":"ai",
-      "description":"A voice-controlled AI agent for macOS using accessibility APIs and ScreenCaptureKit.",
-      "homepage":"https://github.com/m13v/fazm",
-      "tags":[
-        "ai",
-        "macos",
-        "voice",
-        "agent",
-        "swiftui"
-      ]
-    },
-    {
-      "title":"Espresso",
-      "category":"ai",
-      "description":"Compile transformers directly for Apple's Neural Engine.",
-      "homepage":"https://github.com/christopherkarani/Espresso"
-    },
-    {
-      "title":"CenteredCollectionView",
-      "category":"uicollectionview",
-      "description":"A lightweight UICollectionViewLayout that pages and centers it's cells.",
-      "homepage":"https://github.com/BenEmdon/CenteredCollectionView"
-    },
-    {
-      "title":"Stellar",
-      "category":"animation",
-      "description":"A Physical animation library.",
-      "homepage":"https://github.com/AugustRush/Stellar"
-    },
-    {
-      "title":"Advance",
-      "category":"animation",
-      "description":"A powerful animation framework for iOS, tvOS, and OS X.",
-      "homepage":"https://github.com/timdonnelly/Advance"
-    },
-    {
-      "title":"Comets",
-      "category":"animation",
-      "description":"Animating Particles.",
-      "homepage":"https://github.com/cruisediary/Comets"
-    },
-    {
-      "title":"EasyAnimation",
-      "category":"animation",
-      "description":"A library to take the power of UIView.animateWithDuration(_:, animations:...) to a whole new level.",
-      "homepage":"https://github.com/icanzilb/EasyAnimation"
-    },
-    {
-      "title":"FlightAnimator",
-      "category":"animation",
-      "description":"Natural Blocks Based Core Animation Framework.",
-      "homepage":"https://github.com/AntonTheDev/FlightAnimator"
-    },
-    {
-      "title":"Gemini",
-      "category":"animation",
-      "description":"Gemini is rich scroll based animation framework.",
-      "homepage":"https://github.com/shoheiyokoyama/Gemini"
-    },
-    {
-      "title":"IBAnimatable",
-      "category":"animation",
-      "description":"Design and prototype UI, interaction, navigation, transition and animation for App Store ready Apps in Interface Builder with IBAnimatable.",
-      "homepage":"https://github.com/IBAnimatable/IBAnimatable"
-    },
-    {
-      "title":"Interpolate",
-      "category":"animation",
-      "description":"Interpolation framework for creating interactive gesture-driven animations.",
-      "homepage":"https://github.com/marmelroy/Interpolate"
-    },
-    {
-      "title":"Pastel",
-      "category":"animation",
-      "description":"Gradient animation effect like Instagram.",
-      "homepage":"https://github.com/cruisediary/Pastel",
-      "tags":[
+      "title": "CapturePreventionKit",
+      "category": "ui",
+      "description": "Provides `Label` and `ImageView` for `screen capture prevention`.",
+      "homepage": "https://github.com/Jaesung-Jung/CapturePreventionKit",
+      "tags": [
         "swift",
-        "animation",
-        "instagram"
-      ],
-      "swift":4
-    },
-    {
-      "title":"Presentation",
-      "category":"animation",
-      "description":"A library to help you to make tutorials, release notes and animated pages.",
-      "homepage":"https://github.com/hyperoslo/Presentation"
-    },
-    {
-      "title":"Pulsator",
-      "category":"animation",
-      "description":"Pulse animation for iOS.",
-      "homepage":"https://github.com/shu223/pulsator"
-    },
-    {
-      "title":"Spring",
-      "category":"animation",
-      "description":"A library to simplify iOS animations.",
-      "homepage":"https://github.com/MengTo/Spring"
-    },
-    {
-      "title":"spruce-ios",
-      "category":"animation",
-      "description":"Choreograph animations on the screen.",
-      "homepage":"https://github.com/willowtreeapps/spruce-ios"
-    },
-    {
-      "title":"YapAnimator",
-      "category":"animation",
-      "description":"Your fast and friendly physics-based animation system.",
-      "homepage":"https://github.com/yapstudios/YapAnimator"
-    },
-    {
-      "title":"ViewAnimator",
-      "category":"animation",
-      "description":"Brings your UI to life with just one line.",
-      "homepage":"https://github.com/marcosgriselli/ViewAnimator"
-    },
-    {
-      "title":"SpriteKitEasingSwift",
-      "category":"animation",
-      "description":"Better Easing for SpriteKit.",
-      "homepage":"https://github.com/craiggrummitt/SpriteKitEasingSwift"
-    },
-    {
-      "title":"Elephant",
-      "category":"animation",
-      "description":"Elegant SVG animation kit.",
-      "homepage":"https://github.com/s2mr/Elephant"
-    },
-    {
-      "title":"CocoaSprings",
-      "category":"animation",
-      "description":"Interactive spring animations for iOS/macOS.",
-      "homepage":"https://github.com/MacPaw/CocoaSprings"
-    },
-    {
-      "title":"Appz",
-      "category":"app-routing",
-      "description":"Launch external apps and deeplink with ease.",
-      "homepage":"https://github.com/SwiftKitz/Appz"
-    },
-    {
-      "title":"URLNavigator",
-      "category":"app-routing",
-      "description":"Elegant URL Routing.",
-      "homepage":"https://github.com/devxoul/URLNavigator"
-    },
-    {
-      "title":"InAppPurchase",
-      "category":"app-store",
-      "description":"A Simple, Lightweight and Safe framework for In App Purchase.",
-      "homepage":"https://github.com/jinSasaki/InAppPurchase"
-    },
-    {
-      "title":"SwiftyStoreKit",
-      "category":"app-store",
-      "description":"Lightweight In App Purchases framework.",
-      "homepage":"https://github.com/bizz84/SwiftyStoreKit"
-    },
-    {
-      "title":"Flare",
-      "category":"app-store",
-      "description":"A framework that simplifies working with in-app purchases on iOS, macOS, tvOS, and watchOS, with full support for both StoreKit 1 and StoreKit 2.",
-      "homepage":"https://github.com/space-code/flare"
-    },
-    {
-      "title":"AudioKit",
-      "category":"audio",
-      "description":"Powerful audio synthesis, processing and analysis, without the steep learning curve.",
-      "homepage":"https://github.com/audiokit/AudioKit"
-    },
-    {
-      "title":"AudioPlayer",
-      "category":"audio",
-      "description":"A wrapper around AVPlayer with some cool features.",
-      "homepage":"https://github.com/delannoyk/AudioPlayer"
-    },
-    {
-      "title":"AudioPlayerSwift",
-      "category":"audio",
-      "description":"AudioPlayer is a simple class for playing audio (basic and advanced usage) in iOS, OS X and tvOS apps.",
-      "homepage":"https://github.com/tbaranes/AudioPlayerSwift"
-    },
-    {
-      "title":"Beethoven",
-      "category":"audio",
-      "description":"An audio processing library for pitch detection of musical signals.",
-      "homepage":"https://github.com/vadymmarkov/Beethoven"
-    },
-    {
-      "title":"MusicKit",
-      "category":"audio",
-      "description":"A framework for composing and transforming music.",
-      "homepage":"https://github.com/0thernet/MusicKit"
-    },
-    {
-      "title":"Cely",
-      "category":"authentication",
-      "description":"A Plug-n-Play login framework.",
-      "homepage":"https://github.com/cely-tools/Cely"
-    },
-    {
-      "title":"Cleanse",
-      "category":"dependency-injection",
-      "description":"A Lightweight Dependency Injection Framework by Square.",
-      "homepage":"https://github.com/square/Cleanse"
-    },
-    {
-      "title":"Deli",
-      "category":"dependency-injection",
-      "description":"Deli is an easy-to-use Dependency Injection(DI).",
-      "homepage":"https://github.com/kawoou/Deli",
-      "tags":[
-        "swift",
-        "ios",
-        "di"
+        "iOS",
+        "ui",
+        "security"
       ]
     },
     {
-      "title":"Dip",
-      "category":"dependency-injection",
-      "description":"A simple Dependency Injection Container.",
-      "homepage":"https://github.com/AliSoftware/Dip"
+      "title": "Carbon",
+      "category": "form",
+      "description": "🚴 A declarative library for building component-based user interfaces in UITableView and UICollectionView.",
+      "homepage": "https://github.com/ra1028/Carbon"
     },
     {
-      "title":"RandomUserSwift",
-      "category":"api",
-      "description":"Framework to Generate Random Users - An Unofficial SDK for randomuser.me.",
-      "homepage":"https://github.com/dingwilson/RandomUserSwift"
-    },
-    {
-      "title":"PXGoogleDirections",
-      "category":"api",
-      "description":"Google Directions API helper.",
-      "homepage":"https://github.com/poulpix/PXGoogleDirections"
-    },
-    {
-      "title":"reddift",
-      "category":"api",
-      "description":"reddit API wrapper.",
-      "homepage":"https://github.com/sonsongithub/reddift"
-    },
-    {
-      "title":"SwiftDisc",
-      "category":"api",
-      "description":"Discord API library for bots and integrations.",
-      "homepage":"https://github.com/M1tsumi/SwiftDisc"
-    },
-    {
-      "title":"Swifter Twitter",
-      "category":"api",
-      "description":"Twitter framework.",
-      "homepage":"https://github.com/mattdonnelly/Swifter"
-    },
-    {
-      "title":"Swiftkube",
-      "category":"api",
-      "description":"Swift client for Kubernetes.",
-      "homepage":"https://github.com/swiftkube/client",
-      "tags":[
-        "linux",
-        "macos",
-        "kubernetes",
-        "cloud"
+      "title": "CardNavigation",
+      "category": "cards",
+      "description": "A navigation controller that displays its view controllers as an interactive stack of cards.",
+      "homepage": "https://github.com/james01/CardNavigation",
+      "tags": [
+        "navigation",
+        "interactive",
+        "cards",
+        "uikit",
+        "transition",
+        "interruptible"
       ]
     },
     {
-      "title":"SwiftyInsta",
-      "category":"api",
-      "description":"Private and Tokenless Instagram RESTful API.",
-      "homepage":"https://github.com/TheM4hd1/SwiftyInsta"
+      "title": "CardParts",
+      "category": "cards",
+      "description": "A reactive, card-based UI framework built on UIKit for iOS developers.",
+      "homepage": "https://github.com/intuit/CardParts"
     },
     {
-      "title":"Pure",
-      "category":"dependency-injection",
-      "description":"A way to do a dependency injection without a DI container.",
-      "homepage":"https://github.com/devxoul/Pure"
+      "title": "Cards XI",
+      "category": "transition",
+      "description": "Awesome iOS 11 AppStore's Card Views.",
+      "homepage": "https://github.com/PaoloCuscela/Cards"
     },
     {
-      "title":"SafeDI",
-      "category":"dependency-injection",
-      "description":"Compile-time safe dependency injection.",
-      "homepage":"https://github.com/dfed/safedi"
+      "title": "CardsLayout",
+      "category": "uicollectionview",
+      "description": "Nice card-designed custom CollectionView layout.",
+      "homepage": "https://github.com/filletofish/CardsLayout"
     },
     {
-      "title":"Swinject",
-      "category":"dependency-injection",
-      "description":"A dependency injection framework.",
-      "homepage":"https://github.com/Swinject/Swinject"
-    },
-    {
-      "title":"Typhoon",
-      "category":"dependency-injection",
-      "description":"Dependency injection toolkit.",
-      "homepage":"https://github.com/appsquickly/Typhoon"
-    },
-    {
-      "title":"Weaver",
-      "category":"dependency-injection",
-      "description":"A declarative, easy-to-use and safe Dependency Injection framework.",
-      "homepage":"https://github.com/scribd/Weaver"
-    },
-    {
-      "title":"DITranquillity",
-      "category":"dependency-injection",
-      "description":"Dependency injection framework with tranquility.",
-      "homepage":"https://github.com/ivlevAstef/DITranquillity/",
-      "tags":[
-        "Swift",
-        "DI",
-        "IoC"
-      ]
-    },
-    {
-      "title":"BlueCap",
-      "category":"bluetooth",
-      "description":"Wrapper around CoreBluetooth and much more.",
-      "homepage":"https://github.com/troystribling/BlueCap"
-    },
-    {
-      "title":"BluetoothKit",
-      "category":"bluetooth",
-      "description":"Easily communicate between iOS/OSX devices using BLE.",
-      "homepage":"https://github.com/rhummelmose/BluetoothKit"
-    },
-    {
-      "title":"RxBluetoothKit",
-      "category":"bluetooth",
-      "description":"iOS & OSX Bluetooth library for RxSwift.",
-      "homepage":"https://github.com/polidea/RxBluetoothKit"
-    },
-    {
-      "title":"SwiftyBluetooth",
-      "category":"bluetooth",
-      "description":"Simple and reliable closure based wrapper around CoreBluetooth.",
-      "homepage":"https://github.com/jordanebelanger/SwiftyBluetooth"
-    },
-    {
-      "title":"Fusuma",
-      "category":"camera",
-      "description":"Instagram-like photo browser and a camera feature.",
-      "homepage":"https://github.com/ytakzk/Fusuma"
-    },
-    {
-      "title":"NextLevel",
-      "category":"camera",
-      "description":"Rad Media Capture.",
-      "homepage":"https://github.com/NextLevel/NextLevel"
-    },
-    {
-      "title":"CameraKit-iOS",
-      "category":"camera",
-      "description":"Massively increase camera performance and ease of use in your next project.",
-      "homepage":"https://github.com/CameraKit/camerakit-ios"
-    },
-    {
-      "title":"BarcodeScanner",
-      "category":"barcode",
-      "description":"A simple and beautiful barcode scanner view controller.",
-      "homepage":"https://github.com/hyperoslo/BarcodeScanner"
-    },
-    {
-      "title":"QRCodeReader.swift",
-      "category":"barcode",
-      "description":"Simple QRCode reader.",
-      "homepage":"https://github.com/yannickl/QRCodeReader.swift"
-    },
-    {
-      "title":"Chatto",
-      "category":"chat",
-      "description":"A lightweight framework to build chat applications.",
-      "homepage":"https://github.com/badoo/Chatto"
-    },
-    {
-      "title":"DynamicColor",
-      "category":"colors",
-      "description":"An extension to manipulate colors easily.",
-      "homepage":"https://github.com/yannickl/DynamicColor"
-    },
-    {
-      "title":"Gradients",
-      "category":"colors",
-      "description":"A curated collection of splendid 180+ gradients.",
-      "homepage":"https://github.com/Gradients/Gradients"
-    },
-    {
-      "title":"Hue",
-      "category":"colors",
-      "description":"Hue is the all-in-one coloring utility that you'll ever need.",
-      "homepage":"https://github.com/zenangst/Hue"
-    },
-    {
-      "title":"PrettyColors",
-      "category":"colors",
-      "description":"Styles and colors text in the Terminal with ANSI escape codes. Conforms to ECMA Standard 48.",
-      "homepage":"https://github.com/jdhealy/PrettyColors"
-    },
-    {
-      "title":"SwiftGen-Colors",
-      "category":"colors",
-      "description":"A tool to auto-generate `enums` for your `UIColor` constants.",
-      "homepage":"https://github.com/SwiftGen/SwiftGen#uicolor"
-    },
-    {
-      "title":"SwiftHEXColors",
-      "category":"colors",
-      "description":"HEX color handling as an extension for UIColor.",
-      "homepage":"https://github.com/thii/SwiftHEXColors"
-    },
-    {
-      "title":"UIColor-Hex-Swift",
-      "category":"colors",
-      "description":"Hex to UIColor converter.",
-      "homepage":"https://github.com/yeahdongcn/UIColor-Hex-Swift"
-    },
-    {
-      "title":"UIGradient",
-      "category":"colors",
-      "description":"A simple and powerful library for using gradient layer, image, color.",
-      "homepage":"https://github.com/dqhieu/UIGradient"
-    },
-    {
-      "title":"ChromaColorPicker",
-      "category":"colors",
-      "description":"An intuitive and fun iOS color picker.",
-      "homepage":"https://github.com/joncardasis/ChromaColorPicker"
-    },
-    {
-      "title":"SheetyColors",
-      "category":"colors",
-      "description":"An action sheet styled color picker for iOS.",
-      "homepage":"https://github.com/chrs1885/SheetyColors"
-    },
-    {
-      "title":"Commander",
-      "category":"command-line",
-      "description":"Compose beautiful command line interfaces.",
-      "homepage":"https://github.com/kylef/Commander",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"Guaka",
-      "category":"command-line",
-      "description":"The smart and beautiful (POSIX compliant) command line framework.",
-      "homepage":"https://github.com/nsomar/Guaka",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"LineNoise",
-      "category":"command-line",
-      "description":"A zero-dependency replacement for readline.",
-      "homepage":"https://github.com/andybest/linenoise-swift",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"Mocker",
-      "category":"command-line",
-      "description":"Docker-compatible container CLI for macOS, built on Apple's Containerization framework.",
-      "homepage":"https://github.com/us/mocker",
-      "tags":[
-        "macOS",
-        "docker",
-        "containers"
-      ]
-    },
-    {
-      "title":"nef",
-      "category":"command-line",
-      "description":"A set of command line tools that lets you have compile time verification of your documentation written as Xcode Playground.",
-      "homepage":"https://github.com/bow-swift/nef",
-      "tags":[
-        "macOS"
-      ]
-    },
-    {
-      "title":"SwiftCLI",
-      "category":"command-line",
-      "description":"A powerful framework that can be used to develop a CLI.",
-      "homepage":"https://github.com/jakeheis/SwiftCLI",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"Swiftline",
-      "category":"command-line",
-      "description":"A set of tools to help you create command line applications.",
-      "homepage":"https://github.com/nsomar/Swiftline"
-    },
-    {
-      "title":"SwiftyTextTable",
-      "category":"command-line",
-      "description":"A lightweight library to generate text tables.",
-      "homepage":"https://github.com/scottrhoyt/SwiftyTextTable",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"Ashen",
-      "category":"command-line",
-      "description":"A framework for writing terminal applications in Swift. Based on The Elm Architecture.",
-      "homepage":"https://github.com/colinta/Ashen",
-      "tags":[
-        "macOS"
-      ]
-    },
-    {
-      "title":"Venice",
-      "category":"concurrency",
-      "description":"Communicating sequential processes (CSP), Linux ready.",
-      "homepage":"https://github.com/Zewo/Venice",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"Throttler",
-      "category":"concurrency",
-      "description":"Throttle massive number of asynchronous inputs in a single drop of one line API.",
-      "homepage":"https://github.com/boraseoksoon/Throttler",
-      "tags":[
-        "ios",
-        "macos",
-        "tvos",
-        "watchos",
+      "title": "CardTabBar",
+      "category": "tab",
+      "description": "Adding animation to iOS tabbar items.",
+      "homepage": "https://github.com/yusadogru/CardTabBar",
+      "tags": [
+        "uitabbar",
+        "tabbar",
+        "cardTabBar",
+        "uitabbaritem",
+        "uitabbarviewcontroller",
         "swift"
       ]
     },
     {
-      "title":"Futures",
-      "category":"concurrency",
-      "description":"Lightweight promises for iOS, macOS, tvOS, watchOS, and server-side.",
-      "homepage":"https://github.com/davidask/Futures",
-      "tags":[
-        "linux"
+      "title": "Carlos",
+      "category": "cache",
+      "description": "A simple but flexible cache.",
+      "homepage": "https://github.com/spring-media/Carlos"
+    },
+    {
+      "title": "Carthage",
+      "category": "dependency-managers",
+      "description": "A new dependency manager.",
+      "homepage": "https://github.com/Carthage/Carthage"
+    },
+    {
+      "title": "Cartography",
+      "category": "auto-layout",
+      "description": "Declarative auto layout lib for your project.",
+      "homepage": "https://github.com/robb/Cartography"
+    },
+    {
+      "title": "Cassowary",
+      "category": "auto-layout",
+      "description": "A linear constraint solving library using the same algorithm as AutoLayout.",
+      "homepage": "https://github.com/tribalworldwidelondon/CassowarySwift",
+      "tags": [
+        "cassowary",
+        "constraints",
+        "autolayout"
       ]
     },
     {
-      "title":"GroupWork",
-      "category":"concurrency",
-      "description":"Easy concurrent, asynchronous tasks.",
-      "homepage":"https://github.com/quanvo87/GroupWork",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"AERecord",
-      "category":"core-data",
-      "description":"Super awesome Core Data wrapper library for iOS.",
-      "homepage":"https://github.com/tadija/AERecord"
-    },
-    {
-      "title":"CloudCore",
-      "category":"core-data",
-      "description":"Robust CloudKit synchronization: offline editing, relationships, shared and public databases, and more.",
-      "homepage":"https://github.com/deeje/CloudCore/"
-    },
-    {
-      "title":"CoreStore",
-      "category":"core-data",
-      "description":"simple and elegant way to handle Core Data.",
-      "homepage":"https://github.com/JohnEstropia/CoreStore"
-    },
-    {
-      "title":"Graph",
-      "category":"core-data",
-      "description":"An elegant data-driven framework for Core Data.",
-      "homepage":"https://github.com/CosmicMind/Graph"
-    },
-    {
-      "title":"JSQCoreDataKit",
-      "category":"core-data",
-      "description":"A swifter Core Data stack.",
-      "homepage":"https://github.com/jessesquires/JSQCoreDataKit"
-    },
-    {
-      "title":"QueryKit",
-      "category":"core-data",
-      "description":"An easy way to play with Core Data filtering.",
-      "homepage":"https://github.com/QueryKit/QueryKit"
-    },
-    {
-      "title":"Skopelos",
-      "category":"core-data",
-      "description":"A minimalistic, thread safe, non-boilerplate and super easy to use version of Active Record on Core Data.",
-      "homepage":"https://github.com/albertodebortoli/Skopelos"
-    },
-    {
-      "title":"SugarRecord",
-      "category":"core-data",
-      "description":"Helps with Core Data and Realm.",
-      "homepage":"https://github.com/modo-studio/SugarRecord"
-    },
-    {
-      "title":"DataKernel",
-      "category":"core-data",
-      "description":"DataKernel is a minimalistic wrapper around Core Data stack to ease persistence operations. No external dependencies.",
-      "homepage":"https://github.com/mrdekk/DataKernel"
-    },
-    {
-      "title":"LeetCode-Swift",
-      "category":"other-data",
-      "description":"Solutions to LeetCode interview questions.",
-      "homepage":"https://github.com/soapyigu/LeetCode-Swift"
-    },
-    {
-      "title":"Algorithm",
-      "category":"algorithm",
-      "description":"A toolset for writing algorithms and probability models.",
-      "homepage":"https://github.com/CosmicMind/Algorithm"
-    },
-    {
-      "title":"swift-algorithm-club",
-      "category":"algorithm",
-      "description":"Algorithms and data structures, with explanations.",
-      "homepage":"https://github.com/kodecocodes/swift-algorithm-club"
-    },
-    {
-      "title":"Pencil",
-      "category":"other-data",
-      "description":"Write any value to file.",
-      "homepage":"https://github.com/naru-jpn/pencil"
-    },
-    {
-      "title":"Realm",
-      "category":"realm",
-      "description":"Realm is a mobile database: a replacement for Core Data & SQLite.",
-      "homepage":"https://github.com/realm/realm-swift"
-    },
-    {
-      "title":"Ballcap",
-      "category":"firebase",
-      "description":"Ballcap is a database schema design framework for Cloud Firestore.",
-      "homepage":"https://github.com/1amageek/Ballcap-iOS"
-    },
-    {
-      "title":"KZFileWatchers",
-      "category":"files",
-      "description":"A micro-framework for observing file changes, both local and remote.",
-      "homepage":"https://github.com/krzysztofzablocki/KZFileWatchers"
-    },
-    {
-      "title":"FileKit",
-      "category":"files",
-      "description":"Simple and expressive file management.",
-      "homepage":"https://github.com/nvzqz/FileKit"
-    },
-    {
-      "title":"PathKit",
-      "category":"files",
-      "description":"Effortless path operations.",
-      "homepage":"https://github.com/kylef/PathKit",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"FileProvider",
-      "category":"files",
-      "description":"FileManager replacement for Local, iCloud and Remote (WebDAV/FTP/Dropbox/OneDrive/SMB2) files for iOS/tvOS and macOS.",
-      "homepage":"https://github.com/amosavian/FileProvider"
-    },
-    {
-      "title":"AlamofireObjectMapper",
-      "category":"json",
-      "description":"An Alamofire extension which converts JSON response data into objects using ObjectMapper.",
-      "homepage":"https://github.com/tristanhimmelman/AlamofireObjectMapper"
-    },
-    {
-      "title":"Alembic",
-      "category":"json",
-      "description":"Functional JSON parsing, mapping to objects, and serialize to JSON.",
-      "homepage":"https://github.com/ra1028/Alembic"
-    },
-    {
-      "title":"Argo",
-      "category":"json",
-      "description":"JSON parsing library.",
-      "homepage":"https://github.com/thoughtbot/Argo"
-    },
-    {
-      "title":"Arrow",
-      "category":"json",
-      "description":"Elegant JSON Parsing.",
-      "homepage":"https://github.com/freshOS/Arrow"
-    },
-    {
-      "title":"Decodable",
-      "category":"json",
-      "description":"JSON parsing.",
-      "homepage":"https://github.com/Anviking/Decodable",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"Elevate",
-      "category":"json",
-      "description":"JSON parsing framework that makes parsing simple, reliable and composable.",
-      "homepage":"https://github.com/Nike-Inc/Elevate"
-    },
-    {
-      "title":"EVReflection",
-      "category":"json",
-      "description":"Reflection based JSON encoding and decoding. Including support for NSDictionary, NSCoding, Printable, Hashable and Equatable.",
-      "homepage":"https://github.com/evermeer/EVReflection"
-    },
-    {
-      "title":"HandyJSON",
-      "category":"json",
-      "description":"A handy JSON-object serialization/deserialization library.",
-      "homepage":"https://github.com/alibaba/handyjson"
-    },
-    {
-      "title":"Himotoki",
-      "category":"json",
-      "description":"A type-safe JSON decoding library.",
-      "homepage":"https://github.com/ikesyo/Himotoki"
-    },
-    {
-      "title":"JASON",
-      "category":"json",
-      "description":"JSON parsing with outstanding performances and convenient operators.",
-      "homepage":"https://github.com/delba/JASON"
-    },
-    {
-      "title":"JSONHelper",
-      "category":"json",
-      "description":"Lightning fast JSON deserialization and value conversion library for iOS & OS X.",
-      "homepage":"https://github.com/isair/JSONHelper"
-    },
-    {
-      "title":"JSONNeverDie",
-      "category":"json",
-      "description":"Auto reflection tool from JSON to Model, user friendly JSON encoder / decoder, aims to never die.",
-      "homepage":"https://github.com/johnlui/JSONNeverDie"
-    },
-    {
-      "title":"SwiftyJSONAccelerator",
-      "category":"json",
-      "description":"macOS app to generate Swift 5 models for JSON (with Codeable).",
-      "homepage":"https://github.com/insanoid/SwiftyJSONAccelerator"
-    },
-    {
-      "title":"ObjectMapper",
-      "category":"json",
-      "description":"JSON object mapper.",
-      "homepage":"https://github.com/tristanhimmelman/ObjectMapper"
-    },
-    {
-      "title":"SwiftyJSON",
-      "category":"json",
-      "description":"A lib for JSON with error handling.",
-      "homepage":"https://github.com/SwiftyJSON/SwiftyJSON"
-    },
-    {
-      "title":"PMJSON",
-      "category":"json",
-      "description":"JSON encoding/decoding library.",
-      "homepage":"https://github.com/postmates/PMJSON"
-    },
-    {
-      "title":"Sextant",
-      "category":"json",
-      "description":"High performance JSONPath queries",
-      "homepage":"https://github.com/KittyMac/Sextant",
-      "tags":[
-        "linux",
-        "macOS",
-        "iOS",
-        "tvOS"
-      ]
-    },
-    {
-      "title":"YamlSwift",
-      "category":"yaml",
-      "description":"Load YAML and JSON documents.",
-      "homepage":"https://github.com/behrang/YamlSwift"
-    },
-    {
-      "title":"Prephirences",
-      "category":"key-value-store",
-      "description":"Manage application preferences, NSUserDefaults, iCloud, Keychain and more.",
-      "homepage":"https://github.com/phimage/Prephirences"
-    },
-    {
-      "title":"Storez",
-      "category":"key-value-store",
-      "description":"Safe, statically-typed, store-agnostic key-value storage.",
-      "homepage":"https://github.com/SwiftKitz/Storez"
-    },
-    {
-      "title":"SwiftStore",
-      "category":"key-value-store",
-      "description":"A Key-Value store backed by LevelDB.",
-      "homepage":"https://github.com/hemantasapkota/SwiftStore"
-    },
-    {
-      "title":"SwiftyUserDefaults",
-      "category":"key-value-store",
-      "description":"Cleaner, nicer syntax for NSUserDefaults.",
-      "homepage":"https://github.com/sunshinejr/SwiftyUserDefaults"
-    },
-    {
-      "title":"Zephyr",
-      "category":"key-value-store",
-      "description":"Effortlessly synchronize NSUserDefaults over iCloud.",
-      "homepage":"https://github.com/ArtSabintsev/Zephyr"
-    },
-    {
-      "title":"Default",
-      "category":"key-value-store",
-      "description":"Modern interface to UserDefaults + Codable support.",
-      "homepage":"https://github.com/Nirma/Default"
-    },
-    {
-      "title":"MongoKitten",
-      "category":"mongodb",
-      "description":"MongoDB Connector.",
-      "homepage":"https://github.com/orlandos-nl/MongoKitten",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"Perfect-MongoDB",
-      "category":"mongodb",
-      "description":"A stand-alone wrapper around the mongo-c client library, enabling access to MongoDB servers.",
-      "homepage":"https://github.com/PerfectlySoft/Perfect-MongoDB",
-      "tags":[
-        "linux",
-        "macOS"
-      ]
-    },
-    {
-      "title":"fluent",
-      "category":"orm",
-      "description":"Simple ActiveRecord implementation.",
-      "homepage":"https://github.com/vapor/fluent",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"GRDB.swift",
-      "category":"sqlite",
-      "description":"A versatile SQLite toolkit.",
-      "homepage":"https://github.com/groue/GRDB.swift"
-    },
-    {
-      "title":"SQLite.swift",
-      "category":"sqlite",
-      "description":"Framework wrapping SQLite3. Small. Simple. Safe.",
-      "homepage":"https://github.com/stephencelis/SQLite.swift"
-    },
-    {
-      "title":"SQLiteDB",
-      "category":"sqlite",
-      "description":"SQLite wrapper.",
-      "homepage":"https://github.com/FahimF/SQLiteDB"
-    },
-    {
-      "title":"MySQL Swift",
-      "category":"sql-drivers",
-      "description":"MySQL client library.",
-      "homepage":"https://github.com/novi/mysql-swift",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"Perfect-MySQL",
-      "category":"sql-drivers",
-      "description":"A stand-alone wrapper around the MySQL client library, enabling access to MySQL servers.",
-      "homepage":"https://github.com/PerfectlySoft/Perfect-MySQL",
-      "tags":[
-        "linux",
-        "macOS"
-      ]
-    },
-    {
-      "title":"Perfect-PostgreSQL",
-      "category":"sql-drivers",
-      "description":"A stand-alone wrapper around the libpq client library, enabling access to PostgreSQL servers.",
-      "homepage":"https://github.com/PerfectlySoft/Perfect-PostgreSQL",
-      "tags":[
-        "linux",
-        "macOS"
-      ]
-    },
-    {
-      "title":"AEXML",
-      "category":"xml",
-      "description":"xml wrapper.",
-      "homepage":"https://github.com/tadija/AEXML"
-    },
-    {
-      "title":"SWXMLHash",
-      "category":"xml",
-      "description":"Simple XML parsing.",
-      "homepage":"https://github.com/drmohundro/SWXMLHash"
-    },
-    {
-      "title":"CheatyXML",
-      "category":"xml",
-      "description":"A powerful framework designed to manage XML easily.",
-      "homepage":"https://github.com/lobodart/CheatyXML"
-    },
-    {
-      "title":"SwiftyXML",
-      "category":"xml",
-      "description":"The most swifty way to deal with XML.",
-      "homepage":"https://github.com/chenyunguiMilook/SwiftyXML"
-    },
-    {
-      "title":"Zip",
-      "category":"zip",
-      "description":"Framework for zipping and unzipping files.",
-      "homepage":"https://github.com/marmelroy/Zip"
-    },
-    {
-      "title":"EVCloudKitDao",
-      "category":"other-data",
-      "description":"Simplified access to CloudKit with support for subscriptions and local caching.",
-      "homepage":"https://github.com/evermeer/EVCloudKitDao"
-    },
-    {
-      "title":"AnyDate",
-      "category":"date",
-      "description":"Date & Time API inspired from Java 8 DateTime API.",
-      "homepage":"https://github.com/Kawoou/AnyDate"
-    },
-    {
-      "title":"DateHelper",
-      "category":"date",
-      "description":"Simple date helper.",
-      "homepage":"https://github.com/melvitax/DateHelper"
-    },
-    {
-      "title":"Datez",
-      "category":"date",
-      "description":"Library for dealing with `NSDate`, `NSCalendar`, `NSDateComponents`, and `NSTimeInterval`.",
-      "homepage":"https://github.com/SwiftKitz/Datez"
-    },
-    {
-      "title":"NVDate",
-      "category":"date",
-      "description":"Date extension library.",
-      "homepage":"https://github.com/novalagung/nvdate"
-    },
-    {
-      "title":"SwiftDate",
-      "category":"date",
-      "description":"Easy NSDate Management.",
-      "homepage":"https://github.com/malcommac/SwiftDate"
-    },
-    {
-      "title":"SwiftyTimer",
-      "category":"thread",
-      "description":"API for NSTimer.",
-      "homepage":"https://github.com/radex/SwiftyTimer"
-    },
-    {
-      "title":"Each",
-      "category":"thread",
-      "description":"Each is a NSTimer bridge library.",
-      "homepage":"https://github.com/dalu93/Each"
-    },
-    {
-      "title":"Timepiece",
-      "category":"date",
-      "description":"Intuitive NSDate extensions.",
-      "homepage":"https://github.com/naoty/Timepiece"
-    },
-    {
-      "title":"Time",
-      "category":"date",
-      "description":"Type-safe time calculations, powered by generics.",
-      "homepage":"https://github.com/dreymonde/Time"
-    },
-    {
-      "title":"TrueTime.swift",
-      "category":"date",
-      "description":"Get the true current time impervious to device clock time changes (NTP library).",
-      "homepage":"https://github.com/instacart/TrueTime.swift"
-    },
-    {
-      "title":"Datify",
-      "category":"date",
-      "description":"Easypeasy date functions.",
-      "homepage":"https://github.com/hemangshah/Datify"
-    },
-    {
-      "title":"jazzy",
-      "category":"documentation",
-      "description":"Soulful docs.",
-      "homepage":"https://github.com/realm/jazzy/"
-    },
-    {
-      "title":"SourceDocs",
-      "category":"documentation",
-      "description":"Generate Markdown reference documentation that lives with your code.",
-      "homepage":"https://github.com/SourceDocs/SourceDocs",
-      "tags":[
-        "documentation",
-        "reference",
-        "markdown",
-        "generator"
-      ]
-    },
-    {
-      "title":"SwiftyGPIO",
-      "category":"embedded-systems",
-      "description":"Interact with Linux GPIO/SPI/PWM on ARM.",
-      "homepage":"https://github.com/uraimo/SwiftyGPIO",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"OneWay",
-      "category":"events",
-      "description":"State management with unidirectional data flow.",
-      "homepage":"https://github.com/DevYeom/OneWay"
-    },
-    {
-      "title":"OpenCombine",
-      "category":"events",
-      "description":"Open source implementation of Apple's Combine framework for processing values over time.",
-      "homepage":"https://github.com/OpenCombine/OpenCombine"
-    },
-    {
-      "title":"Bond",
-      "category":"events",
-      "description":"Binding framework.",
-      "homepage":"https://github.com/DeclarativeHub/Bond"
-    },
-    {
-      "title":"EmitterKit",
-      "category":"events",
-      "description":"Implementation of event emitters and listeners.",
-      "homepage":"https://github.com/aleclarson/emitter-kit"
-    },
-    {
-      "title":"FutureKit",
-      "category":"events",
-      "description":"Future/Promises Library.",
-      "homepage":"https://github.com/FutureKit/FutureKit"
-    },
-    {
-      "title":"Tomorrowland",
-      "category":"events",
-      "description":"Lightweight Promises.",
-      "homepage":"https://github.com/lilyball/Tomorrowland"
-    },
-    {
-      "title":"Notificationz",
-      "category":"events",
-      "description":"Helping you own `NSNotificationCenter` by providing a simple, customizable adapter.",
-      "homepage":"https://github.com/SwiftKitz/Notificationz"
-    },
-    {
-      "title":"PromiseKit",
-      "category":"events",
-      "description":"Async promise programming lib.",
-      "homepage":"https://github.com/mxcl/PromiseKit"
-    },
-    {
-      "title":"ReactiveCocoa",
-      "category":"events",
-      "description":"ReactiveCocoa (RAC) is a Cocoa framework inspired by Functional Reactive Programming. It provides APIs for composing and transforming streams of values over time.",
-      "homepage":"https://github.com/ReactiveCocoa/ReactiveCocoa"
-    },
-    {
-      "title":"ReactorKit",
-      "category":"events",
-      "description":"A framework for reactive and unidirectional application architecture.",
-      "homepage":"https://github.com/ReactorKit/ReactorKit"
-    },
-    {
-      "title":"RxSwift",
-      "category":"events",
-      "description":"Microsoft Reactive Extensions (Rx).",
-      "homepage":"https://github.com/ReactiveX/RxSwift"
-    },
-    {
-      "title":"Signals",
-      "category":"events",
-      "description":"Replaces delegates and notifications.",
-      "homepage":"https://github.com/artman/Signals"
-    },
-    {
-      "title":"SwiftEventBus",
-      "category":"events",
-      "description":"A publish/subscribe event bus optimized for iOS.",
-      "homepage":"https://github.com/cesarferreira/SwiftEventBus"
-    },
-    {
-      "title":"When",
-      "category":"events",
-      "description":"A lightweight implementation of Promises.",
-      "homepage":"https://github.com/vadymmarkov/When"
-    },
-    {
-      "title":"ReSwift",
-      "category":"events",
-      "description":"Unidirectional Data Flow.",
-      "homepage":"https://github.com/ReSwift/ReSwift"
-    },
-    {
-      "title":"Katana",
-      "category":"events",
-      "description":"Write apps a la React and Redux.",
-      "homepage":"https://github.com/BendingSpoons/katana-swift"
-    },
-    {
-      "title":"NoticeObserveKit",
-      "category":"events",
-      "description":"NoticeObserveKit is type-safe NotificationCenter wrapper that associates notice type with info type.",
-      "homepage":"https://github.com/marty-suzuki/NoticeObserveKit"
-    },
-    {
-      "title":"PMKVObserver",
-      "category":"events",
-      "description":"Modern thread-safe and type-safe key-value observing.",
-      "homepage":"https://github.com/postmates/PMKVObserver/"
-    },
-    {
-      "title":"TopicEventBus",
-      "category":"events",
-      "description":"Publish–subscribe design pattern implementation framework, with ability to publish events by topic.",
-      "homepage":"https://github.com/mcmatan/topicEventBus"
-    },
-    {
-      "title":"FontAwesome.swift",
-      "category":"fonts",
-      "description":"Use FontAwesome in your projects.",
-      "homepage":"https://github.com/thii/FontAwesome.swift"
-    },
-    {
-      "title":"FontBlaster",
-      "category":"fonts",
-      "description":"Programmatically load custom fonts into your iOS app.",
-      "homepage":"https://github.com/ArtSabintsev/FontBlaster"
-    },
-    {
-      "title":"IoniconsKit",
-      "category":"fonts",
-      "description":"Use ionicons as UIImage / UIFont in your projects.",
-      "homepage":"https://github.com/keitaoouchi/IoniconsKit"
-    },
-    {
-      "title":"OcticonsKit",
-      "category":"fonts",
-      "description":"Use Octicons as UIImage / UIFont in your projects.",
-      "homepage":"https://github.com/keitaoouchi/OcticonsKit"
-    },
-    {
-      "title":"SwiftIconFont",
-      "category":"fonts",
-      "description":"Fontawesome, Iconic, Ionicons, Octicon ports.",
-      "homepage":"https://github.com/segecey/SwiftIconFont"
-    },
-    {
-      "title":"UIFontComplete",
-      "category":"fonts",
-      "description":"Font management (System & Custom) for iOS and tvOS.",
-      "homepage":"https://github.com/Nirma/UIFontComplete"
-    },
-    {
-      "title":"SwiftIcons",
-      "category":"fonts",
-      "description":"Library for Font Icons: dripicons, emoji, font awesome, icofont, ionicons, linear icons, map icons, material icons, open iconic, state, weather.",
-      "homepage":"https://github.com/ranesr/SwiftIcons"
-    },
-    {
-      "title":"SYSymbol",
-      "category":"fonts",
-      "description":"All the SFSymbols at your fingertips.",
-      "homepage":"https://github.com/Nirma/SFSymbol"
-    },
-    {
-      "title":"SwiftUI-FontIcon",
-      "category":"fonts",
-      "description":"Font icons for SwiftUI: font awesome, ionicons, material icons.",
-      "homepage":"https://github.com/huybuidac/SwiftUIFontIcon"
-    },
-    {
-      "title":"Sage",
-      "category":"games",
-      "description":"A cross-platform chess library.",
-      "homepage":"https://github.com/nvzqz/Sage",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"SwiftyGestureRecognition",
-      "category":"gesture",
-      "description":"UIGestureRecognizers in Xcode Playgrounds.",
-      "homepage":"https://github.com/b3ll/SwiftyGestureRecognition"
-    },
-    {
-      "title":"SwipyCell",
-      "category":"gesture",
-      "description":"UITableViewCell implementing swiping to trigger actions (known from the Mailbox App).",
-      "homepage":"https://github.com/moritzsternemann/SwipyCell"
-    },
-    {
-      "title":"ShowTime",
-      "category":"gesture",
-      "description":"Show off your iOS taps and gestures for demos and videos with just one line of code.",
-      "homepage":"https://github.com/KaneCheshire/ShowTime"
-    },
-    {
-      "title":"SwiftLocation",
-      "category":"ibeacon",
-      "description":"Location & Beacon Monitoring.",
-      "homepage":"https://github.com/malcommac/SwiftLocation"
-    },
-    {
-      "title":"Agrume",
-      "category":"images",
-      "description":"A lemony fresh iOS image viewer.",
-      "homepage":"https://github.com/JanGorman/Agrume"
-    },
-    {
-      "title":"AlamofireImage",
-      "category":"images",
-      "description":"AlamofireImage is an image component library for Alamofire.",
-      "homepage":"https://github.com/Alamofire/AlamofireImage"
-    },
-    {
-      "title":"APNGKit",
-      "category":"images",
-      "description":"High performance and delightful way to play with APNG format in iOS.",
-      "homepage":"https://github.com/onevcat/APNGKit"
-    },
-    {
-      "title":"ATGMediaBrowser",
-      "category":"images",
-      "description":"Image slide-show viewer with multiple predefined transition styles, and with ability to create new transitions with ease.",
-      "homepage":"https://github.com/altayer-digital/ATGMediaBrowser"
-    },
-    {
-      "title":"FacebookImagePicker",
-      "category":"images",
-      "description":"Facebook album photo picker.",
-      "homepage":"https://github.com/floriangbh/FacebookImagePicker"
-    },
-    {
-      "title":"FaceCrop",
-      "category":"images",
-      "description":"Detect and center faces in your images using Apple’s Vision Framework.",
-      "homepage":"https://github.com/Ancestry/FaceCrop"
-    },
-    {
-      "title":"FMPhotoPicker",
-      "category":"images",
-      "description":"A modern, simple and zero-dependency photo picker with an elegant and customizable image editor.",
-      "homepage":"https://github.com/congnd/FMPhotoPicker"
-    },
-    {
-      "title":"gifu",
-      "category":"images",
-      "description":"Highly performant animated GIF support for iOS.",
-      "homepage":"https://github.com/kaishin/gifu"
-    },
-    {
-      "title":"GPUImage 2",
-      "category":"images",
-      "description":"GPUImage 2 is a BSD-licensed framework for GPU-accelerated video and image processing.",
-      "homepage":"https://github.com/BradLarson/GPUImage2"
-    },
-    {
-      "title":"GPUImage 3",
-      "category":"images",
-      "description":"GPUImage 3 is a BSD-licensed framework for GPU-accelerated video and image processing using Metal.",
-      "homepage":"https://github.com/BradLarson/GPUImage3"
-    },
-    {
-      "title":"Harbeth",
-      "category":"images",
-      "description":"Metal API for GPU accelerated Graphics and Video and Camera filter framework.",
-      "homepage":"https://github.com/yangKJ/Harbeth"
-    },
-    {
-      "title":"HanekeSwift",
-      "category":"images",
-      "description":"A lightweight generic cache for iOS with extra love for images.",
-      "homepage":"https://github.com/Haneke/HanekeSwift"
-    },
-    {
-      "title":"ImageLoader",
-      "category":"images",
-      "description":"A lightweight and fast image loader for iOS.",
-      "homepage":"https://github.com/hirohisa/ImageLoaderSwift"
-    },
-    {
-      "title":"ImageScout",
-      "category":"images",
-      "description":"Implementation of [fastimage](https://pypi.org/project/fastimage/0.2.1/) - supports PNG, GIF, and JPEG.",
-      "homepage":"https://github.com/kaishin/ImageScout"
-    },
-    {
-      "title":"ImgixSwift",
-      "category":"images",
-      "description":"Easily update image urls to be fast and responsive.",
-      "homepage":"https://github.com/imgix/imgix-swift"
-    },
-    {
-      "title":"JLStickerTextView",
-      "category":"images",
-      "description":"A UIImageView allow you to add multiple Label (multiple line text support) on it, you can edit, rotate, resize the Label as you want with one finger ,then render the text on Image.",
-      "homepage":"https://github.com/Textcat/JLStickerTextView"
-    },
-    {
-      "title":"SwiftWebImage",
-      "category":"images",
-      "description":"🚀SwiftUI Image downloader with performant LRU mem/disk cache.",
-      "homepage":"https://github.com/HotWordland/SwiftWebImage"
-    },
-    {
-      "title":"Kingfisher",
-      "category":"images",
-      "description":"Image download and caching.",
-      "homepage":"https://github.com/onevcat/Kingfisher"
-    },
-    {
-      "title":"Lightbox",
-      "category":"images",
-      "description":"A convenient and easy to use image viewer for your iOS app.",
-      "homepage":"https://github.com/hyperoslo/Lightbox"
-    },
-    {
-      "title":"MapleBacon",
-      "category":"images",
-      "description":"Image download and caching library.",
-      "homepage":"https://github.com/JanGorman/MapleBacon"
-    },
-    {
-      "title":"Moa",
-      "category":"images",
-      "description":"An image download extension of the image view for iOS, tvOS and macOS.",
-      "homepage":"https://github.com/evgenyneu/moa"
-    },
-    {
-      "title":"Nuke",
-      "category":"images",
-      "description":"Advanced framework for loading, caching, processing, displaying and preheating images.",
-      "homepage":"https://github.com/kean/Nuke"
-    },
-    {
-      "title":"PassportScanner",
-      "category":"images",
-      "description":"Scan the MRZ code of a passport and extract the first name, last name, passport number, nationality, date of birth, expiration date and personal number.",
-      "homepage":"https://github.com/evermeer/PassportScanner"
-    },
-    {
-      "title":"SkyFloatingLabelTextField",
-      "category":"textfield",
-      "description":"A beautiful and flexible text field control implementation of \"Float Label Pattern\".",
-      "homepage":"https://github.com/Skyscanner/SkyFloatingLabelTextField"
-    },
-    {
-      "title":"FloatingLabelTextFieldSwiftUI",
-      "category":"textfield",
-      "description":"FloatingLabelTextFieldSwiftUI is a small and lightweight SwiftUI framework written in completely SwiftUI (not using UIViewRepresentable) that allows to create beautiful and customisable floating label textfield!",
-      "tags":[
-        "floatinglabeltextfield",
-        "swiftui",
-        "textfield",
-        "floatinglabeltextfieldswiftui"
-      ],
-      "homepage":"https://github.com/kishanraja/FloatingLabelTextFieldSwiftUI"
-    },
-    {
-      "title":"SwiftGen-Assets",
-      "category":"images",
-      "description":"A tool to auto-generate `enums` for all your `UIImages` from your Assets Catalogs.",
-      "homepage":"https://github.com/SwiftGen/SwiftGen#assets-catalogs"
-    },
-    {
-      "title":"SwiftSVG",
-      "category":"images",
-      "description":"A single pass SVG parser with multiple interface options (String, NS/UIBezierPath, CAShapeLayer, and NS/UIView).",
-      "homepage":"https://github.com/mchoe/SwiftSVG"
-    },
-    {
-      "title":"SwiftyGif",
-      "category":"images",
-      "description":"High performance GIF engine.",
-      "homepage":"https://github.com/alexiscreuzot/SwiftyGif"
-    },
-    {
-      "title":"Toucan",
-      "category":"images",
-      "description":"Image processing api.",
-      "homepage":"https://github.com/gavinbunney/Toucan"
-    },
-    {
-      "title":"UIImageColors",
-      "category":"images",
-      "description":"iTunes style color fetcher for UIImage.",
-      "homepage":"https://github.com/jathu/UIImageColors"
-    },
-    {
-      "title":"FlexibleImage",
-      "category":"images",
-      "description":"A simple way to play with images.",
-      "homepage":"https://github.com/kawoou/FlexibleImage"
-    },
-    {
-      "title":"Snowflake",
-      "category":"images",
-      "description":"Work with SVG.",
-      "homepage":"https://github.com/onmyway133/Snowflake"
-    },
-    {
-      "title":"TinyCrayon",
-      "category":"images",
-      "description":"A smart and easy-to-use image masking and cutout SDK for mobile apps.",
-      "homepage":"https://github.com/TinyCrayon/TinyCrayon-iOS-SDK"
-    },
-    {
-      "title":"ZImageCropper",
-      "category":"images",
-      "description":"Crop image in any shape.",
-      "homepage":"https://github.com/ZaidPathan/ZImageCropper"
-    },
-    {
-      "title":"LetterAvatarKit",
-      "category":"images",
-      "description":"A UIImage extension that generates letter-based avatars.",
-      "homepage":"https://github.com/vpeschenkov/LetterAvatarKit"
-    },
-    {
-      "title":"DTPhotoViewerController",
-      "category":"images",
-      "description":"A fully customizable photo viewer ViewController to display single photo or collection of photos, inspired by Facebook photo viewer.",
-      "homepage":"https://github.com/tungvoduc/DTPhotoViewerController"
-    },
-    {
-      "title":"C4iOS",
-      "category":"kit",
-      "description":"Harnesses the power of native iOS programming with a simplified API.",
-      "homepage":"https://github.com/C4Labs/C4iOS"
-    },
-    {
-      "title":"BFKit-Swift",
-      "category":"kit",
-      "description":"A collection of useful classes, structs and extensions to develop Apps faster.",
-      "homepage":"https://github.com/FabrizioBrancati/BFKit-Swift",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"ContactsChangeNotifier",
-      "category":"kit",
-      "description":"Which contacts changed outside your app? Better CNContactStoreDidChange notification: Get real changes, without the noise.",
-      "homepage":"https://github.com/yonat/ContactsChangeNotifier"
-    },
-    {
-      "title":"EasySwiftLayout",
-      "category":"auto-layout",
-      "description":"Lightweight Swift framework for Apple's Auto-Layout.",
-      "homepage":"https://github.com/Pimine/EasySwiftLayout"
-    },
-    {
-      "title":"KVConstraintKit",
-      "category":"auto-layout",
-      "description":"An Impressive Autolayout DSL for iOS, tvOS & OSX.",
-      "homepage":"https://github.com/keshavvishwkarma/KVConstraintKit"
-    },
-    {
-      "title":"Neon",
-      "category":"layout",
-      "description":"A powerful programmatic UI layout framework.",
-      "homepage":"https://github.com/mamaral/Neon"
-    },
-    {
-      "title":"Static",
-      "category":"layout",
-      "description":"A simple static table views for iOS.",
-      "homepage":"https://github.com/venmo/Static"
-    },
-    {
-      "title":"FlexLayout",
-      "category":"layout",
-      "description":"Nice and clean interface to the highly optimized Facebook yoga Flexbox implementation.",
-      "homepage":"https://github.com/layoutBox/FlexLayout"
-    },
-    {
-      "title":"FrameLayoutKit",
-      "category":"layout",
-      "description":"This framework supports complex layouts, including chaining and nesting layout with simple and intuitive operand & DSL syntax.",
-      "homepage":"https://github.com/kennic/FrameLayoutKit"
-    },
-    {
-      "title":"PinLayout",
-      "category":"layout",
-      "description":"Fast Views layouting without auto layout. No magic, pure code, full control and blazing fast. Concise syntax, intuitive, readable & chainable. [iOS/macOS/tvOS]",
-      "homepage":"https://github.com/layoutBox/PinLayout"
-    },
-    {
-      "title":"Stevia",
-      "category":"layout",
-      "description":"Elegant view layout for iOS.",
-      "homepage":"https://github.com/freshOS/Stevia"
-    },
-    {
-      "title":"Cartography",
-      "category":"auto-layout",
-      "description":"Declarative auto layout lib for your project.",
-      "homepage":"https://github.com/robb/Cartography"
-    },
-    {
-      "title":"DeviceLayout",
-      "category":"auto-layout",
-      "description":"AutoLayout can be set differently for each device.",
-      "homepage":"https://github.com/cruisediary/DeviceLayout"
-    },
-    {
-      "title":"EasyPeasy",
-      "category":"auto-layout",
-      "description":"Auto Layout made easy.",
-      "homepage":"https://github.com/nakiostudio/EasyPeasy"
-    },
-    {
-      "title":"FixFlex",
-      "category":"auto-layout",
-      "description":"Declarative autolayout based on NSLayoutAnchor, swifty reimagination of VFL, alternative to UIStackView.",
-      "homepage":"https://github.com/psharanda/FixFlex"
-    },
-    {
-      "title":"MisterFusion",
-      "category":"auto-layout",
-      "description":"DSL for AutoLayout, supports Size Class.",
-      "homepage":"https://github.com/marty-suzuki/MisterFusion"
-    },
-    {
-      "title":"Mortar",
-      "category":"auto-layout",
-      "description":"A concise but flexible DSL for creating Auto Layout constraints and adding subviews.",
-      "homepage":"https://github.com/jmfieldman/Mortar"
-    },
-    {
-      "title":"NorthLayout",
-      "category":"auto-layout",
-      "description":"Fast path to layout using Visual Format Language (VFL) with extended syntax.",
-      "homepage":"https://github.com/banjun/NorthLayout"
-    },
-    {
-      "title":"PureLayout",
-      "category":"auto-layout",
-      "description":"The ultimate API for iOS & OS X Auto Layout.",
-      "homepage":"https://github.com/PureLayout/PureLayout"
-    },
-    {
-      "title":"SnapKit",
-      "category":"auto-layout",
-      "description":"Autolayout DSL for iOS & OS X.",
-      "homepage":"https://github.com/SnapKit/SnapKit"
-    },
-    {
-      "title":"Swiftstraints",
-      "category":"auto-layout",
-      "description":"Powerful auto-layout framework that lets you write constraints in one line of code.",
-      "homepage":"https://github.com/Skyvive/Swiftstraints"
-    },
-    {
-      "title":"TinyConstraints",
-      "category":"auto-layout",
-      "description":"TinyConstraints is the syntactic sugar that makes Auto Layout sweeter for human use.",
-      "homepage":"https://github.com/roberthein/TinyConstraints"
-    },
-    {
-      "title":"Cupcake",
-      "category":"auto-layout",
-      "description":"An easy way to create and layout UI components for iOS.",
-      "homepage":"https://github.com/nerdycat/Cupcake"
-    },
-    {
-      "title":"Transition",
-      "category":"transition",
-      "description":"Easy interactive interruptible custom ViewController transitions.",
-      "homepage":"https://github.com/Touchwonders/Transition"
-    },
-    {
-      "title":"BartyCrouch",
-      "category":"localization",
-      "description":"Incrementally update/translate your Strings files from Code and Storyboards/XIBs.",
-      "homepage":"https://github.com/FlineDev/BartyCrouch"
-    },
-    {
-      "title":"Localize-Swift",
-      "category":"localization",
-      "description":"Localize apps using e.g. regular expressions in Localizable.strings.",
-      "homepage":"https://github.com/marmelroy/Localize-Swift"
-    },
-    {
-      "title":"Locheck",
-      "category":"localization",
-      "description":"Validate .strings and .stringsdict files for errors",
-      "homepage":"https://github.com/Asana/locheck"
-    },
-    {
-      "title":"StringSwitch",
-      "category":"localization",
-      "description":"Easily convert iOS .strings files to Android strings.xml format and vice versa.",
-      "homepage":"https://stringswitch.com"
-    },
-    {
-      "title":"SwiftGen-L10n",
-      "category":"localization",
-      "description":"A tool to auto-generate `enums` for all your Localizable.strings keys (with appropriate associated values if those strings contains printf-format placeholders like `%@`).",
-      "homepage":"https://github.com/SwiftGen/SwiftGen#localizablestrings"
-    },
-    {
-      "title":"AEConsole",
-      "category":"logging",
-      "description":"Customizable Console UI overlay with debug log on top of your iOS App.",
-      "homepage":"https://github.com/tadija/AEConsole"
-    },
-    {
-      "title":"CleanroomLogger",
-      "category":"logging",
-      "description":"Configurable and extensible high-level logging API that is simple, lightweight and performant.",
-      "homepage":"https://github.com/emaloney/CleanroomLogger"
-    },
-    {
-      "title":"Duration",
-      "category":"logging",
-      "description":"Lightweight logging library focused on reporting timings for operations.",
-      "homepage":"https://github.com/SwiftStudies/Duration",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"HeliumLogger",
-      "category":"logging",
-      "description":"IBM's lightweight logging framework.",
-      "homepage":"https://github.com/Kitura/HeliumLogger",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"QorumLogs",
-      "category":"logging",
-      "description":"Logging Utility for Xcode & Google Docs.",
-      "homepage":"https://github.com/Esqarrouth/QorumLogs"
-    },
-    {
-      "title":"Rainbow",
-      "category":"logging",
-      "description":"Delightful console output.",
-      "homepage":"https://github.com/onevcat/Rainbow",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"SwiftyBeaver",
-      "category":"logging",
-      "description":"Multi-platform logging during development & release.",
-      "homepage":"https://github.com/SwiftyBeaver/SwiftyBeaver",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"TinyConsole",
-      "category":"logging",
-      "description":"A tiny log console to display information while using your iOS app.",
-      "homepage":"https://github.com/Cosmo/TinyConsole"
-    },
-    {
-      "title":"Watchdog",
-      "category":"logging",
-      "description":"Utility for logging excessive blocking on the main thread.",
-      "homepage":"https://github.com/wojteklu/Watchdog"
-    },
-    {
-      "title":"WatchdogInspector",
-      "category":"logging",
-      "description":"A logging tool to show the current framerate (fps) in the status bar of your iOS app.",
-      "homepage":"https://github.com/tapwork/WatchdogInspector"
-    },
-    {
-      "title":"Willow",
-      "category":"logging",
-      "description":"Willow is a powerful, yet lightweight logging library.",
-      "homepage":"https://github.com/Nike-Inc/Willow"
-    },
-    {
-      "title":"XCGLogger",
-      "category":"logging",
-      "description":"Full featured & Configurable logging utility with log levels, timestamps, and line numbers.",
-      "homepage":"https://github.com/DaveWoodCom/XCGLogger"
-    },
-    {
-      "title":"Gedatsu",
-      "category":"logging",
-      "description":"Provide readable format about AutoLayout error console log.",
-      "homepage":"https://github.com/bannzai/gedatsu"
-    },
-    {
-      "title":"Printer",
-      "category":"logging",
-      "description":"A fancy logger for your next app.",
-      "homepage":"https://github.com/hemangshah/printer"
-    },
-    {
-      "title":"GEOSwift",
-      "category":"maps",
-      "description":"Make it easier to work with geographic models and calculate intersections, overlapping, projections etc.",
-      "homepage":"https://github.com/GEOSwift/GEOSwift"
-    },
-    {
-      "title":"FlyoverKit",
-      "category":"maps",
-      "description":"FlyoverKit enables you to present stunning 360° flyover views on your MKMapView with zero effort while maintaining full configuration possibilities.",
-      "homepage":"https://github.com/SvenTiigi/FlyoverKit"
-    },
-    {
-      "title":"STLocationRequest",
-      "category":"location",
-      "description":"An elegant and simple 3D Flyover Location Request Screen.",
-      "homepage":"https://github.com/SvenTiigi/STLocationRequest"
-    },
-    {
-      "title":"AsyncLocationKit",
-      "category":"location",
-      "description":"Wrapper for Apple CoreLocation framework with Modern Concurrency Swift (async/await).",
-      "homepage":"https://github.com/AsyncSwift/AsyncLocationKit"
-    },
-    {
-      "title":"Arithmosophi",
-      "category":"math",
-      "description":"Set of protocols for Arithmetic and Logical operations.",
-      "homepage":"https://github.com/phimage/Arithmosophi"
-    },
-    {
-      "title":"DDMathParser",
-      "category":"math",
-      "description":"DDMathParser makes it easy to parse a String and evaluate it as a mathematical expression.",
-      "homepage":"https://github.com/davedelong/DDMathParser"
-    },
-    {
-      "title":"SigmaSwiftStatistics",
-      "category":"math",
-      "description":"A collection of functions for statistical calculation.",
-      "homepage":"https://github.com/evgenyneu/SigmaSwiftStatistics"
-    },
-    {
-      "title":"Upsurge",
-      "category":"math",
-      "description":"Simple and fast matrix and vector math.",
-      "homepage":"https://github.com/alejandro-isaza/Upsurge"
-    },
-    {
-      "title":"Alamofire",
-      "category":"network",
-      "description":"Elegant networking.",
-      "homepage":"https://github.com/Alamofire/Alamofire",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"APIKit",
-      "category":"network",
-      "description":"Library for building type-safe web API client.",
-      "homepage":"https://github.com/ishkawa/APIKit"
-    },
-    {
-      "title":"Conduit",
-      "category":"network",
-      "description":"Robust networking for web APIs.",
-      "homepage":"https://github.com/mindbody/Conduit"
-    },
-    {
-      "title":"CodyFire",
-      "category":"network",
-      "description":"Powerful Codable API requests builder and manager for iOS. Based on Alamofire.",
-      "homepage":"https://github.com/CodyFlame/CodyFire"
-    },
-    {
-      "title":"Connectivity",
-      "category":"network",
-      "description":"🌐 Makes Internet connectivity detection more robust by detecting Wi-Fi networks without Internet access.",
-      "homepage":"https://github.com/rwbutler/Connectivity",
-      "tags":[
-        "swift",
-        "connectivity",
-        "reachability",
-        "networking",
-        "network",
-        "connection"
-      ],
-      "swift":4.2
-    },
-    {
-      "title":"Heimdallr.swift",
-      "category":"network",
-      "description":"Easy to use OAuth 2 library for iOS.",
-      "homepage":"https://github.com/trivago/Heimdallr.swift"
-    },
-    {
-      "title":"Just",
-      "category":"network",
-      "description":"HTTP for Humans (a python-requests style HTTP library).",
-      "homepage":"https://github.com/dduan/Just",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"Malibu",
-      "category":"network",
-      "description":"A networking library built on promises.",
-      "homepage":"https://github.com/hyperoslo/Malibu"
-    },
-    {
-      "title":"Moya",
-      "category":"network",
-      "description":"Network abstraction layer.",
-      "homepage":"https://github.com/Moya/Moya"
-    },
-    {
-      "title":"Netfox",
-      "category":"network",
-      "description":"A lightweight, one line setup, network debugging library.",
-      "homepage":"https://github.com/kasketis/netfox"
-    },
-    {
-      "title":"OAuth2",
-      "category":"network",
-      "description":"oauth2 auth lib.",
-      "homepage":"https://github.com/p2/OAuth2"
-    },
-    {
-      "title":"OAuthSwift",
-      "category":"network",
-      "description":"OAuth library for iOS.",
-      "homepage":"https://github.com/OAuthSwift/OAuthSwift"
-    },
-    {
-      "title":"Pitaya",
-      "category":"network",
-      "description":"HTTP / HTTPS networking library just incidentally execute on machines.",
-      "homepage":"https://github.com/johnlui/Pitaya",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"Reachability.swift",
-      "category":"network",
-      "description":"A replacement for Apple's Reachability with closures.",
-      "homepage":"https://github.com/ashleymills/Reachability.swift"
-    },
-    {
-      "title":"ResponseDetective",
-      "category":"network",
-      "description":"A non-intrusive framework for intercepting any outgoing requests and incoming responses between your app and server for debugging purposes.",
-      "homepage":"https://github.com/netguru/ResponseDetective"
-    },
-    {
-      "title":"Siesta",
-      "category":"network",
-      "description":"Elegant abstraction for REST APIs that untangles stateful messes. An alternative to callback- and delegate-based networking.",
-      "homepage":"https://bustoutsolutions.github.io/siesta/"
-    },
-    {
-      "title":"SolarNetwork",
-      "category":"network",
-      "description":"Elegant network abstraction layer.",
-      "homepage":"https://github.com/ThreeGayHub/SolarNetwork"
-    },
-    {
-      "title":"SwiftHTTP",
-      "category":"network",
-      "description":"NSURLSession wrapper.",
-      "homepage":"https://github.com/daltoniam/SwiftHTTP"
-    },
-    {
-      "title":"SwiftyOAuth",
-      "category":"network",
-      "description":"A small OAuth library with a built-in set of providers.",
-      "homepage":"https://github.com/delba/SwiftyOAuth"
-    },
-    {
-      "title":"TRON",
-      "category":"network",
-      "description":"Lightweight network abstraction layer, written on top of Alamofire.",
-      "homepage":"https://github.com/MLSDev/TRON"
-    },
-    {
-      "title":"MultiPeer",
-      "category":"network",
-      "description":"A wrapper for the MultipeerConnectivity framework for automatic offline data transmission between devices.",
-      "homepage":"https://github.com/dingwilson/MultiPeer"
-    },
-    {
-      "title":"PMHTTP",
-      "category":"network",
-      "description":"HTTP framework with a focus on REST and JSON.",
-      "homepage":"https://github.com/postmates/PMHTTP"
-    },
-    {
-      "title":"Fuzi",
-      "category":"html",
-      "description":"A fast & lightweight XML/HTML parser with XPath & CSS support.",
-      "homepage":"https://github.com/cezheng/Fuzi"
-    },
-    {
-      "title":"Kanna",
-      "category":"html",
-      "description":"Another XML/HTML parser.",
-      "homepage":"https://github.com/tid-kijyun/Kanna"
-    },
-    {
-      "title":"WKZombie",
-      "category":"html",
-      "description":"Headless browser.",
-      "homepage":"https://github.com/mkoehnke/WKZombie"
-    },
-    {
-      "title":"ZMarkupParser",
-      "category":"html",
-      "description":"Helps you convert HTML strings into NSAttributedString with customized styles and tags.",
-      "homepage":"https://github.com/ZhgChgLi/ZMarkupParser"
-    },
-    {
-      "title":"CocoaMQTT",
-      "category":"messaging-protocol",
-      "description":"MQTT for iOS and OS X.",
-      "homepage":"https://github.com/emqx/CocoaMQTT"
-    },
-    {
-      "title":"Perfect-Notifications",
-      "category":"messaging-protocol",
-      "description":"iOS Notifications for Linux and OS X.",
-      "homepage":"https://github.com/PerfectlySoft/Perfect-Notifications"
-    },
-    {
-      "title":"BlueSocket",
-      "category":"socket",
-      "description":"IBM's cross platform low level socket framework.",
-      "homepage":"https://github.com/Kitura/BlueSocket "
-    },
-    {
-      "title":"BlueSSLService",
-      "category":"socket",
-      "description":"SSL/TLS add-in for IBM's low level socket framework.",
-      "homepage":"https://github.com/Kitura/BlueSSLService"
-    },
-    {
-      "title":"Socket.IO",
-      "category":"socket",
-      "description":"Socket.IO client for iOS/OS X.",
-      "homepage":"https://github.com/socketio/socket.io-client-swift",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"sockets",
-      "category":"socket",
-      "description":"TCP, UDP; Client, Server; Linux, OS X.",
-      "homepage":"https://github.com/vapor-community/sockets",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"Starscream",
-      "category":"socket",
-      "description":"Websockets for iOS and OSX.",
-      "homepage":"https://github.com/daltoniam/Starscream"
-    },
-    {
-      "title":"SwiftSocket",
-      "category":"socket",
-      "description":"Simple TCP socket library.",
-      "homepage":"https://github.com/swiftsocket/SwiftSocket"
-    },
-    {
-      "title":"SwiftWebSocket",
-      "category":"socket",
-      "description":"A high performance WebSocket client library .",
-      "homepage":"https://github.com/tidwall/SwiftWebSocket"
-    },
-    {
-      "title":"Ambassador",
-      "category":"webserver",
-      "description":"Super lightweight web framework based on SWSGI.",
-      "homepage":"https://github.com/envoy/Ambassador"
-    },
-    {
-      "title":"Curassow",
-      "category":"webserver",
-      "description":"HTTP server using the pre-fork worker model.",
-      "homepage":"https://github.com/kylef-archive/Curassow",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"Lightning",
-      "category":"webserver",
-      "description":"Multiplatform Single-threaded Non-blocking Web and Networking Framework.",
-      "homepage":"https://github.com/skylab-inc/Lightning",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"Embassy",
-      "category":"webserver",
-      "description":"Super lightweight async HTTP server library.",
-      "homepage":"https://github.com/envoy/Embassy",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"Kitura",
-      "category":"webserver",
-      "description":"IBM's web framework and server for web services.",
-      "homepage":"https://github.com/Kitura/Kitura",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"Noze.io",
-      "category":"webserver",
-      "description":"Evented I/O streams like Node.js.",
-      "homepage":"https://github.com/NozeIO/Noze.io",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"Perfect",
-      "category":"webserver",
-      "description":"Server-side Swift. The Perfect library, application server, connectors and example apps.",
-      "homepage":"https://github.com/PerfectlySoft/Perfect",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"swifter",
-      "category":"webserver",
-      "description":"Http server with routing handler.",
-      "homepage":"https://github.com/httpswift/swifter",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"Vapor",
-      "category":"webserver",
-      "description":"Elegant web framework that works on iOS, OS X, and Ubuntu.",
-      "homepage":"https://github.com/vapor/vapor",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"Zewo",
-      "category":"webserver",
-      "description":"Server-Side Swift.",
-      "homepage":"https://github.com/Zewo/Zewo",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"SwiftOCR",
-      "category":"ocr",
-      "description":"Neural Network based OCR lib.",
-      "homepage":"https://github.com/NMAC427/SwiftOCR"
-    },
-    {
-      "title":"SwiftLint",
-      "category":"quality",
-      "description":"A tool to enforce coding conventions.",
-      "homepage":"https://github.com/realm/SwiftLint"
-    },
-    {
-      "title":"Swimat",
-      "category":"quality",
-      "description":"Xcode plugin to format code.",
-      "homepage":"https://github.com/Jintin/Swimat"
-    },
-    {
-      "title":"Tailor",
-      "category":"quality",
-      "description":"Cross-platform static analyzer that helps you to write cleaner code and avoid bugs.",
-      "homepage":"https://github.com/sleekbyte/tailor",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"IBLinter",
-      "category":"quality",
-      "description":"A linter tool for Interface Builder.",
-      "homepage":"https://github.com/IBDecodable/IBLinter"
-    },
-    {
-      "title":"TouchBridge",
-      "category":"security",
-      "description":"Use your phone's fingerprint to authenticate on any Mac.",
-      "homepage":"https://github.com/HMAKT99/UnTouchID"
-    },
-    {
-      "title":"BlueCryptor",
-      "category":"cryptography",
-      "description":"IBM's Cross Platform Crypto library.",
-      "homepage":"https://github.com/Kitura/BlueCryptor"
-    },
-    {
-      "title":"BlueRSA",
-      "category":"cryptography",
-      "description":"IBM's Cross Platform RSA Crypto library.",
-      "homepage":"https://github.com/Kitura/BlueRSA"
-    },
-    {
-      "title":"CryptoSwift",
-      "category":"cryptography",
-      "description":"Crypto related functions and helpers.",
-      "homepage":"https://github.com/krzyzanowskim/CryptoSwift",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"IDZSwiftCommonCrypto",
-      "category":"cryptography",
-      "description":"A wrapper for Apple's Common Crypto library.",
-      "homepage":"https://github.com/iosdevzone/IDZSwiftCommonCrypto"
-    },
-    {
-      "title":"SCrypto",
-      "category":"cryptography",
-      "description":"Elegant interface to access the CommonCrypto routines.",
-      "homepage":"https://github.com/sgl0v/scrypto"
-    },
-    {
-      "title":"Siphash",
-      "category":"cryptography",
-      "description":"Simple and secure hashing with the SipHash algorithm.",
-      "homepage":"https://github.com/attaswift/SipHash"
-    },
-    {
-      "title":"Swift-Sodium",
-      "category":"cryptography",
-      "description":"Interface to the Sodium library for common crypto operations for iOS and OS X.",
-      "homepage":"https://github.com/jedisct1/swift-sodium"
-    },
-    {
-      "title":"RNCryptor",
-      "category":"cryptography",
-      "description":"CCCryptor (Apple's AES encryption) wrappers for iOS and Mac.",
-      "homepage":"https://github.com/RNCryptor/RNCryptor"
-    },
-    {
-      "title":"Themis",
-      "category":"cryptography",
-      "description":"Multilanguage framework for making typical encryption schemes easy to use: data at rest, authenticated data exchange, transport protection, authentication, and so on.",
-      "homepage":"https://github.com/cossacklabs/themis"
-    },
-    {
-      "title":"JOSESwift",
-      "category":"cryptography",
-      "description":"A framework for the JOSE standards JWS, JWE, and JWK.",
-      "homepage":"https://github.com/airsidemobile/JOSESwift"
-    },
-    {
-      "title":"keychain-swift",
-      "category":"keychain",
-      "description":"Helper functions for saving text in Keychain securely for iOS, OS X, tvOS and watchOS.",
-      "homepage":"https://github.com/evgenyneu/keychain-swift"
-    },
-    {
-      "title":"KeychainAccess",
-      "category":"keychain",
-      "description":"Simple wrapper for Keychain that works on iOS and OS X.",
-      "homepage":"https://github.com/kishikawakatsumi/KeychainAccess"
-    },
-    {
-      "title":"Latch",
-      "category":"keychain",
-      "description":"A simple Keychain Wrapper for iOS.",
-      "homepage":"https://github.com/endocrimes/Latch"
-    },
-    {
-      "title":"SwiftKeychainWrapper",
-      "category":"keychain",
-      "description":"Simple static wrapper for the iOS Keychain to allow you to use it in a similar fashion to user defaults.",
-      "homepage":"https://github.com/jrendel/SwiftKeychainWrapper"
-    },
-    {
-      "title":"Valet",
-      "category":"keychain",
-      "description":"Valet lets you securely store data in the Keychain without knowing a thing about how the Keychain works. It’s easy. We promise.",
-      "homepage":"https://github.com/square/Valet"
-    },
-    {
-      "title":"BlueSignals",
-      "category":"system",
-      "description":"IBM's Cross Platform OS signal handling library.",
-      "homepage":"https://github.com/Kitura/BlueSignals"
-    },
-    {
-      "title":"SystemKit",
-      "category":"system",
-      "description":"OS X system library.",
-      "homepage":"https://github.com/beltex/SystemKit/"
-    },
-    {
-      "title":"Cuckoo",
-      "category":"mock",
-      "description":"First boilerplate-free mocking framework.",
-      "homepage":"https://github.com/Brightify/Cuckoo"
-    },
-    {
-      "title":"DVR",
-      "category":"testing",
-      "description":"A simple network testing framework.",
-      "homepage":"https://github.com/venmo/DVR"
-    },
-    {
-      "title":"Erik",
-      "category":"testing",
-      "description":"An headless browser to access and manipulate webpages using javascript allowing to run functional tests.",
-      "homepage":"https://github.com/phimage/Erik"
-    },
-    {
-      "title":"Fakery",
-      "category":"testing",
-      "description":"Fake data generator.",
-      "homepage":"https://github.com/vadymmarkov/Fakery"
-    },
-    {
-      "title":"Mockingjay",
-      "category":"mock",
-      "description":"An elegant library for stubbing HTTP requests with ease.",
-      "homepage":"https://github.com/kylef/Mockingjay"
-    },
-    {
-      "title":"Mockit",
-      "category":"mock",
-      "description":"A simple mocking framework, inspired by the famous Mockito for Java.",
-      "homepage":"https://github.com/sabirvirtuoso/Mockit"
-    },
-    {
-      "title":"Mussel",
-      "category":"testing",
-      "description":"A framework for easily testing Push Notifications, Universal Links and Routing in XCUITests.",
-      "homepage":"https://github.com/UrbanCompass/Mussel"
-    },
-    {
-      "title":"OHHTTPStubs",
-      "category":"testing",
-      "description":"A testing library designed to stub your network requests easily.",
-      "homepage":"https://github.com/AliSoftware/OHHTTPStubs"
-    },
-    {
-      "title":"SBTUITestTunnel",
-      "category":"testing",
-      "description":"UI testing library for interact with network requests, stub CLLocationManager and UNUserNotificationCenter, and fine grain scrolling in table/collection/scroll views",
-      "homepage":"https://github.com/Subito-it/SBTUITestTunnel"
-    },
-    {
-      "title":"Quick",
-      "category":"testing",
-      "description":"Quick is a behavior-driven development framework.",
-      "homepage":"https://github.com/Quick/Quick",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"SnapshotTest",
-      "category":"testing",
-      "description":"Snapshot testing tool for iOS and tvOS.",
-      "homepage":"https://github.com/parski/SnapshotTest",
-      "tags":[
-        "iOS",
-        "tvOS"
-      ]
-    },
-    {
-      "title":"Spectre",
-      "category":"testing",
-      "description":"BDD Framework.",
-      "homepage":"https://github.com/kylef/Spectre",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"SwiftCheck",
-      "category":"testing",
-      "description":"A testing library that automatically generates random data for testing program properties.",
-      "homepage":"https://github.com/typelift/SwiftCheck"
-    },
-    {
-      "title":"UI Testing Cheat Sheet",
-      "category":"testing",
-      "description":"Answers to common \"How do I test this with UI Testing?\" questions with a working example app.",
-      "homepage":"https://github.com/joemasilotti/UI-Testing-Cheat-Sheet"
-    },
-    {
-      "title":"Nimble",
-      "category":"testing",
-      "description":"A matcher framework.",
-      "homepage":"https://github.com/Quick/Nimble"
-    },
-    {
-      "title":"Sizes",
-      "category":"testing",
-      "description":"Test your app on different device and font sizes.",
-      "homepage":"https://github.com/marcosgriselli/Sizes"
-    },
-    {
-      "title":"swift-testing-expectation",
-      "category":"testing",
-      "description":"Create an asynchronous expectation in Swift Testing.",
-      "homepage":"https://github.com/dfed/swift-testing-expectation"
-    },
-    {
-      "title":"AttributedTextView",
-      "category":"text",
-      "description":"Easiest way to create an attributed UITextView with support for multiple links, hashtags and mentions.",
-      "homepage":"https://github.com/evermeer/AttributedTextView"
-    },
-    {
-      "title":"BonMot",
-      "category":"text",
-      "description":"Beautiful, easy attributed strings for iOS.",
-      "homepage":"https://github.com/Rightpoint/BonMot"
-    },
-    {
-      "title":"edhita",
-      "category":"text",
-      "description":"Fully open source text editor for iOS.",
-      "homepage":"https://github.com/tnantoka/edhita"
-    },
-    {
-      "title":"MarkdownDisplayView",
-      "category":"text",
-      "description":"A Markdown rendering component built on TextKit 2, providing smooth performance, rich customization options, and support for streaming AI-driven conversational interactions.",
-      "homepage":"https://github.com/zjc19891106/MarkdownDisplayView"
-    },
-    {
-      "title":"MarkdownKit",
-      "category":"text",
-      "description":"A simple and customizable Markdown Parser.",
-      "homepage":"https://github.com/bmoliveira/MarkdownKit"
-    },
-    {
-      "title":"MarkyMark",
-      "category":"text",
-      "description":"Converts Markdown into native views or attributed strings.",
-      "homepage":"https://github.com/M2Mobi/Marky-Mark"
-    },
-    {
-      "title":"PrediKit",
-      "category":"text",
-      "description":"An NSPredicate DSL for iOS & OS X inspired by SnapKit.",
-      "homepage":"https://github.com/KrakenDev/PrediKit"
-    },
-    {
-      "title":"Regex by crossroadlabs",
-      "category":"text",
-      "description":"Very easy to use Regular Expressions library with rich functionality. Features both operator `=~` and method based APIs. Unit tests covered.",
-      "homepage":"https://github.com/crossroadlabs/Regex",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"Regex by sindresorhus",
-      "category":"text",
-      "description":"Swifty regular expressions, fully tested & documented, and with correct Unicode handling.",
-      "homepage":"https://github.com/sindresorhus/Regex",
-      "tags":[
-        "regex"
-      ]
-    },
-    {
-      "title":"RichEditorView",
-      "category":"text",
-      "description":" RichEditorView is a simple, modular, drop-in UIView subclass for Rich Text Editing.",
-      "homepage":"https://github.com/cjwirth/RichEditorView"
-    },
-    {
-      "title":"SwiftVerbalExpressions",
-      "category":"text",
-      "description":"VerbalExpressions porting.",
-      "homepage":"https://github.com/VerbalExpressions/SwiftVerbalExpressions"
-    },
-    {
-      "title":"TextAttributes",
-      "category":"text",
-      "description":"An easier way to compose attributed strings.",
-      "homepage":"https://github.com/delba/TextAttributes"
-    },
-    {
-      "title":"Attributed",
-      "category":"text",
-      "description":"Modern µframework for attributed strings.",
-      "homepage":"https://github.com/Nirma/Attributed"
-    },
-    {
-      "title":"SwiftRichString",
-      "category":"text",
-      "description":"Elegant & Painless Attributed Strings Management Library.",
-      "homepage":"https://github.com/malcommac/SwiftRichString"
-    },
-    {
-      "title":"Parsey",
-      "category":"text",
-      "description":"Parser combinator framework that supports source location tracking, backtracking prevention, and rich error messages.",
-      "homepage":"https://github.com/rxwei/Parsey"
-    },
-    {
-      "title":"PhoneNumberKit",
-      "category":"phone-numbers",
-      "description":"Framework for parsing, formatting and validating international phone numbers. Inspired by Google's libphonenumber.",
-      "homepage":"https://github.com/marmelroy/PhoneNumberKit"
-    },
-    {
-      "title":"NKVPhonePicker",
-      "category":"phone-numbers",
-      "description":"An UITextField subclass to simplify country code's picking.",
-      "homepage":"https://github.com/NikKovIos/NKVPhonePicker"
-    },
-    {
-      "title":"Async",
-      "category":"thread",
-      "description":"Syntactic sugar for Grand Central Dispatch.",
-      "homepage":"https://github.com/duemunk/Async"
-    },
-    {
-      "title":"AwaitKit",
-      "category":"thread",
-      "description":"The ES7 Async/Await control flow.",
-      "homepage":"https://github.com/yannickl/AwaitKit"
-    },
-    {
-      "title":"GCDTimer",
-      "category":"thread",
-      "description":"A well-tested GCD timer.",
-      "homepage":"https://github.com/hemantasapkota/GCDTimer"
-    },
-    {
-      "title":"Queuer",
-      "category":"concurrency",
-      "description":"A queue manager, built on top of OperationQueue and Dispatch (aka GCD).",
-      "homepage":"https://github.com/FabrizioBrancati/Queuer",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"ActiveLabel",
-      "category":"label",
-      "description":"UILabel drop-in replacement supporting Hashtags (#), Mentions (@) and URLs (http://).",
-      "homepage":"https://github.com/optonaut/ActiveLabel.swift"
-    },
-    {
-      "title":"Adaptive Tab Bar",
-      "category":"tab",
-      "description":"Adaptive tab bar.",
-      "homepage":"https://github.com/Ramotion/adaptive-tab-bar"
-    },
-    {
-      "title":"AECoreDataUI",
-      "category":"ui",
-      "description":"Core Data driven UI.",
-      "homepage":"https://github.com/tadija/AERecord",
-      "swift":4
-    },
-    {
-      "title":"AMScrollingNavbar",
-      "category":"ui",
-      "description":"Scrollable UINavigationBar that follows the scrolling of a UIScrollView.",
-      "homepage":"https://github.com/andreamazz/AMScrollingNavbar",
-      "swift":4
-    },
-    {
-      "title":"Animated Tab Bar",
-      "category":"tab",
-      "description":"RAMAnimatedTabBarController is a module for adding animation to tab bar items.",
-      "homepage":"https://github.com/Ramotion/animated-tab-bar"
-    },
-    {
-      "title":"BreakOutToRefresh",
-      "category":"ui",
-      "description":"A playable pull to refresh view using SpriteKit.",
-      "homepage":"https://github.com/dasdom/BreakOutToRefresh"
-    },
-    {
-      "title":"BWWalkthrough",
-      "category":"walkthrough",
-      "description":"A class to build custom walkthroughs for your iOS App.",
-      "homepage":"https://github.com/ariok/BWWalkthrough"
-    },
-    {
-      "title":"ConcentricOnboarding",
-      "category":"walkthrough",
-      "description":"SwiftUI library for a walkthrough or onboarding flow with tap actions.",
-      "homepage":"https://github.com/exyte/ConcentricOnboarding"
-    },
-    {
-      "title":"Charts",
-      "category":"chart",
-      "description":"Beautiful charts for iOS/tvOS/OSX (port of MPAndroidChart).",
-      "homepage":"https://github.com/ChartsOrg/Charts"
-    },
-    {
-      "title":"FLCharts",
-      "category":"chart",
-      "description":"Easy to use and highly customizable charts library for iOS.",
-      "homepage":"https://github.com/francescoleoni98/FLCharts",
-      "tags":[
-        "iOS",
-        "swift",
-        "Mac Catalyst"
-      ]
-    },
-    {
-      "title":"ChartView",
-      "category":"chart",
-      "description":"Swift package for displaying beautiful charts effortlessly",
-      "homepage":"https://github.com/AppPear/ChartView"
-    },
-    {
-      "title":"CountdownLabel",
-      "category":"label",
-      "description":"Simple countdown UILabel with morphing animation, and some useful function.",
-      "homepage":"https://github.com/suzuki-0000/CountdownLabel"
-    },
-    {
-      "title":"CustomSegue",
-      "category":"ui",
-      "description":"Custom segue for OSX Storyboards with slide and cross fade effects.",
-      "homepage":"https://github.com/phimage/CustomSegue"
-    },
-    {
-      "title":"Drag and Drop UICollectionView",
-      "category":"uicollectionview",
-      "description":"Dragging and Dropping data across multiple UICollectionViews.",
-      "homepage":"https://github.com/mmick66/KDDragAndDropCollectionView"
-    },
-    {
-      "title":"Dodo",
-      "category":"ui",
-      "description":"A message bar for iOS.",
-      "homepage":"https://github.com/evgenyneu/Dodo"
-    },
-    {
-      "title":"EstMusicIndicator",
-      "category":"ui",
-      "description":"Music play indicator like iTunes.",
-      "homepage":"https://github.com/Aufree/ESTMusicIndicator"
-    },
-    {
-      "title":"EZLoadingActivity",
-      "category":"hud",
-      "description":"Lightweight loading activity HUD.",
-      "homepage":"https://github.com/Esqarrouth/EZLoadingActivity"
-    },
-    {
-      "title":"FAQView",
-      "category":"ui",
-      "description":"An easy to use FAQ view for iOS.",
-      "homepage":"https://github.com/mukeshthawani/faqview"
-    },
-    {
-      "title":"Fashion",
-      "category":"ui",
-      "description":"Fashion accessories and beauty tools to share and reuse UI styles.",
-      "homepage":"https://github.com/vadymmarkov/Fashion"
-    },
-    {
-      "title":"FlagKit",
-      "category":"ui",
-      "description":"Beautiful flag icons for usage in apps and on the web.",
-      "homepage":"https://github.com/madebybowtie/FlagKit"
-    },
-    {
-      "title":"FloatRatingView",
-      "category":"ui",
-      "description":"Floating rating system.",
-      "homepage":"https://github.com/glenyi/FloatRatingView"
-    },
-    {
-      "title":"GaugeKit",
-      "category":"ui",
-      "description":"Customizable gauges. Easy reproduce Apple's style gauges.",
-      "homepage":"https://github.com/skywinder/GaugeKit"
-    },
-    {
-      "title":"Gecco",
-      "category":"walkthrough",
-      "description":"Spotlight view for iOS.",
-      "homepage":"https://github.com/xai3/Gecco"
-    },
-    {
-      "title":"GlitchLabel",
-      "category":"label",
-      "description":"Glitching UILabel for iOS.",
-      "homepage":"https://github.com/kciter/GlitchLabel"
-    },
-    {
-      "title":"GMStepper",
-      "category":"ui",
-      "description":"A stepper with a sliding label in the middle.",
-      "homepage":"https://github.com/gmertk/GMStepper"
-    },
-    {
-      "title":"GRMustache",
-      "category":"ui",
-      "description":"Flexible Mustache templates.",
-      "homepage":"https://github.com/groue/GRMustache.swift"
-    },
-    {
-      "title":"HGCircularSlider",
-      "category":"ui",
-      "description":"A custom reusable circular slider control for iOS application.",
-      "homepage":"https://github.com/HamzaGhazouani/HGCircularSlider"
-    },
-    {
-      "title":"HTYTextField",
-      "category":"textfield",
-      "description":"A UITextField with bouncy placeholder.",
-      "homepage":"https://github.com/hanton/HTYTextField"
-    },
-    {
-      "title":"YNSearch",
-      "category":"ui",
-      "description":"Awesome fully customizable search view like Pinterest.",
-      "homepage":"https://github.com/younatics/YNSearch"
-    },
-    {
-      "title":"ActivityIndicatorView",
-      "category":"ui",
-      "description":"A number of preset loading indicators created with SwiftUI.",
-      "homepage":"https://github.com/exyte/ActivityIndicatorView"
-    },
-    {
-      "title":"Instructions",
-      "category":"walkthrough",
-      "description":"A library to create app walkthroughs and guided tours.",
-      "homepage":"https://github.com/ephread/Instructions"
-    },
-    {
-      "title":"IncrementableLabel",
-      "category":"label",
-      "description":"An UILabel subclass to (de)increment numbers in an UILabel.",
-      "homepage":"https://github.com/tbaranes/IncrementableLabel"
-    },
-    {
-      "title":"Toaster",
-      "category":"ui",
-      "description":"Notification toasts.",
-      "homepage":"https://github.com/devxoul/Toaster"
-    },
-    {
-      "title":"Toast-Swift",
-      "category":"alert",
-      "description":"An easy to use library to create iOS 14 and newer style toasts.",
-      "homepage":"https://github.com/BastiaanJansen/Toast-Swift"
-    },
-    {
-      "title":"HorizontalDial",
-      "category":"ui",
-      "description":"A horizontal scroll dial like Instagram.",
-      "homepage":"https://github.com/kciter/HorizontalDial"
-    },
-    {
-      "title":"SelectionDialog",
-      "category":"ui",
-      "description":"Simple selection dialog.",
-      "homepage":"https://github.com/kciter/SelectionDialog"
-    },
-    {
-      "title":"KDEDateLabel",
-      "category":"label",
-      "description":"An UILabel subclass that updates itself to make time ago's format easier.",
-      "homepage":"https://github.com/delannoyk/KDEDateLabel"
-    },
-    {
-      "title":"KMNavigationBarTransition",
-      "category":"ui",
-      "description":"A drop-in universal library helps you to manage the navigation bar styles and makes transition animations smooth between different navigation bar styles while pushing or popping a view controller for all orientations.",
-      "homepage":"https://github.com/MoZhouqi/KMNavigationBarTransition"
-    },
-    {
-      "title":"KMPlaceholderTextView",
-      "category":"ui",
-      "description":"A UITextView subclass that adds support for multiline placeholder.",
-      "homepage":"https://github.com/MoZhouqi/KMPlaceholderTextView"
-    },
-    {
-      "title":"KRProgressHUD",
-      "category":"hud",
-      "description":"A beautiful and customizable progress HUD.",
-      "homepage":"https://github.com/krimpedance/KRProgressHUD"
-    },
-    {
-      "title":"LiquidLoader",
-      "category":"ui",
-      "description":"Spinner loader components with liquid animation.",
-      "homepage":"https://github.com/yoavlt/LiquidLoader"
-    },
-    {
-      "title":"LTMorphingLabel",
-      "category":"label",
-      "description":"Graceful morphing effects for UILabel.",
-      "homepage":"https://github.com/lexrus/LTMorphingLabel"
-    },
-    {
-      "title":"Doric Design System Foundation",
-      "category":"ui",
-      "description":"Protocol oriented, type safe, scalable design system foundation framework for iOS.",
-      "homepage":"https://github.com/jayeshk/Doric"
-    },
-    {
-      "title":"MantleModal",
-      "category":"ui",
-      "description":"A simple modal resource that uses a UIScrollView to allow the user to close the modal by dragging it down.",
-      "homepage":"https://github.com/canalesb93/MantleModal"
-    },
-    {
-      "title":"Material",
-      "category":"ui",
-      "description":"Express your creativity with Material, an animation and graphics framework for Google's Material Design and Apple's Flat UI.",
-      "homepage":"https://github.com/CosmicMind/Material"
-    },
-    {
-      "title":"Material Components for iOS",
-      "category":"ui",
-      "description":"Modular and customizable Material Design UI components.",
-      "homepage":"https://github.com/material-components/material-components-ios"
-    },
-    {
-      "title":"MaterialKit",
-      "category":"ui",
-      "description":"Material design components.",
-      "homepage":"https://github.com/nghialv/MaterialKit"
-    },
-    {
-      "title":"MPParallaxView",
-      "category":"ui",
-      "description":"Apple TV Parallax effect.",
-      "homepage":"https://github.com/DroidsOnRoids/MPParallaxView"
-    },
-    {
-      "title":"Arale",
-      "category":"ui",
-      "description":"A custom stretchable header view for UIScrollView or any its subclasses with UIActivityIndicatorView support for content reloading.",
-      "homepage":"https://github.com/supercomputra/Arale"
-    },
-    {
-      "title":"MXParallaxHeader",
-      "category":"ui",
-      "description":"Simple parallax header for UIScrollView.",
-      "homepage":"https://github.com/maxep/MXParallaxHeader"
-    },
-    {
-      "title":"HPParallaxHeader",
-      "category":"ui",
-      "description":"Simple parallax header for UIScrollView.",
-      "homepage":"https://github.com/ngochiencse/HPParallaxHeader"
-    },
-    {
-      "title":"MZFormSheetPresentationController",
-      "category":"ui",
-      "description":"Provides an alternative to the native iOS UIModalPresentationFormSheet, adding support for iPhone and additional opportunities to setup controller size and feel form sheet.",
-      "homepage":"https://github.com/m1entus/MZFormSheetPresentationController"
-    },
-    {
-      "title":"NextGrowingTextView",
-      "category":"ui",
-      "description":"The next in the generations of 'growing textviews' optimized for iOS 7 and above.",
-      "homepage":"https://github.com/FluidGroup/NextGrowingTextView"
-    },
-    {
-      "title":"NVActivityIndicatorView",
-      "category":"ui",
-      "description":"Collection of nice loading animations.",
-      "homepage":"https://github.com/ninjaprox/NVActivityIndicatorView"
-    },
-    {
-      "title":"PageController",
-      "category":"pagination",
-      "description":"Infinite paging controller.",
-      "homepage":"https://github.com/hirohisa/PageController"
-    },
-    {
-      "title":"PKHUD",
-      "category":"hud",
-      "description":"Reimplementation of the Apple HUD.",
-      "homepage":"https://github.com/pkluz/PKHUD"
-    },
-    {
-      "title":"TKRadarChart",
-      "category":"chart",
-      "description":"A customizable radar chart.",
-      "homepage":"https://github.com/TBXark/TKRadarChart"
-    },
-    {
-      "title":"PullToDismiss",
-      "category":"ui",
-      "description":"You can dismiss modal viewcontroller by pulling scrollview or navigationbar.",
-      "homepage":"https://github.com/sgr-ksmt/PullToDismiss"
-    },
-    {
-      "title":"Reel search",
-      "category":"ui",
-      "description":"Option list managed as a reel.",
-      "homepage":"https://github.com/Ramotion/reel-search"
-    },
-    {
-      "title":"ScrollableGraphView",
-      "category":"chart",
-      "description":"Adaptive scrollable graph view for iOS to visualise simple discrete datasets.",
-      "homepage":"https://github.com/philackm/ScrollableGraphView"
-    },
-    {
-      "title":"Siren",
-      "category":"version-manager",
-      "description":"Notify users when a new version of your app is available and prompt them to upgrade.",
-      "homepage":"https://github.com/ArtSabintsev/Siren"
-    },
-    {
-      "title":"SKPhotoBrowser",
-      "category":"ui",
-      "description":"Simple PhotoBrowser/Viewer inspired by facebook, twitter photo browsers.",
-      "homepage":"https://github.com/suzuki-0000/SKPhotoBrowser"
-    },
-    {
-      "title":"Spots",
-      "category":"ui",
-      "description":"Spots is a view controller framework that makes your setup and future development blazingly fast.",
-      "homepage":"https://github.com/hyperoslo"
-    },
-    {
-      "title":"StarryStars",
-      "category":"ui",
-      "description":"Display & edit ratings, fully customizable from interface builder.",
-      "homepage":"https://github.com/peterprokop/StarryStars"
-    },
-    {
-      "title":"StatefulViewController",
-      "category":"ui",
-      "description":"Placeholder views based on content, loading, error or empty states.",
-      "homepage":"https://github.com/aschuch/StatefulViewController"
-    },
-    {
-      "title":"SwiftTheme",
-      "category":"styling",
-      "description":"Powerful theme/skin manager for iOS 8+.",
-      "homepage":"https://github.com/wxxsw/SwiftTheme"
-    },
-    {
-      "title":"DropDown",
-      "category":"ui",
-      "description":"A Material Design drop down for iOS.",
-      "homepage":"https://github.com/AssistoLab/DropDown"
-    },
-    {
-      "title":"RxValidator",
-      "category":"validation",
-      "description":"Simple, Extensible, Flexible Validation Checker.",
-      "homepage":"https://github.com/vbmania/RxValidator"
-    },
-    {
-      "title":"SwiftValidator",
-      "category":"validation",
-      "description":"A rule-based validation library.",
-      "homepage":"https://github.com/SwiftValidatorCommunity/SwiftValidator"
-    },
-    {
-      "title":"SwiftCharts",
-      "category":"chart",
-      "description":"Highly customizable charts for iOS.",
-      "homepage":"https://github.com/ivnsch/SwiftCharts"
-    },
-    {
-      "title":"SwiftyWalkthrough",
-      "category":"walkthrough",
-      "description":"The easiest way to create a great walkthrough experience in your apps.",
-      "homepage":"https://github.com/ruipfcosta/SwiftyWalkthrough"
-    },
-    {
-      "title":"Switch",
-      "category":"switch",
-      "description":"A switch control with full Interface Builder support.",
-      "homepage":"https://github.com/T-Pham/Switch"
-    },
-    {
-      "title":"TabPageViewController",
-      "category":"tab",
-      "description":"Paging view controller and scroll tab view.",
-      "homepage":"https://github.com/EndouMari/TabPageViewController"
-    },
-    {
-      "title":"DTPagerController",
-      "category":"tab",
-      "description":"Container view controller to display a set of ViewControllers in a horizontal scroll view.",
-      "homepage":"https://github.com/tungvoduc/DTPagerController"
-    },
-    {
-      "title":"TagCellLayout",
-      "category":"uicollectionview",
-      "description":"UICollectionView layout for Tags with Left, Center & Right alignments.",
-      "homepage":"https://github.com/riteshhgupta/TagCellLayout"
-    },
-    {
-      "title":"TagListView",
-      "category":"ui",
-      "description":"Simple but highly customizable iOS tag list view.",
-      "homepage":"https://github.com/ElaWorkshop/TagListView"
-    },
-    {
-      "title":"TextFieldEffects",
-      "category":"textfield",
-      "description":"Several ready to use effects for UITextFields.",
-      "homepage":"https://github.com/raulriera/TextFieldEffects"
-    },
-    {
-      "title":"Twinkle",
-      "category":"ui",
-      "description":"Easy way to make elements in your iOS app twinkle.",
-      "homepage":"https://github.com/piemonte/Twinkle"
-    },
-    {
-      "title":"Insert3D",
-      "category":"ui-3d",
-      "description":"The fastest 🚀 way to embed a 3D model.",
-      "homepage":"https://github.com/Viktoo/Insert3D"
-    },
-    {
-      "title":"URLEmbeddedView",
-      "category":"ui",
-      "description":"Automatically caches the object that is confirmed the Open Graph Protocol, and displays it as URL embedded card.",
-      "homepage":"https://github.com/marty-suzuki/URLEmbeddedView"
-    },
-    {
-      "title":"UITextField-Navigation",
-      "category":"textfield",
-      "description":"UITextField-Navigation adds next, previous and done buttons to the keyboard for your UITextFields. Highly customizable.",
-      "homepage":"https://github.com/T-Pham/UITextField-Navigation"
-    },
-    {
-      "title":"ALRT",
-      "category":"alert",
-      "description":"An easier constructor for UIAlertController. Present an alert from anywhere.",
-      "homepage":"https://github.com/mshrwtnb/alrt"
-    },
-    {
-      "title":"Alertift",
-      "category":"alert",
-      "description":"Modern, easy UIAlertController wrapper.",
-      "homepage":"https://github.com/sgr-ksmt/Alertift"
-    },
-    {
-      "title":"Zingle",
-      "category":"alert",
-      "description":"An alert will display underneath your UINavigationBar.",
-      "homepage":"https://github.com/hemangshah/Zingle"
-    },
-    {
-      "title":"CDAlertView",
-      "category":"alert",
-      "description":"Highly customizable alert/notification/success/error/alarm popup.",
-      "homepage":"https://github.com/candostdagdeviren/CDAlertView"
-    },
-    {
-      "title":"CFNotify",
-      "category":"alert",
-      "description":"A customizable framework to create draggable alert views.",
-      "homepage":"https://github.com/JT501/SwiftNotify"
-    },
-    {
-      "title":"EZAlertController",
-      "category":"alert",
-      "description":"Easy UIAlertController.",
-      "homepage":"https://github.com/thellimist/EZAlertController"
-    },
-    {
-      "title":"GSMessage",
-      "category":"alert",
-      "description":"A simple style messages/notifications for iOS 7+.",
-      "homepage":"https://github.com/wxxsw/GSMessages"
-    },
-    {
-      "title":"Jelly",
-      "category":"transition",
-      "description":"Jelly provides custom view controller transitions with just a few lines of code.",
-      "homepage":"https://github.com/SebastianBoldt/Jelly"
-    },
-    {
-      "title":"Kamagari",
-      "category":"alert",
-      "description":"Simple UIAlertController builder class.",
-      "homepage":"https://github.com/tasanobu-zz/Kamagari"
-    },
-    {
-      "title":"PMAlertController",
-      "category":"alert",
-      "description":"PMAlertController is a great and customizable substitute to UIAlertController.",
-      "homepage":"https://github.com/pmusolino/PMAlertController"
-    },
-    {
-      "title":"PopupDialog",
-      "category":"alert",
-      "description":"A simple, customizable popup dialog. Replaces UIAlertController alert style.",
-      "homepage":"https://github.com/orderella/PopupDialog"
-    },
-    {
-      "title":"SCLAlertView",
-      "category":"alert",
-      "description":"Animated Alert view.",
-      "homepage":"https://github.com/vikmeup/SCLAlertView-Swift"
-    },
-    {
-      "title":"SweetAlert",
-      "category":"alert",
-      "description":"Alert system.",
-      "homepage":"https://github.com/codestergit/SweetAlert-iOS"
-    },
-    {
-      "title":"SwiftOverlays",
-      "category":"alert",
-      "description":"various popups and notifications.",
-      "homepage":"https://github.com/peterprokop/SwiftOverlays"
-    },
-    {
-      "title":"XLActionController",
-      "category":"alert",
-      "description":"Fully customizable and extensible action sheet controller.",
-      "homepage":"https://github.com/xmartlabs/XLActionController"
-    },
-    {
-      "title":"NFDownloadButton",
-      "category":"button",
-      "description":"Revamped Download Button. It's kinda a reverse engineering of Netflix's app download button.",
-      "homepage":"https://github.com/LeonardoCardoso/NFDownloadButton"
-    },
-    {
-      "title":"DOFavoriteButton",
-      "category":"button",
-      "description":"Cute Animated Button.",
-      "homepage":"https://github.com/okmr-d/DOFavoriteButton"
-    },
-    {
-      "title":"Floaty",
-      "category":"button",
-      "description":"Floating Action Button for iOS.",
-      "homepage":"https://github.com/kciter/Floaty"
-    },
-    {
-      "title":"FloatingButton",
-      "category":"button",
-      "description":"Easily customizable floating button menu created with SwiftUI.",
-      "homepage":"https://github.com/exyte/FloatingButton"
-    },
-    {
-      "title":"LTHRadioButton",
-      "category":"button",
-      "description":"A radio button with a pretty animation.",
-      "homepage":"https://github.com/rolandleth/LTHRadioButton"
-    },
-    {
-      "title":"SwiftShareBubbles",
-      "category":"button",
-      "description":"Animated social share buttons control for iOS.",
-      "homepage":"https://github.com/takecian/SwiftShareBubbles"
-    },
-    {
-      "title":"PMSuperButton",
-      "category":"button",
-      "description":"A powerful UIButton with super powers, customizable from Storyboard.",
-      "homepage":"https://github.com/pmusolino/PMSuperButton"
-    },
-    {
-      "title":"IGStoryButtonKit",
-      "category":"button",
-      "description":"Easy-to-use button with rich animation inspired by instagram stories.",
-      "homepage":"https://github.com/KaoruMuta/IGStoryButtonKit"
-    },
-    {
-      "title":"Eureka",
-      "category":"form",
-      "description":"Elegant iOS form builder.",
-      "homepage":"https://github.com/xmartlabs/Eureka"
-    },
-    {
-      "title":"Former",
-      "category":"form",
-      "description":"A fully customizable library for easy creating UITableView based form.",
-      "homepage":"https://github.com/ra1028/Former"
-    },
-    {
-      "title":"SwiftyFORM",
-      "category":"form",
-      "description":"Forms that can be validated.",
-      "homepage":"https://github.com/neoneye/SwiftyFORM"
-    },
-    {
-      "title":"ObjectForm",
-      "category":"form",
-      "description":"A simple yet powerful library to build form for your class models.",
-      "homepage":"https://github.com/haojianzong/ObjectForm"
-    },
-    {
-      "title":"AKSwiftSlideMenu",
-      "category":"menu",
-      "description":"Slide Menu (Drawer).",
-      "homepage":"https://github.com/ashishkakkad8/AKSwiftSlideMenu"
-    },
-    {
-      "title":"ENSwiftSideMenu",
-      "category":"menu",
-      "description":"Sliding side menu.",
-      "homepage":"https://github.com/evnaz/ENSwiftSideMenu"
-    },
-    {
-      "title":"GuillotineMenu",
-      "category":"menu",
-      "description":"Guillotine style menu.",
-      "homepage":"https://github.com/Yalantis/GuillotineMenu"
-    },
-    {
-      "title":"InteractiveSideMenu",
-      "category":"menu",
-      "description":"Customizable iOS Interactive Side Menu.",
-      "homepage":"https://github.com/handsomecode/InteractiveSideMenu"
-    },
-    {
-      "title":"Pagemenu",
-      "category":"menu",
-      "description":"Pagination enabled view controller.",
-      "homepage":"https://github.com/PageMenu/PageMenu"
-    },
-    {
-      "title":"MenuItemKit",
-      "category":"menu",
-      "description":"`UIMenuItem` with image and block (closure) support.",
-      "homepage":"https://github.com/cxa/MenuItemKit"
-    },
-    {
-      "title":"XLPagerTabStrip",
-      "category":"menu",
-      "description":"Android PagerTabStrip for iOS.",
-      "homepage":"https://github.com/xmartlabs/XLPagerTabStrip"
-    },
-    {
-      "title":"SideMenu",
-      "category":"menu",
-      "description":"Simple side menu control for iOS inspired by Facebook. Right and Left sides. No coding required.",
-      "homepage":"https://github.com/jonkykong/SideMenu"
-    },
-    {
-      "title":"SwipeMenuViewController",
-      "category":"menu",
-      "description":"Swipable tab and menu View and ViewController.",
-      "homepage":"https://github.com/yysskk/SwipeMenuViewController"
-    },
-    {
-      "title":"YNDropDownMenu",
-      "category":"menu",
-      "description":"Adorable iOS drop down menu.",
-      "homepage":"https://github.com/younatics/YNDropDownMenu"
-    },
-    {
-      "title":"HHFloatingView",
-      "category":"menu",
-      "description":"An easy to use and setup floating view for your app.",
-      "homepage":"https://github.com/hemangshah/HHFloatingView"
-    },
-    {
-      "title":"SegmentIO",
-      "category":"menu",
-      "description":"Animated top/bottom segmented menu for iOS.",
-      "homepage":"https://github.com/Yalantis/Segmentio"
-    },
-    {
-      "title":"KWDrawerController",
-      "category":"menu",
-      "description":"Drawer view controller that easy to use.",
-      "homepage":"https://github.com/Kawoou/KWDrawerController"
-    },
-    {
-      "title":"PagingKit",
-      "category":"menu",
-      "description":"PagingKit provides customizable menu UI.",
-      "homepage":"https://github.com/kazuhiro4949/PagingKit"
-    },
-    {
-      "title":"Parchment",
-      "category":"menu",
-      "description":"A paging view controller with a highly customizable menu, built on UICollectionView.",
-      "homepage":"https://github.com/rechsteiner/Parchment",
-      "swift":4
-    },
-    {
-      "title":"PopMenu",
-      "category":"menu",
-      "description":"😎 A cool and customizable popup style action sheet for iOS.",
-      "homepage":"https://github.com/CaliCastle/PopMenu"
-    },
-    {
-      "title":"Caishen",
-      "category":"payment",
-      "description":"A Payment Card UI & Validator for iOS.",
-      "homepage":"https://github.com/prolificinteractive/Caishen"
-    },
-    {
-      "title":"MFCard",
-      "category":"payment",
-      "description":"Easily integrate Credit Card payments in iOS App.",
-      "homepage":"https://github.com/MobileFirstInc/MFCard"
-    },
-    {
-      "title":"Permission",
-      "category":"permissions",
-      "description":"A unified API to ask for permissions on iOS.",
-      "homepage":"https://github.com/delba/Permission"
-    },
-    {
-      "title":"Swift-Prompts",
-      "category":"alert",
-      "description":"Design custom prompts with a great scope of options to choose from.",
-      "homepage":"https://github.com/GabrielAlva/Swift-Prompts"
-    },
-    {
-      "title":"AREK",
-      "category":"permissions",
-      "description":"AREK is a clean and easy to use wrapper over any kind of iOS permission.",
-      "homepage":"https://github.com/ennioma/arek"
-    },
-    {
-      "title":"StackViewController",
-      "category":"stackview",
-      "description":"Simplify the use of UIStackView.",
-      "homepage":"https://github.com/seedco/StackViewController"
-    },
-    {
-      "title":"TZStackView",
-      "category":"stackview",
-      "description":"An iOS9 UIStackView layout component re-implemented for iOS 7 and 8.",
-      "homepage":"https://github.com/tomvanzummeren/TZStackView"
-    },
-    {
-      "title":"BubbleTransition",
-      "category":"transition",
-      "description":"Bubble transition in an easy way.",
-      "homepage":"https://github.com/andreamazz/BubbleTransition"
-    },
-    {
-      "title":"MusicPlayerTransition",
-      "category":"transition",
-      "description":"Custom interactive transition like Apple Music iOS App.",
-      "homepage":"https://github.com/xxxAIRINxxx/MusicPlayerTransition"
-    },
-    {
-      "title":"PinterestSwift",
-      "category":"transition",
-      "description":"Pinterest style transition.",
-      "homepage":"https://github.com/demonnico/PinterestSwift"
-    },
-    {
-      "title":"StarWars.iOS",
-      "category":"transition",
-      "description":"Transition animation to crumble view-controller into tiny pieces.",
-      "homepage":"https://github.com/Yalantis/StarWars.iOS"
-    },
-    {
-      "title":"SectionedSlider",
-      "category":"ui",
-      "description":"Control Center Slider.",
-      "homepage":"https://github.com/LeonardoCardoso/SectionedSlider"
-    },
-    {
-      "title":"Hero",
-      "category":"transition",
-      "description":"Elegant transition library for iOS.",
-      "homepage":"https://github.com/HeroTransitions/Hero"
-    },
-    {
-      "title":"NavigationTransitions",
-      "category":"transition",
-      "description":"Pure SwiftUI Navigation transitions.",
-      "homepage":"https://github.com/davdroman/swiftui-navigation-transitions"
-    },
-    {
-      "title":"ImageTransition",
-      "category":"transition",
-      "description":"ImageTransition is a library for smooth animation of images during transitions.",
-      "homepage":"https://github.com/shtnkgm/ImageTransition"
-    },
-    {
-      "title":"DTTableViewManager",
-      "category":"uitableview",
-      "description":"Protocol-oriented UITableView management, powered by generics and associated types.",
-      "homepage":"https://github.com/DenTelezhkin/DTTableViewManager"
-    },
-    {
-      "title":"folding-cell",
-      "category":"uitableview",
-      "description":"Folding cell transition.",
-      "homepage":"https://github.com/Ramotion/folding-cell"
-    },
-    {
-      "title":"Persei",
-      "category":"uitableview",
-      "description":"Animated top menu for UITableView / UICollectionView / UIScrollView.",
-      "homepage":"https://github.com/Yalantis/Persei"
-    },
-    {
-      "title":"PullToRefreshSwift",
-      "category":"uitableview",
-      "description":"PullToRefresh library.",
-      "homepage":"https://github.com/dekatotoro/PullToRefreshSwift"
-    },
-    {
-      "title":"QuickTableViewController",
-      "category":"uitableview",
-      "description":"A simple way to create a UITableView for settings.",
-      "homepage":"https://github.com/bcylin/QuickTableViewController"
-    },
-    {
-      "title":"Shoyu",
-      "category":"uitableview",
-      "description":"Easier way to represent the structure of UITableView.",
-      "homepage":"https://github.com/xai3/Shoyu"
-    },
-    {
-      "title":"YNExpandableCell",
-      "category":"uitableview",
-      "description":"Awesome expandable, collapsible tableview cell for iOS.",
-      "homepage":"https://github.com/younatics/YNExpandableCell"
-    },
-    {
-      "title":"SwipeCellKit",
-      "category":"uitableview",
-      "description":"Swipeable UITableViewCell based on the stock Mail.app.",
-      "homepage":"https://github.com/SwipeCellKit/SwipeCellKit"
-    },
-    {
-      "title":"ExpandableCell",
-      "category":"uitableview",
-      "description":"Fully refactored YNExapnadableCell with more concise, bug free. Easiest usage of expandable & collapsible cell for iOS. You can customize expandable UITableViewCell whatever you like. ExpandableCell is made because insertRows and deleteRows is hard to use. Just inheirt ExpandableDelegate.",
-      "homepage":"https://github.com/younatics/ExpandableCell"
-    },
-    {
-      "title":"AlexaSkillsKit",
-      "category":"utility",
-      "description":"Develop custom Alexa Skills.",
-      "homepage":"https://github.com/choefele/AlexaSkillsKit"
-    },
-    {
-      "title":"AwesomeCache",
-      "category":"cache",
-      "description":"Manage cache easy.",
-      "homepage":"https://github.com/aschuch/AwesomeCache"
-    },
-    {
-      "title":"Basis",
-      "category":"utility",
-      "description":"Pure Declarative Programming.",
-      "homepage":"https://github.com/typelift/Basis"
-    },
-    {
-      "title":"ChainPageCollectionView",
-      "category":"animation",
-      "description":"Fancy two-level collection view layout and animation.",
-      "homepage":"https://github.com/jindulys/ChainPageCollectionView"
-    },
-    {
-      "title":"Cache",
-      "category":"cache",
-      "description":"Nothing but Cache.",
-      "homepage":"https://github.com/hyperoslo/Cache"
-    },
-    {
-      "title":"CallbackURLKit",
-      "category":"utility",
-      "description":"Implementation of x-callback-url (Inter app communication).",
-      "homepage":"https://github.com/phimage/CallbackURLKit"
-    },
-    {
-      "title":"Carlos",
-      "category":"cache",
-      "description":"A simple but flexible cache.",
-      "homepage":"https://github.com/spring-media/Carlos"
-    },
-    {
-      "title":"RxFlow",
-      "category":"app-routing",
-      "description":"RxFlow is a navigation framework for iOS applications based on a Reactive Flow Coordinator pattern.",
-      "homepage":"https://github.com/RxSwiftCommunity/RxFlow"
-    },
-    {
-      "title":"Curry",
-      "category":"utility",
-      "description":"Function currying.",
-      "homepage":"https://github.com/thoughtbot/Curry"
-    },
-    {
-      "title":"Device.swift",
-      "category":"device",
-      "description":"Super-lightweight library to detect used device.",
-      "homepage":"https://github.com/schickling/Device.swift"
-    },
-    {
-      "title":"Device",
-      "category":"device",
-      "description":"Light weight tool for detecting the current device and screen size.",
-      "homepage":"https://github.com/Ekhoo/Device"
-    },
-    {
-      "title":"Dollar",
-      "category":"utility",
-      "description":"Similar to Lo-Dash or Underscore in Javascript.",
-      "homepage":"https://github.com/ankurp/Dollar"
-    },
-    {
-      "title":"EVURLCache",
-      "category":"cache",
-      "description":"If you want to make your app still works when it's offline.",
-      "homepage":"https://github.com/evermeer/EVURLCache"
-    },
-    {
-      "title":"EZSwiftExtensions",
-      "category":"utility",
-      "description":"How standard types and classes were supposed to work.",
-      "homepage":"https://github.com/Esqarrouth/EZSwiftExtensions"
-    },
-    {
-      "title":"XestiMonitors",
-      "category":"utility",
-      "description":"An extensible monitoring framework.",
-      "homepage":"https://github.com/eBardX/XestiMonitors"
-    },
-    {
-      "title":"FormValidatorSwift",
-      "category":"validation",
-      "description":"Allows you to validate inputs of text fields and text views in a convenient way.",
-      "homepage":"https://github.com/ustwo/formvalidator-swift"
-    },
-    {
-      "title":"ObjectiveKit",
-      "category":"utility",
-      "description":"API for Objective C runtime functions.",
-      "homepage":"https://github.com/marmelroy/ObjectiveKit"
-    },
-    {
-      "title":"OpenSourceController",
-      "category":"utility",
-      "description":"The simplest way to display the librarie's licences used in your application.",
-      "homepage":"https://github.com/floriangbh/OpenSourceController"
-    },
-    {
-      "title":"PDFGenerator",
-      "category":"pdf",
-      "description":"A simple Generator of PDF. Generate PDF from view(s) or image(s).",
-      "homepage":"https://github.com/sgr-ksmt/PDFGenerator"
-    },
-    {
-      "title":"Pluralize.swift",
-      "category":"text",
-      "description":"Great String Pluralize Extension.",
-      "homepage":"https://github.com/joshualat/Pluralize.swift"
-    },
-    {
-      "title":"protobuf-swift",
-      "category":"utility",
-      "description":"ProtocolBuffers.",
-      "homepage":"https://github.com/alexeyxo/protobuf-swift"
-    },
-    {
-      "title":"Prototope",
-      "category":"utility",
-      "description":"Library of lightweight interfaces for prototyping, bridged to JS.",
-      "homepage":"http://khan.github.io/Prototope/"
-    },
-    {
-      "title":"R.swift",
-      "category":"utility",
-      "description":"Tool to get strong typed, autocompleted resources like images, cells and segues.",
-      "homepage":"https://github.com/mac-cain13/R.swift"
-    },
-    {
-      "title":"RandomKit",
-      "category":"utility",
-      "description":"Random data generation.",
-      "homepage":"https://github.com/nvzqz/RandomKit/",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"ResourceKit",
-      "category":"utility",
-      "description":"Enable autocomplete use resources.",
-      "homepage":"https://github.com/bannzai/ResourceKit"
-    },
-    {
-      "title":"Result",
-      "category":"utility",
-      "description":"Type modelling the success/failure of arbitrary operations.",
-      "homepage":"https://github.com/antitypical/Result"
-    },
-    {
-      "title":"Runes",
-      "category":"utility",
-      "description":"Functional operators: flatMap, map, apply.",
-      "homepage":"https://github.com/thoughtbot/Runes"
-    },
-    {
-      "title":"SimplePDF",
-      "category":"pdf",
-      "description":"Create a simple PDF effortlessly.",
-      "homepage":"https://github.com/nRewik/SimplePDF"
-    },
-    {
-      "title":"Solar",
-      "category":"utility",
-      "description":"Calculate sunrise and sunset times given a location.",
-      "homepage":"https://github.com/ceeK/Solar"
-    },
-    {
-      "title":"SpriteKit+Spring",
-      "category":"utility",
-      "description":"SpriteKit API reproducing UIView's spring animations with SKAction.",
-      "homepage":"https://github.com/ataugeron/SpriteKit-Spring"
-    },
-    {
-      "title":"Sugar",
-      "category":"utility",
-      "description":"Something sweet that goes great with your Cocoa.",
-      "homepage":"https://github.com/hyperoslo/Sugar"
-    },
-    {
-      "title":"SwiftGen-Storyboard",
-      "category":"utility",
-      "description":"A tool to auto-generate `enums` for all your Storyboards, Scenes and Segues constants + appropriate convenience accessors.",
-      "homepage":"https://github.com/SwiftGen/SwiftGen#uistoryboard"
-    },
-    {
-      "title":"SwiftLCS",
-      "category":"algorithm",
-      "description":"implementation of the longest common subsequence (LCS) algorithm.",
-      "homepage":"https://github.com/Frugghi/SwiftLCS",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"SwiftRandom",
-      "category":"utility",
-      "description":"A tiny generator of random data.",
-      "homepage":"https://github.com/thellimist/SwiftRandom"
-    },
-    {
-      "title":"SwiftRater",
-      "category":"utility",
-      "description":"A utility that reminds your iPhone app's users to review the app.",
-      "homepage":"https://github.com/takecian/SwiftRater"
-    },
-    {
-      "title":"SwiftRouter",
-      "category":"app-routing",
-      "description":"A URL Router for iOS.",
-      "homepage":"https://github.com/skyline75489/SwiftRouter"
-    },
-    {
-      "title":"SwiftTweaks",
-      "category":"utility",
-      "description":"Tweak your iOS app without recompiling.",
-      "homepage":"https://github.com/bryanjclark/SwiftTweaks"
-    },
-    {
-      "title":"SwiftValidators",
-      "category":"validation",
-      "description":"String validation for iOS (inspired by validator.js).",
-      "homepage":"https://github.com/gkaimakas/SwiftValidators"
-    },
-    {
-      "title":"SwiftVideoBackground",
-      "category":"video",
-      "description":"Easy to Use UIView subclass for implementating a video background.",
-      "homepage":"https://github.com/dingwilson/SwiftVideoBackground"
-    },
-    {
-      "title":"Swiftx",
-      "category":"utility",
-      "description":"Functional data types and functions for any project.",
-      "homepage":"https://github.com/typelift/Swiftx"
-    },
-    {
-      "title":"Swifty360Player",
-      "category":"video",
-      "description":"iOS 360-degree video player streaming from an AVPlayer.",
-      "homepage":"https://github.com/abdullahselek/Swifty360Player",
-      "tags":[
-        "iOS",
-        "AVPlayer",
-        "360 video player"
-      ]
-    },
-    {
-      "title":"SwiftyUtils",
-      "category":"utility",
-      "description":"All the reusable code that we need in each project.",
-      "homepage":"https://github.com/tbaranes/SwiftyUtils"
-    },
-    {
-      "title":"Swiftz",
-      "category":"utility",
-      "description":"Functional programming.",
-      "homepage":"https://github.com/typelift/Swiftz"
-    },
-    {
-      "title": "SyntaxKit",
-      "category": "utility",
-      "description": "Generate Swift code programmatically with a declarative syntax.",
-      "homepage": "https://github.com/brightdigit/SyntaxKit"
-    },
-    {
-      "title":"Then",
-      "category":"utility",
-      "description":"Super sweet syntactic sugar for initializers.",
-      "homepage":"https://github.com/devxoul/Then"
-    },
-    {
-      "title":"UTIKit",
-      "category":"utility",
-      "description":"an UTI (Uniform Type Identifier) wrapper.",
-      "homepage":"https://github.com/cockscomb/UTIKit"
-    },
-    {
-      "title":"Highlighter",
-      "category":"utility",
-      "description":"Highlight whatever you want! Highlighter will magically find UI objects such as UILabel, UITextView, UITexTfield, UIButton in your UITableViewCell or other Class.",
-      "homepage":"https://github.com/younatics/Highlighter"
-    },
-    {
-      "title":"MobilePlayer",
-      "category":"video",
-      "description":"A powerful and completely customizable media player for iOS.",
-      "homepage":"https://github.com/sahin/mobileplayer-ios"
-    },
-    {
-      "title":"Player",
-      "category":"video",
-      "description":"iOS video player, simple drop in component for playing and streaming media.",
-      "homepage":"https://github.com/piemonte/Player"
-    },
-    {
-      "title":"PlayerView",
-      "category":"video",
-      "description":"Easy to use video player using a UIView, manage rate of reproduction, screenshots and callbacks-delegate for player state.",
-      "homepage":"https://github.com/davidlondono/PlayerView"
-    },
-    {
-      "title":"SlideMenuControllerSwift",
-      "category":"menu",
-      "description":"iOS Slide Menu View based on Google+, iQON, Feedly, Ameba iOS app.",
-      "homepage":"https://github.com/dekatotoro/SlideMenuControllerSwift"
-    },
-    {
-      "title":"LeeGo",
-      "category":"ui",
-      "description":"Declarative, configurable & highly reusable UI development as making Lego bricks.",
-      "homepage":"https://github.com/wangshengjia/LeeGo"
-    },
-    {
-      "title":"VisualEffectView",
-      "category":"blur",
-      "description":"UIVisualEffectView subclass with tint color.",
-      "homepage":"https://github.com/efremidze/VisualEffectView"
-    },
-    {
-      "title":"SwiftLinkPreview",
-      "category":"utility",
-      "description":"It makes a preview from an url, grabbing all information such as title, relevant texts and images.",
-      "homepage":"https://github.com/LeonardoCardoso/SwiftLinkPreview"
-    },
-    {
-      "title":"Version",
-      "category":"version-manager",
-      "description":"Version represents and compares semantic versions.",
-      "homepage":"https://github.com/mrackwitz/Version"
-    },
-    {
-      "title":"AppVersionMonitor",
-      "category":"version-manager",
-      "description":"Monitor iOS app version easily.",
-      "homepage":"https://github.com/eure/AppVersionMonitor"
-    },
-    {
-      "title":"Version Tracker Swift",
-      "category":"version-manager",
-      "description":"Versions tracker for your iOS, OS X, and tvOS app.",
-      "homepage":"https://github.com/tbaranes/VersionTrackerSwift"
-    },
-    {
-      "title":"Live",
-      "category":"streaming",
-      "description":"Demonstrate how to build a live broadcast app.",
-      "homepage":"https://github.com/ltebean/Live"
-    },
-    {
-      "title":"Facebook",
-      "category":"SDK",
-      "description":"Facebook SDK for iOS.",
-      "homepage":"https://github.com/facebook/facebook-ios-sdk"
-    },
-    {
-      "title":"DateTimePicker",
-      "category":"calendar",
-      "description":"A nicer iOS UI component for picking date and time.",
-      "homepage":"https://github.com/itsmeichigo/DateTimePicker"
-    },
-    {
-      "title":"JTAppleCalendar",
-      "category":"calendar",
-      "description":"UI calendar handler.",
-      "homepage":"https://github.com/patchthecode/JTAppleCalendar"
-    },
-    {
-      "title":"OBCalendar",
-      "category":"calendar",
-      "description":"OBCalendar is designed for simplicity and customization, it allows you to build beautiful and functional calendar interfaces effortlessly.",
-      "homepage":"https://github.com/oBilet/OBCalendar"
-    },
-    {
-      "title":"WSTagsField",
-      "category":"ui",
-      "description":"An iOS text field that represents different Tags.",
-      "homepage":"https://github.com/whitesmith/WSTagsField"
-    },
-    {
-      "title":"PasswordTextField",
-      "category":"textfield",
-      "description":"A custom TextField with a switchable icon which shows or hides the password and enforces good password policies.",
-      "homepage":"https://github.com/PiXeL16/PasswordTextField"
-    },
-    {
-      "title":"DTTextField",
-      "category":"textfield",
-      "description":"DTTextField is a custom textfield with floating placeholder and error label.",
-      "homepage":"https://github.com/iDhaval/DTTextField"
-    },
-    {
-      "title":"RevealingSplashView",
-      "category":"transition",
-      "description":"A Splash view that animates and reveals its content, inspired by the Twitter splash.",
-      "homepage":"https://github.com/PiXeL16/RevealingSplashView"
-    },
-    {
-      "title":"Postal",
-      "category":"network",
-      "description":"Framework providing simple access to common email providers.",
-      "homepage":"https://github.com/snipsco/Postal"
-    },
-    {
-      "title":"ColorMatchTabs",
-      "category":"tab",
-      "description":"Interesting way to display tabs.",
-      "homepage":"https://github.com/Yalantis/ColorMatchTabs"
-    },
-    {
-      "title":"IBLocalizable",
-      "category":"localization",
-      "description":"Localize your views directly in Interface Builder with IBLocalizable.",
-      "homepage":"https://github.com/PiXeL16/IBLocalizable"
-    },
-    {
-      "title":"TriLabelView",
-      "category":"label",
-      "description":"A triangle shaped corner label view for iOS.",
-      "homepage":"https://github.com/mukeshthawani/TriLabelView"
-    },
-    {
-      "title":"ReadabilityKit",
-      "category":"utility",
-      "description":"Preview extractor for news, articles and full-texts.",
-      "homepage":"https://github.com/exyte/ReadabilityKit"
-    },
-    {
-      "title":"SwiftMessages",
-      "category":"alert",
-      "description":"A very flexible message bar for iOS.",
-      "homepage":"https://github.com/SwiftKickMobile/SwiftMessages"
-    },
-    {
-      "title":"Swift Module Template",
-      "category":"boilerplates",
-      "description":"An opinionated starting point for awesome, reusable modules.",
-      "homepage":"https://github.com/fulldecent/swift6-module-template"
-    },
-    {
-      "title":"Toybox",
-      "category":"misc",
-      "description":"Xcode Playground management made easy.",
-      "homepage":"https://github.com/giginet/Toybox"
-    },
-    {
-      "title":"SwiftChart",
-      "category":"chart",
-      "description":"A simple line and area charting library for iOS. Supports multiple series, partially filled series and touch events.",
-      "homepage":"https://github.com/gpbl/SwiftChart"
-    },
-    {
-      "title":"SwiftyAttributes",
-      "category":"text",
-      "description":"Extensions that make it a breeze to work with attributed strings.",
-      "homepage":"https://github.com/eddiekaiger/SwiftyAttributes"
-    },
-    {
-      "title":"DeviceKit",
-      "category":"device",
-      "description":"DeviceKit is a value-type replacement of UIDevice.",
-      "homepage":"https://github.com/devicekit/DeviceKit"
-    },
-    {
-      "title":"Workaholic",
-      "category":"calendar",
-      "description":"A GitHub-like work contribution timeline.",
-      "homepage":"https://github.com/hemangshah/Workaholic"
-    },
-    {
-      "title":"CalendarKit",
-      "category":"calendar",
-      "description":"Fully customizable calendar day view.",
-      "homepage":"https://github.com/richardtop/CalendarKit"
-    },
-    {
-      "title":"CardParts",
-      "category":"cards",
-      "description":"A reactive, card-based UI framework built on UIKit for iOS developers.",
-      "homepage":"https://github.com/intuit/CardParts"
-    },
-    {
-      "title":"CBORCoding",
-      "category":"cbor",
-      "description":"Easy CBOR encoding and decoding for iOS, macOS, tvOS and watchOS.",
-      "homepage":"https://github.com/SomeRandomiOSDev/CBORCoding",
-      "tags":[
+      "title": "CBORCoding",
+      "category": "cbor",
+      "description": "Easy CBOR encoding and decoding for iOS, macOS, tvOS and watchOS.",
+      "homepage": "https://github.com/SomeRandomiOSDev/CBORCoding",
+      "tags": [
         "ios",
         "macos",
         "tvos",
@@ -4931,300 +1795,92 @@
       ]
     },
     {
-      "title":"CodableCSV",
-      "category":"csv",
-      "description":"Read and write CSV files row-by-row or through Swift's Codable interface.",
-      "homepage":"https://github.com/dehesa/CodableCSV",
-      "tags":[
+      "title": "CBPinEntryView",
+      "category": "textfield",
+      "description": "Easy to use, very customisable pin entry.",
+      "homepage": "https://github.com/Fawxy/CBPinEntryView"
+    },
+    {
+      "title": "CDAlertView",
+      "category": "alert",
+      "description": "Highly customizable alert/notification/success/error/alarm popup.",
+      "homepage": "https://github.com/candostdagdeviren/CDAlertView"
+    },
+    {
+      "title": "Cely",
+      "category": "authentication",
+      "description": "A Plug-n-Play login framework.",
+      "homepage": "https://github.com/cely-tools/Cely"
+    },
+    {
+      "title": "CenteredCollectionView",
+      "category": "uicollectionview",
+      "description": "A lightweight UICollectionViewLayout that pages and centers it's cells.",
+      "homepage": "https://github.com/BenEmdon/CenteredCollectionView"
+    },
+    {
+      "title": "CFNotify",
+      "category": "alert",
+      "description": "A customizable framework to create draggable alert views.",
+      "homepage": "https://github.com/JT501/SwiftNotify"
+    },
+    {
+      "title": "CGLayout",
+      "category": "layout",
+      "description": "Powerful autolayout framework, that can manage UIView(NSView), CALayer, not rendered views and etc. Provides placeholders.",
+      "homepage": "https://github.com/k-o-d-e-n/CGLayout",
+      "tags": [
         "linux"
       ]
     },
     {
-      "title":"CSVParser",
-      "category":"csv",
-      "description":"Fast parser for CSV.",
-      "homepage":"https://github.com/Nero5023/CSVParser",
-      "tags":[
-        "linux"
-      ]
+      "title": "ChainPageCollectionView",
+      "category": "animation",
+      "description": "Fancy two-level collection view layout and animation.",
+      "homepage": "https://github.com/jindulys/ChainPageCollectionView"
     },
     {
-      "title":"Macaw",
-      "category":"ui",
-      "description":"Powerful and easy-to-use vector graphics library with SVG support.",
-      "homepage":"https://github.com/exyte/macaw"
+      "title": "Charts",
+      "category": "chart",
+      "description": "Beautiful charts for iOS/tvOS/OSX (port of MPAndroidChart).",
+      "homepage": "https://github.com/ChartsOrg/Charts"
     },
     {
-      "title":"SwiftlySalesforce",
-      "category":"api",
-      "description":"Framework for rapid development of native iOS apps that integrate with Salesforce.",
-      "homepage":"https://github.com/mike4aday/SwiftlySalesforce"
+      "title": "ChartView",
+      "category": "chart",
+      "description": "Swift package for displaying beautiful charts effortlessly",
+      "homepage": "https://github.com/AppPear/ChartView"
     },
     {
-      "title":"Notepad",
-      "category":"text",
-      "description":"A fully themeable markdown editor with live syntax highlighting.",
-      "homepage":"https://github.com/ruddfawcett/Notepad"
+      "title": "Chatto",
+      "category": "chat",
+      "description": "A lightweight framework to build chat applications.",
+      "homepage": "https://github.com/badoo/Chatto"
     },
     {
-      "title":"Luminous",
-      "category":"device",
-      "description":"Get everything you need to know about the device.",
-      "homepage":"https://github.com/andrealufino/Luminous",
-      "tags":[
-        "device",
-        "system"
-      ]
+      "title": "CheatyXML",
+      "category": "xml",
+      "description": "A powerful framework designed to manage XML easily.",
+      "homepage": "https://github.com/lobodart/CheatyXML"
     },
     {
-      "title":"Yams",
-      "category":"yaml",
-      "description":"Sweet YAML parser.",
-      "homepage":"https://github.com/jpsim/Yams",
-      "tags":[
-        "linux"
-      ]
+      "title": "CheckmarkCollectionViewCell",
+      "category": "uicollectionview",
+      "description": "UICollectionViewCell with checkbox when it isSelected and empty circle when not - like Photos.app 'Select' mode.",
+      "homepage": "https://github.com/yonat/CheckmarkCollectionViewCell"
     },
     {
-      "title":"UXMPDFKit",
-      "category":"pdf",
-      "description":"A PDF viewer and annotator that can be embedded in iOS applications.",
-      "homepage":"https://github.com/uxmstudio/UXMPDFKit"
+      "title": "CHIOTPField",
+      "category": "textfield",
+      "description": "A set of textfields that can be used for One-time passwords, SMS codes, PIN codes, etc.",
+      "homepage": "https://github.com/ChiliLabs/CHIOTPField"
     },
     {
-      "title":"BrickKit",
-      "category":"layout",
-      "description":"Create complex and responsive layouts in a simple way.",
-      "homepage":"https://github.com/wayfair-archive/brickkit-ios"
-    },
-    {
-      "title":"SwifterSwift",
-      "category":"utility",
-      "description":"A handy collection of more than 500 native extensions to boost your productivity.",
-      "homepage":"https://github.com/SwifterSwift/SwifterSwift",
-      "tags":[
-        "extensions",
-        "ios"
-      ]
-    },
-    {
-      "title":"ReerKit",
-      "category":"utility",
-      "description":"Powerful Swift foundation library of extensions and providing utility functions to supercharge your iOS/macOS/Linux development workflow.",
-      "homepage":"https://github.com/reers/ReerKit",
-      "tags":[
-        "swift",
-        "extensions",
-        "iOS",
-        "macOS",
-        "tvOS"
-      ]
-    },
-    {
-      "title":"Progress.swift",
-      "category":"command-line",
-      "description":"Add beautiful progress bars to your command line.",
-      "homepage":"https://github.com/jkandzi/Progress.swift",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"xcprofiler",
-      "category":"benchmark",
-      "description":"Command line utility to profile compilation time.",
-      "homepage":"https://github.com/giginet/xcprofiler"
-    },
-    {
-      "title":"Swiftify",
-      "category":"converters",
-      "description":"Objective-C to Swift online code converter and Xcode extension.",
-      "homepage":"https://swiftify.com/#/converter/code/",
-      "tags":[
-        "extensions",
-        "ios",
-        "macos",
-        "objective-c",
-        "swift"
-      ]
-    },
-    {
-      "title":"Zolang",
-      "homepage":"https://github.com/Zolang/Zolang",
-      "category":"converters",
-      "description":"A DSL for generating code in multiple programming languages.",
-      "tags":[
-        "extensions",
-        "ios",
-        "macos",
-        "linux",
-        "swift"
-      ]
-    },
-    {
-      "title":"LocalizationKit",
-      "category":"localization",
-      "description":"Realtime dynamic localization of your app with remote management so you can manage maintain and deploy translations without resubmitting app.",
-      "homepage":"https://github.com/willpowell8/LocalizationKit_iOS",
-      "tags":[
-        "extensions",
-        "ios"
-      ]
-    },
-    {
-      "title":"ValidatedPropertyKit",
-      "category":"validation",
-      "description":"Easily validate your Properties with Property Wrappers 👮.",
-      "homepage":"https://github.com/SvenTiigi/ValidatedPropertyKit",
-      "tags":[
-        "ios",
-        "macos",
-        "tvos",
-        "watchos",
-        "swift",
-        "propertywrapper"
-      ]
-    },
-    {
-      "title":"Input Mask",
-      "category":"validation",
-      "description":"Pattern-based user input formatter, parser and validator for iOS.",
-      "homepage":"https://github.com/RedMadRobot/input-mask-ios"
-    },
-    {
-      "title":"YPImagePicker",
-      "category":"images",
-      "description":"Instagram-like image picker & filters for iOS.",
-      "homepage":"https://github.com/Yummypets/YPImagePicker"
-    },
-    {
-      "title":"Sharaku",
-      "category":"images",
-      "description":"Image filtering UI library like Instagram.",
-      "homepage":"https://github.com/makomori/Sharaku"
-    },
-    {
-      "title":"IHKeyboardAvoiding",
-      "category":"keyboard",
-      "description":"An elegant solution for keeping any UIView visible when the keyboard is being shown. No UIScrollView required.",
-      "homepage":"https://github.com/IdleHandsApps/IHKeyboardAvoiding",
-      "tags":[
-        "iOS",
-        "swift",
-        "keyboard"
-      ]
-    },
-    {
-      "title":"KeyboardHideManager",
-      "category":"keyboard",
-      "description":"Codeless manager to hide keyboard by tapping on views for iOS.",
-      "homepage":"https://github.com/bonyadmitr/KeyboardHideManager",
-      "tags":[
-        "iOS",
-        "swift",
-        "keyboard"
-      ]
-    },
-    {
-      "title":"Typist",
-      "category":"keyboard",
-      "description":"Small, drop-in UIKit keyboard manager for iOS apps-helps manage keyboard's screen presence and behavior without notification center.",
-      "homepage":"https://github.com/totocaster/Typist",
-      "tags":[
-        "iOS",
-        "swift",
-        "keyboard"
-      ]
-    },
-    {
-      "title":"IQKeyboardManager",
-      "category":"keyboard",
-      "description":"Codeless drop-in universal library allows to prevent issues of keyboard sliding up and cover UITextField/UITextView.",
-      "homepage":"https://github.com/hackiftekhar/IQKeyboardManager"
-    },
-    {
-      "title":"Getting Started",
-      "category":"official-guides",
-      "description":"Find information about the how to use the Swift programming language.",
-      "homepage":"https://www.swift.org/getting-started/"
-    },
-    {
-      "title":"About Swift",
-      "category":"third-party-guides",
-      "description":"A playground about the Swift language.",
-      "homepage":"https://github.com/NicolaLancellotti/about-swift"
-    },
-    {
-      "title":"Telegram Bot SDK",
-      "category":"bots",
-      "description":"Unofficial SDK.",
-      "homepage":"https://github.com/rapierorg/telegram-bot-swift",
-      "tags":[
-        "linux",
-        "iOS",
-        "swift",
-        "bot",
-        "telegram"
-      ]
-    },
-    {
-      "title":"SwagGen",
-      "category":"misc",
-      "description":"A command line tool for generating a REST API from a Swagger spec based off Stencil templates.",
-      "homepage":"https://github.com/yonaskolb/SwagGen",
-      "tags":[
-        "linux",
-        "swagger",
-        "swift",
-        "CI",
-        "generator",
-        "template",
-        "open-api"
-      ]
-    },
-    {
-      "title":"Hydra",
-      "category":"concurrency",
-      "description":"Promises & Await - Write better async code.",
-      "homepage":"https://github.com/malcommac/Hydra"
-    },
-    {
-      "title":"IGColorPicker",
-      "category":"ui",
-      "description":"A customizable color picker for iOS.",
-      "homepage":"https://github.com/iGenius-Srl/IGColorPicker",
-      "tags":[
-        "iOS",
-        "swift",
-        "color",
-        "color-picker",
-        "picker"
-      ]
-    },
-    {
-      "title":"CTPanoramaView",
-      "category":"images",
-      "description":"A library that displays spherical or cylindrical panoramas with touch or motion based controls.",
-      "homepage":"https://github.com/scihant/CTPanoramaView"
-    },
-    {
-      "title":"RangeSeekSlider",
-      "category":"ui",
-      "description":"A customizable range slider like a UISlider for iOS.",
-      "homepage":"https://github.com/WorldDownTown/RangeSeekSlider"
-    },
-    {
-      "title":"JustPersist",
-      "category":"core-data",
-      "description":"Easiest and safest way to do persistence on iOS with Core Data support out of the box.",
-      "homepage":"https://github.com/justeat/JustPersist"
-    },
-    {
-      "title":"CHIPageControl",
-      "category":"pagination",
-      "description":"A set of cool animated page controls to replace boring UIPageControl.",
-      "homepage":"https://github.com/ChiliLabs/CHIPageControl",
-      "tags":[
+      "title": "CHIPageControl",
+      "category": "pagination",
+      "description": "A set of cool animated page controls to replace boring UIPageControl.",
+      "homepage": "https://github.com/ChiliLabs/CHIPageControl",
+      "tags": [
         "iOS",
         "swift",
         "pagination",
@@ -5234,51 +1890,819 @@
       ]
     },
     {
-      "title":"iTextField ⌨️",
-      "category":"textfield",
-      "description":"A fully-wrapped `UITextField` that works entirely in SwiftUI 🦅.",
-      "homepage":"https://github.com/blsage/iTextField",
-      "tags":[
-        "iOS",
-        "swift",
-        "swiftui",
-        "textfield",
-        "UITextField",
-        "viewmodifiers"
+      "title": "ChromaColorPicker",
+      "category": "colors",
+      "description": "An intuitive and fun iOS color picker.",
+      "homepage": "https://github.com/joncardasis/ChromaColorPicker"
+    },
+    {
+      "title": "Chronology",
+      "category": "date",
+      "description": "Building a better date/time library.",
+      "homepage": "https://github.com/davedelong/time"
+    },
+    {
+      "title": "Ciao",
+      "category": "network",
+      "description": "Publish and discover services using mDNS (Bonjour, Zeroconf).",
+      "homepage": "https://github.com/AlTavares/Ciao"
+    },
+    {
+      "title": "CircleBar",
+      "category": "tab",
+      "description": "A fun, easy-to-use tab bar navigation controller for iOS.",
+      "homepage": "https://github.com/softhausHQ/CircleBar",
+      "tags": [
+        "tab",
+        "navigation"
       ]
     },
     {
-      "title":"iPages",
-      "category":"pagination",
-      "description":"Quickly implement swipable page views in SwiftUI 📝.",
-      "homepage":"https://github.com/blsage/iPages",
-      "tags":[
-        "iOS",
+      "title": "CircleMenu",
+      "category": "menu",
+      "description": "CircleMenu is a simple, elegant UI menu with a circular layout and material design animations.",
+      "homepage": "https://github.com/Ramotion/circle-menu"
+    },
+    {
+      "title": "CircularProgress",
+      "category": "ui",
+      "description": "Circular progress indicator for your macOS app.",
+      "homepage": "https://github.com/sindresorhus/CircularProgress"
+    },
+    {
+      "title": "CircularRangeSlider",
+      "category": "ui",
+      "description": "A customizable SwiftUI component for selecting a range of values using a circular slider.",
+      "homepage": "https://github.com/diegotid/circular-range-slider"
+    },
+    {
+      "title": "ClassicKit",
+      "category": "ui",
+      "description": "A collection of classic-style UI components.",
+      "homepage": "https://github.com/Baddaboo/ClassicKit"
+    },
+    {
+      "title": "Claude Code Server-Side Swift Skills",
+      "category": "third-party-guides",
+      "description": "Production-ready Claude Code skills for server-side Swift (Vapor 4, Hummingbird 2, Fluent ORM) and Xcode Cloud CI/CD patterns.",
+      "homepage": "https://github.com/melissa-pereira-deel/claude-code-server-side-swift-skills"
+    },
+    {
+      "title": "CleanArchitectureRxSwift",
+      "category": "patterns",
+      "description": "Example of Clean Architecture of iOS app using RxSwift.",
+      "homepage": "https://github.com/sergdort/ModernCleanArchitectureSwiftUI"
+    },
+    {
+      "title": "CleanroomLogger",
+      "category": "logging",
+      "description": "Configurable and extensible high-level logging API that is simple, lightweight and performant.",
+      "homepage": "https://github.com/emaloney/CleanroomLogger"
+    },
+    {
+      "title": "Cleanse",
+      "category": "dependency-injection",
+      "description": "A Lightweight Dependency Injection Framework by Square.",
+      "homepage": "https://github.com/square/Cleanse"
+    },
+    {
+      "title": "Closures",
+      "category": "utility",
+      "description": "Swifty closures for UIKit and Foundation.",
+      "homepage": "https://github.com/vhesener/Closures"
+    },
+    {
+      "title": "CloudCore",
+      "category": "core-data",
+      "description": "Robust CloudKit synchronization: offline editing, relationships, shared and public databases, and more.",
+      "homepage": "https://github.com/deeje/CloudCore/"
+    },
+    {
+      "title": "Cluster",
+      "category": "maps",
+      "description": "Easy Map Annotation Clustering.",
+      "homepage": "https://github.com/efremidze/Cluster",
+      "tags": [
+        "map",
+        "cluster",
+        "annotations",
         "swift",
-        "pagination",
-        "swiftui",
-        "pagecontrol",
-        "UIPageControl",
-        "UIPageViewController"
+        "mapkit"
       ]
     },
     {
-      "title":"ReverseExtension",
-      "category":"uitableview",
-      "description":"UITableView extension that enables the insertion of cells the from bottom of a table view.",
-      "homepage":"https://github.com/marty-suzuki/ReverseExtension",
-      "tags":[
-        "iOS",
-        "swift",
-        "UITableView"
+      "title": "CocoaMQTT",
+      "category": "messaging-protocol",
+      "description": "MQTT for iOS and OS X.",
+      "homepage": "https://github.com/emqx/CocoaMQTT"
+    },
+    {
+      "title": "CocoaPods",
+      "category": "dependency-managers",
+      "description": "The most used dependency manager.",
+      "homepage": "https://github.com/CocoaPods/CocoaPods"
+    },
+    {
+      "title": "CocoaSprings",
+      "category": "animation",
+      "description": "Interactive spring animations for iOS/macOS.",
+      "homepage": "https://github.com/MacPaw/CocoaSprings"
+    },
+    {
+      "title": "CodableCSV",
+      "category": "csv",
+      "description": "Read and write CSV files row-by-row or through Swift's Codable interface.",
+      "homepage": "https://github.com/dehesa/CodableCSV",
+      "tags": [
+        "linux"
       ]
     },
     {
-      "title":"Elissa",
-      "category":"ui",
-      "description":"Displays a notification on top of a UITabBarItem or any UIView anchor view to reveal additional information.",
-      "homepage":"https://github.com/KitchenStories/Elissa",
-      "tags":[
+      "title": "CodableWrappers",
+      "category": "misc",
+      "description": "A Collection of PropertyWrappers to make custom Serialization of Codable Types easy.",
+      "homepage": "https://github.com/GottaGetSwifty/CodableWrappers",
+      "tags": [
+        "swift",
+        "codable",
+        "property-wrappers"
+      ]
+    },
+    {
+      "title": "Codextended",
+      "category": "utility",
+      "description": "Extensions giving Codable API type inference super powers.",
+      "homepage": "https://github.com/JohnSundell/Codextended"
+    },
+    {
+      "title": "CodyFire",
+      "category": "network",
+      "description": "Powerful Codable API requests builder and manager for iOS. Based on Alamofire.",
+      "homepage": "https://github.com/CodyFlame/CodyFire"
+    },
+    {
+      "title": "CollapsibleTableSectionViewController",
+      "category": "uitableview",
+      "description": "A library to support collapsible sections in a table view.",
+      "homepage": "https://github.com/jeantimex/CollapsibleTableSectionViewController"
+    },
+    {
+      "title": "CollectionViewShelfLayout",
+      "category": "uicollectionview",
+      "description": "A UICollectionViewLayout subclass displays its items as rows of items similar to the App Store Feature tab without a nested UITableView/UICollectionView hack.",
+      "homepage": "https://github.com/pitiphong-p/CollectionViewShelfLayout"
+    },
+    {
+      "title": "CollectionViewSlantedLayout",
+      "category": "uicollectionview",
+      "description": "UICollectionViewLayout to show slanted content.",
+      "homepage": "https://github.com/yacir/CollectionViewSlantedLayout"
+    },
+    {
+      "title": "ColorKit",
+      "category": "colors",
+      "description": "Advanced color manipulation for iOS.",
+      "homepage": "https://github.com/Boris-Em/ColorKit"
+    },
+    {
+      "title": "ColorMatchTabs",
+      "category": "tab",
+      "description": "Interesting way to display tabs.",
+      "homepage": "https://github.com/Yalantis/ColorMatchTabs"
+    },
+    {
+      "title": "Combinative",
+      "category": "events",
+      "description": "UI event handling using Apple's combine framework.",
+      "homepage": "https://github.com/noppefoxwolf/Combinative"
+    },
+    {
+      "title": "Comets",
+      "category": "animation",
+      "description": "Animating Particles.",
+      "homepage": "https://github.com/cruisediary/Comets"
+    },
+    {
+      "title": "Commander",
+      "category": "command-line",
+      "description": "Compose beautiful command line interfaces.",
+      "homepage": "https://github.com/kylef/Commander",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "ConcentricOnboarding",
+      "category": "walkthrough",
+      "description": "SwiftUI library for a walkthrough or onboarding flow with tap actions.",
+      "homepage": "https://github.com/exyte/ConcentricOnboarding"
+    },
+    {
+      "title": "Conduit",
+      "category": "network",
+      "description": "Robust networking for web APIs.",
+      "homepage": "https://github.com/mindbody/Conduit"
+    },
+    {
+      "title": "Conferences.digital",
+      "category": "third-party-guides",
+      "description": "Watch conference videos in a native macOS app.",
+      "homepage": "https://github.com/zagahr/Conferences.digital"
+    },
+    {
+      "title": "Connectivity",
+      "category": "network",
+      "description": "🌐 Makes Internet connectivity detection more robust by detecting Wi-Fi networks without Internet access.",
+      "homepage": "https://github.com/rwbutler/Connectivity",
+      "tags": [
+        "swift",
+        "connectivity",
+        "reachability",
+        "networking",
+        "network",
+        "connection"
+      ],
+      "swift": 4.2
+    },
+    {
+      "title": "ContactsChangeNotifier",
+      "category": "kit",
+      "description": "Which contacts changed outside your app? Better CNContactStoreDidChange notification: Get real changes, without the noise.",
+      "homepage": "https://github.com/yonat/ContactsChangeNotifier"
+    },
+    {
+      "title": "ContainerController",
+      "category": "ui",
+      "description": "UI Component. This is a copy swipe-panel from app: Apple Maps, Stocks",
+      "homepage": "https://github.com/mrustaa/ContainerController",
+      "tags": [
+        "swift",
+        "maps",
+        "swipe",
+        "panel",
+        "collection",
+        "tableview",
+        "scrollview",
+        "view",
+        "recognizer",
+        "gesture",
+        "pan"
+      ]
+    },
+    {
+      "title": "CoreML-Models",
+      "category": "ai",
+      "description": "A collection of unique Core ML Models.",
+      "homepage": "https://github.com/likedan/Awesome-CoreML-Models"
+    },
+    {
+      "title": "CoreStore",
+      "category": "core-data",
+      "description": "simple and elegant way to handle Core Data.",
+      "homepage": "https://github.com/JohnEstropia/CoreStore"
+    },
+    {
+      "title": "CoreXLSX",
+      "category": "other-data",
+      "description": "Excel spreadsheet (XLSX) format support.",
+      "homepage": "https://github.com/CoreOffice/CoreXLSX"
+    },
+    {
+      "title": "Corridor",
+      "category": "dependency-injection",
+      "description": "A Coreader-like Dependency Injection μFramework.",
+      "homepage": "https://github.com/symentis/Corridor"
+    },
+    {
+      "title": "CountdownLabel",
+      "category": "label",
+      "description": "Simple countdown UILabel with morphing animation, and some useful function.",
+      "homepage": "https://github.com/suzuki-0000/CountdownLabel"
+    },
+    {
+      "title": "CountryPickerView",
+      "category": "ui",
+      "description": "A simple, customizable view for efficiently collecting country information in iOS apps.",
+      "homepage": "https://github.com/kizitonwose/CountryPickerView"
+    },
+    {
+      "title": "Croc",
+      "category": "text",
+      "description": "A lightweight Emoji parsing and querying library.",
+      "homepage": "https://github.com/JKalash/Croc",
+      "tags": [
+        "emoji",
+        "croc",
+        "macOS",
+        "iOS",
+        "tvOS"
+      ]
+    },
+    {
+      "title": "Crossroad",
+      "category": "app-routing",
+      "description": ":oncoming_bus: Crossroad is an URL router focused on handling Custom URL Schemes.",
+      "homepage": "https://github.com/giginet/Crossroad"
+    },
+    {
+      "title": "CrowdinSDK",
+      "category": "localization",
+      "description": "Delivers all new translations from Crowdin project to the application immediately.",
+      "homepage": "https://github.com/crowdin/mobile-sdk-ios",
+      "tags": [
+        "swift",
+        "crowdin",
+        "localization"
+      ]
+    },
+    {
+      "title": "CryptoSwift",
+      "category": "cryptography",
+      "description": "Crypto related functions and helpers.",
+      "homepage": "https://github.com/krzyzanowskim/CryptoSwift",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "CSVParser",
+      "category": "csv",
+      "description": "Fast parser for CSV.",
+      "homepage": "https://github.com/Nero5023/CSVParser",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "CTPanoramaView",
+      "category": "images",
+      "description": "A library that displays spherical or cylindrical panoramas with touch or motion based controls.",
+      "homepage": "https://github.com/scihant/CTPanoramaView"
+    },
+    {
+      "title": "Cuckoo",
+      "category": "mock",
+      "description": "First boilerplate-free mocking framework.",
+      "homepage": "https://github.com/Brightify/Cuckoo"
+    },
+    {
+      "title": "Cupcake",
+      "category": "auto-layout",
+      "description": "An easy way to create and layout UI components for iOS.",
+      "homepage": "https://github.com/nerdycat/Cupcake"
+    },
+    {
+      "title": "Curassow",
+      "category": "webserver",
+      "description": "HTTP server using the pre-fork worker model.",
+      "homepage": "https://github.com/kylef-archive/Curassow",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "Curry",
+      "category": "utility",
+      "description": "Function currying.",
+      "homepage": "https://github.com/thoughtbot/Curry"
+    },
+    {
+      "title": "CustomSegue",
+      "category": "ui",
+      "description": "Custom segue for OSX Storyboards with slide and cross fade effects.",
+      "homepage": "https://github.com/phimage/CustomSegue"
+    },
+    {
+      "title": "DataKernel",
+      "category": "core-data",
+      "description": "DataKernel is a minimalistic wrapper around Core Data stack to ease persistence operations. No external dependencies.",
+      "homepage": "https://github.com/mrdekk/DataKernel"
+    },
+    {
+      "title": "DateHelper",
+      "category": "date",
+      "description": "Simple date helper.",
+      "homepage": "https://github.com/melvitax/DateHelper"
+    },
+    {
+      "title": "DateTimePicker",
+      "category": "calendar",
+      "description": "A nicer iOS UI component for picking date and time.",
+      "homepage": "https://github.com/itsmeichigo/DateTimePicker"
+    },
+    {
+      "title": "Datez",
+      "category": "date",
+      "description": "Library for dealing with `NSDate`, `NSCalendar`, `NSDateComponents`, and `NSTimeInterval`.",
+      "homepage": "https://github.com/SwiftKitz/Datez"
+    },
+    {
+      "title": "Datify",
+      "category": "date",
+      "description": "Easypeasy date functions.",
+      "homepage": "https://github.com/hemangshah/Datify"
+    },
+    {
+      "title": "DDMathParser",
+      "category": "math",
+      "description": "DDMathParser makes it easy to parse a String and evaluate it as a mathematical expression.",
+      "homepage": "https://github.com/davedelong/DDMathParser"
+    },
+    {
+      "title": "DebugSwift",
+      "category": "debug",
+      "description": "DebugSwift is a comprehensive toolkit designed to simplify and enhance the debugging process for Swift-based applications. Whether you're troubleshooting issues or optimizing performance, DebugSwift provides a set of powerful features to make your debugging experience more efficient.",
+      "homepage": "https://github.com/DebugSwift/DebugSwift",
+      "tags": [
+        "debug",
+        "network",
+        "debugger",
+        "log",
+        "logger",
+        "logging",
+        "logging-library",
+        "layout-debugger",
+        "leak-detection",
+        "crashlytics",
+        "performance-analysis"
+      ]
+    },
+    {
+      "title": "DeckTransition",
+      "category": "ui",
+      "description": "A library to recreate the iOS 10 Apple Music now playing transition.",
+      "homepage": "https://github.com/HarshilShah/DeckTransition"
+    },
+    {
+      "title": "Decodable",
+      "category": "json",
+      "description": "JSON parsing.",
+      "homepage": "https://github.com/Anviking/Decodable",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "Default",
+      "category": "key-value-store",
+      "description": "Modern interface to UserDefaults + Codable support.",
+      "homepage": "https://github.com/Nirma/Default"
+    },
+    {
+      "title": "Defaults",
+      "category": "key-value-store",
+      "description": "Strongly-typed UserDefaults with support for Codable and key observation.",
+      "homepage": "https://github.com/sindresorhus/Defaults"
+    },
+    {
+      "title": "DefaultsKit",
+      "category": "key-value-store",
+      "description": "Simple, Strongly Typed UserDefaults for iOS, macOS and tvOS.",
+      "homepage": "https://github.com/nmdias/DefaultsKit"
+    },
+    {
+      "title": "Delegated",
+      "category": "utility",
+      "description": "Closure-based delegation without memory leaks.",
+      "homepage": "https://github.com/dreymonde/Delegated",
+      "swift": 4
+    },
+    {
+      "title": "Deli",
+      "category": "dependency-injection",
+      "description": "Deli is an easy-to-use Dependency Injection(DI).",
+      "homepage": "https://github.com/kawoou/Deli",
+      "tags": [
+        "swift",
+        "ios",
+        "di"
+      ]
+    },
+    {
+      "title": "Design-Patterns-In-Swift",
+      "category": "patterns",
+      "description": "Design Patterns.",
+      "homepage": "https://github.com/ochococo/Design-Patterns-In-Swift"
+    },
+    {
+      "title": "Developing iOS Apps with Swift",
+      "category": "third-party-guides",
+      "description": "Stanford course by Paul Hegarty.",
+      "homepage": "https://podcasts.apple.com/us/podcast/developing-ios-11-apps-with-swift/id1315130780"
+    },
+    {
+      "title": "Device",
+      "category": "device",
+      "description": "Light weight tool for detecting the current device and screen size.",
+      "homepage": "https://github.com/Ekhoo/Device"
+    },
+    {
+      "title": "Device.swift",
+      "category": "device",
+      "description": "Super-lightweight library to detect used device.",
+      "homepage": "https://github.com/schickling/Device.swift"
+    },
+    {
+      "title": "DeviceKit",
+      "category": "device",
+      "description": "DeviceKit is a value-type replacement of UIDevice.",
+      "homepage": "https://github.com/devicekit/DeviceKit"
+    },
+    {
+      "title": "DeviceLayout",
+      "category": "auto-layout",
+      "description": "AutoLayout can be set differently for each device.",
+      "homepage": "https://github.com/cruisediary/DeviceLayout"
+    },
+    {
+      "title": "Deviice",
+      "category": "device",
+      "description": "Swift library to easily check the current device and some more info about it.",
+      "homepage": "https://github.com/andrealufino/Deviice",
+      "tags": [
+        "device",
+        "detection"
+      ]
+    },
+    {
+      "title": "DGElasticPullToRefresh",
+      "category": "uitableview",
+      "description": "Elastic pull to refresh.",
+      "homepage": "https://github.com/gontovnik/DGElasticPullToRefresh"
+    },
+    {
+      "title": "DiffableDataSources",
+      "category": "uitableview",
+      "description": "💾 A library for backporting UITableView/UICollectionViewDiffableDataSource.",
+      "homepage": "https://github.com/ra1028/DiffableDataSources"
+    },
+    {
+      "title": "DifferenceKit",
+      "category": "utility",
+      "description": "💻 A fast and flexible O(n) difference algorithm framework.",
+      "homepage": "https://github.com/ra1028/DifferenceKit"
+    },
+    {
+      "title": "Differific",
+      "category": "utility",
+      "description": "A fast and convenient diffing framework.",
+      "homepage": "https://github.com/zenangst/Differific"
+    },
+    {
+      "title": "DIKit",
+      "category": "dependency-injection",
+      "description": "Dependency Injection Framework for Swift, inspired by KOIN.",
+      "homepage": "https://github.com/Liftric/DIKit"
+    },
+    {
+      "title": "Dip",
+      "category": "dependency-injection",
+      "description": "A simple Dependency Injection Container.",
+      "homepage": "https://github.com/AliSoftware/Dip"
+    },
+    {
+      "title": "Disk",
+      "category": "other-data",
+      "description": "Delightful framework for iOS to easily persist structs, images, and data.",
+      "homepage": "https://github.com/saoudrizwan/Disk"
+    },
+    {
+      "title": "DITranquillity",
+      "category": "dependency-injection",
+      "description": "Dependency injection framework with tranquility.",
+      "homepage": "https://github.com/ivlevAstef/DITranquillity/",
+      "tags": [
+        "Swift",
+        "DI",
+        "IoC"
+      ]
+    },
+    {
+      "title": "DL4S",
+      "category": "ai",
+      "description": "Automatic differentiation, fast tensor operations and dynamic neural networks from CNNs and RNNs to transformers.",
+      "homepage": "https://github.com/palle-k/DL4S",
+      "tags": [
+        "math",
+        "machine-learning",
+        "automatic-differentiation",
+        "neural-networks"
+      ]
+    },
+    {
+      "title": "DMScrollBar",
+      "category": "scroll-bars",
+      "description": "Best in class customizable ScrollBar for any type of ScrollView with Decelerating, Bounce & Rubber band mechanisms and many many more.",
+      "homepage": "https://github.com/batanus/DMScrollBar",
+      "tags": [
+        "swift",
+        "iOS",
+        "scroll-bar",
+        "scroll-indicator",
+        "scroll-view"
+      ]
+    },
+    {
+      "title": "DNWebSocket",
+      "category": "socket",
+      "description": "Object-Oriented, Autobahn tested WebSocket Library (RFC 6455).",
+      "homepage": "https://github.com/GlebRadchenko/DNWebSocket",
+      "tags": [
+        "websocket",
+        "socket",
+        "io",
+        "network",
+        "networking"
+      ]
+    },
+    {
+      "title": "DockProgress",
+      "category": "ui",
+      "description": "Show progress in your macOS app's Dock icon.",
+      "homepage": "https://github.com/sindresorhus/DockProgress"
+    },
+    {
+      "title": "Dodo",
+      "category": "ui",
+      "description": "A message bar for iOS.",
+      "homepage": "https://github.com/evgenyneu/Dodo"
+    },
+    {
+      "title": "DOFavoriteButton",
+      "category": "button",
+      "description": "Cute Animated Button.",
+      "homepage": "https://github.com/okmr-d/DOFavoriteButton"
+    },
+    {
+      "title": "Dollar",
+      "category": "utility",
+      "description": "Similar to Lo-Dash or Underscore in Javascript.",
+      "homepage": "https://github.com/ankurp/Dollar"
+    },
+    {
+      "title": "Doric Design System Foundation",
+      "category": "ui",
+      "description": "Protocol oriented, type safe, scalable design system foundation framework for iOS.",
+      "homepage": "https://github.com/jayeshk/Doric"
+    },
+    {
+      "title": "Dots",
+      "category": "network",
+      "description": "Lightweight Concurrent Networking Framework.",
+      "homepage": "https://github.com/iAmrSalman/Dots"
+    },
+    {
+      "title": "Drag and Drop UICollectionView",
+      "category": "uicollectionview",
+      "description": "Dragging and Dropping data across multiple UICollectionViews.",
+      "homepage": "https://github.com/mmick66/KDDragAndDropCollectionView"
+    },
+    {
+      "title": "DropDown",
+      "category": "ui",
+      "description": "A Material Design drop down for iOS.",
+      "homepage": "https://github.com/AssistoLab/DropDown"
+    },
+    {
+      "title": "DTPagerController",
+      "category": "tab",
+      "description": "Container view controller to display a set of ViewControllers in a horizontal scroll view.",
+      "homepage": "https://github.com/tungvoduc/DTPagerController"
+    },
+    {
+      "title": "DTPhotoViewerController",
+      "category": "images",
+      "description": "A fully customizable photo viewer ViewController to display single photo or collection of photos, inspired by Facebook photo viewer.",
+      "homepage": "https://github.com/tungvoduc/DTPhotoViewerController"
+    },
+    {
+      "title": "DTTableViewManager",
+      "category": "uitableview",
+      "description": "Protocol-oriented UITableView management, powered by generics and associated types.",
+      "homepage": "https://github.com/DenTelezhkin/DTTableViewManager"
+    },
+    {
+      "title": "DTTextField",
+      "category": "textfield",
+      "description": "DTTextField is a custom textfield with floating placeholder and error label.",
+      "homepage": "https://github.com/iDhaval/DTTextField"
+    },
+    {
+      "title": "DuctTape",
+      "category": "utility",
+      "description": "📦 KeyPath dynamicMemberLookup based syntax sugar for Swift.",
+      "homepage": "https://github.com/marty-suzuki/DuctTape"
+    },
+    {
+      "title": "Duration",
+      "category": "logging",
+      "description": "Lightweight logging library focused on reporting timings for operations.",
+      "homepage": "https://github.com/SwiftStudies/Duration",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "DVR",
+      "category": "testing",
+      "description": "A simple network testing framework.",
+      "homepage": "https://github.com/venmo/DVR"
+    },
+    {
+      "title": "DynamicColor",
+      "category": "colors",
+      "description": "An extension to manipulate colors easily.",
+      "homepage": "https://github.com/yannickl/DynamicColor"
+    },
+    {
+      "title": "Each",
+      "category": "thread",
+      "description": "Each is a NSTimer bridge library.",
+      "homepage": "https://github.com/dalu93/Each"
+    },
+    {
+      "title": "Ease",
+      "category": "animation",
+      "description": "Animate everything with Ease.",
+      "homepage": "https://github.com/roberthein/Ease"
+    },
+    {
+      "title": "EasyAnimation",
+      "category": "animation",
+      "description": "A library to take the power of UIView.animateWithDuration(_:, animations:...) to a whole new level.",
+      "homepage": "https://github.com/icanzilb/EasyAnimation"
+    },
+    {
+      "title": "EasyPeasy",
+      "category": "auto-layout",
+      "description": "Auto Layout made easy.",
+      "homepage": "https://github.com/nakiostudio/EasyPeasy"
+    },
+    {
+      "title": "EasySwiftLayout",
+      "category": "auto-layout",
+      "description": "Lightweight Swift framework for Apple's Auto-Layout.",
+      "homepage": "https://github.com/Pimine/EasySwiftLayout"
+    },
+    {
+      "title": "EasyTransitions",
+      "category": "transition",
+      "description": "A simple way to create custom interactive UIViewController transitions.",
+      "homepage": "https://github.com/marcosgriselli/EasyTransitions",
+      "tags": [
+        "ios",
+        "tvos"
+      ]
+    },
+    {
+      "title": "edhita",
+      "category": "text",
+      "description": "Fully open source text editor for iOS.",
+      "homepage": "https://github.com/tnantoka/edhita"
+    },
+    {
+      "title": "EFQRCode",
+      "category": "barcode",
+      "description": "A better way to operate quick response code.",
+      "homepage": "https://github.com/EFPrefix/EFQRCode",
+      "tags": [
+        "swift",
+        "qrcode",
+        "barcode",
+        "generator",
+        "recognizer"
+      ]
+    },
+    {
+      "title": "ElegantCalendar",
+      "category": "calendar",
+      "description": "The elegant full screen calendar missed in SwiftUI.",
+      "homepage": "https://github.com/ThasianX/ElegantCalendar",
+      "tags": [
+        "elegantcalendar",
+        "calendar",
+        "declarative",
+        "swiftui"
+      ]
+    },
+    {
+      "title": "Elephant",
+      "category": "animation",
+      "description": "Elegant SVG animation kit.",
+      "homepage": "https://github.com/s2mr/Elephant"
+    },
+    {
+      "title": "Elevate",
+      "category": "json",
+      "description": "JSON parsing framework that makes parsing simple, reliable and composable.",
+      "homepage": "https://github.com/Nike-Inc/Elevate"
+    },
+    {
+      "title": "Elissa",
+      "category": "ui",
+      "description": "Displays a notification on top of a UITabBarItem or any UIView anchor view to reveal additional information.",
+      "homepage": "https://github.com/KitchenStories/Elissa",
+      "tags": [
         "iOS",
         "Swift",
         "UITabBar",
@@ -5290,17 +2714,813 @@
       ]
     },
     {
-      "title":"HHTabBarView",
-      "category":"tab",
-      "description":"A lightweight customized tab bar view.",
-      "homepage":"https://github.com/hemangshah/HHTabBarView"
+      "title": "Embassy",
+      "category": "webserver",
+      "description": "Super lightweight async HTTP server library.",
+      "homepage": "https://github.com/envoy/Embassy",
+      "tags": [
+        "linux"
+      ]
     },
     {
-      "title":"GrowingTextView",
-      "category":"ui",
-      "description":"UITextView that supports auto growing, placeholder and length limit.",
-      "homepage":"https://github.com/KennethTsang/GrowingTextView",
-      "tags":[
+      "title": "EmitterKit",
+      "category": "events",
+      "description": "Implementation of event emitters and listeners.",
+      "homepage": "https://github.com/aleclarson/emitter-kit"
+    },
+    {
+      "title": "ENSwiftSideMenu",
+      "category": "menu",
+      "description": "Sliding side menu.",
+      "homepage": "https://github.com/evnaz/ENSwiftSideMenu"
+    },
+    {
+      "title": "Erik",
+      "category": "testing",
+      "description": "An headless browser to access and manipulate webpages using javascript allowing to run functional tests.",
+      "homepage": "https://github.com/phimage/Erik"
+    },
+    {
+      "title": "Espresso",
+      "category": "ai",
+      "description": "Compile transformers directly for Apple's Neural Engine.",
+      "homepage": "https://github.com/christopherkarani/Espresso"
+    },
+    {
+      "title": "ESTabBarController",
+      "category": "tab",
+      "description": "A highly customizable TabBarController component, which is inherited from UITabBarController.",
+      "homepage": "https://github.com/eggswift/ESTabBarController"
+    },
+    {
+      "title": "EstMusicIndicator",
+      "category": "ui",
+      "description": "Music play indicator like iTunes.",
+      "homepage": "https://github.com/Aufree/ESTMusicIndicator"
+    },
+    {
+      "title": "EtherWalletKit",
+      "category": "utility",
+      "description": "Ethereum Wallet Toolkit for iOS - You can implement Ethereum wallet without a server and blockchain knowledge.",
+      "homepage": "https://github.com/SteadyAction/EtherWalletKit",
+      "tags": [
+        "ethereum",
+        "wallet",
+        "ethereum-wallet",
+        "swift",
+        "ios",
+        "blockchain",
+        "coin",
+        "token",
+        "crypto",
+        "cryptocurrency",
+        "cryptowallet"
+      ]
+    },
+    {
+      "title": "Eureka",
+      "category": "form",
+      "description": "Elegant iOS form builder.",
+      "homepage": "https://github.com/xmartlabs/Eureka"
+    },
+    {
+      "title": "EVCloudKitDao",
+      "category": "other-data",
+      "description": "Simplified access to CloudKit with support for subscriptions and local caching.",
+      "homepage": "https://github.com/evermeer/EVCloudKitDao"
+    },
+    {
+      "title": "EVReflection",
+      "category": "json",
+      "description": "Reflection based JSON encoding and decoding. Including support for NSDictionary, NSCoding, Printable, Hashable and Equatable.",
+      "homepage": "https://github.com/evermeer/EVReflection"
+    },
+    {
+      "title": "EVURLCache",
+      "category": "cache",
+      "description": "If you want to make your app still works when it's offline.",
+      "homepage": "https://github.com/evermeer/EVURLCache"
+    },
+    {
+      "title": "example-ios-apps",
+      "category": "other-awesome-lists",
+      "description": "An amazing list for people who are beginners and learning ios development and for ios developers who need any example app or feature.",
+      "homepage": "https://github.com/jogendra/example-ios-apps"
+    },
+    {
+      "title": "ExceptionCatcher",
+      "category": "utility",
+      "description": "Catch Objective-C exceptions.",
+      "homepage": "https://github.com/sindresorhus/ExceptionCatcher"
+    },
+    {
+      "title": "ExpandableButton",
+      "category": "button",
+      "description": "Customizable and easy to use expandable button.",
+      "homepage": "https://github.com/DimaMishchenko/ExpandableButton",
+      "tags": [
+        "swift",
+        "button",
+        "uibutton",
+        "expandable",
+        "ui",
+        "ios"
+      ]
+    },
+    {
+      "title": "ExpandableCell",
+      "category": "uitableview",
+      "description": "Fully refactored YNExapnadableCell with more concise, bug free. Easiest usage of expandable & collapsible cell for iOS. You can customize expandable UITableViewCell whatever you like. ExpandableCell is made because insertRows and deleteRows is hard to use. Just inheirt ExpandableDelegate.",
+      "homepage": "https://github.com/younatics/ExpandableCell"
+    },
+    {
+      "title": "ExtendedAttributes",
+      "category": "files",
+      "description": "Manage extended attributes for files and folders.",
+      "homepage": "https://github.com/sindresorhus/ExtendedAttributes",
+      "tags": [
+        "swift",
+        "system",
+        "file-system"
+      ]
+    },
+    {
+      "title": "ExyteChat",
+      "category": "chat",
+      "description": "SwiftUI Chat UI framework with fully customizable message cells, input view, and a built-in media picker",
+      "homepage": "https://github.com/exyte/chat",
+      "tags": [
+        "swift",
+        "iOS",
+        "swiftui",
+        "chat"
+      ]
+    },
+    {
+      "title": "EZAlertController",
+      "category": "alert",
+      "description": "Easy UIAlertController.",
+      "homepage": "https://github.com/thellimist/EZAlertController"
+    },
+    {
+      "title": "EZLayout",
+      "category": "auto-layout",
+      "description": "An easier and faster way to code Autolayout.",
+      "homepage": "https://github.com/alexliubj/EZAnchor"
+    },
+    {
+      "title": "EZLoadingActivity",
+      "category": "hud",
+      "description": "Lightweight loading activity HUD.",
+      "homepage": "https://github.com/Esqarrouth/EZLoadingActivity"
+    },
+    {
+      "title": "EZSwiftExtensions",
+      "category": "utility",
+      "description": "How standard types and classes were supposed to work.",
+      "homepage": "https://github.com/Esqarrouth/EZSwiftExtensions"
+    },
+    {
+      "title": "Facebook",
+      "category": "SDK",
+      "description": "Facebook SDK for iOS.",
+      "homepage": "https://github.com/facebook/facebook-ios-sdk"
+    },
+    {
+      "title": "FacebookImagePicker",
+      "category": "images",
+      "description": "Facebook album photo picker.",
+      "homepage": "https://github.com/floriangbh/FacebookImagePicker"
+    },
+    {
+      "title": "FaceCrop",
+      "category": "images",
+      "description": "Detect and center faces in your images using Apple’s Vision Framework.",
+      "homepage": "https://github.com/Ancestry/FaceCrop"
+    },
+    {
+      "title": "Fakery",
+      "category": "testing",
+      "description": "Fake data generator.",
+      "homepage": "https://github.com/vadymmarkov/Fakery"
+    },
+    {
+      "title": "Family",
+      "category": "ui",
+      "description": "A child view controller framework that makes setting up your parent controllers as easy as pie.",
+      "homepage": "https://github.com/zenangst/Family"
+    },
+    {
+      "title": "FanMenu",
+      "category": "menu",
+      "description": "Menu with a circular layout based on Macaw.",
+      "homepage": "https://github.com/exyte/fan-menu"
+    },
+    {
+      "title": "FAQView",
+      "category": "ui",
+      "description": "An easy to use FAQ view for iOS.",
+      "homepage": "https://github.com/mukeshthawani/faqview"
+    },
+    {
+      "title": "Fashion",
+      "category": "ui",
+      "description": "Fashion accessories and beauty tools to share and reuse UI styles.",
+      "homepage": "https://github.com/vadymmarkov/Fashion"
+    },
+    {
+      "title": "Fazm",
+      "category": "ai",
+      "description": "A voice-controlled AI agent for macOS using accessibility APIs and ScreenCaptureKit.",
+      "homepage": "https://github.com/m13v/fazm",
+      "tags": [
+        "ai",
+        "macos",
+        "voice",
+        "agent",
+        "swiftui"
+      ]
+    },
+    {
+      "title": "FDBarGauge",
+      "category": "form",
+      "description": "Simulate the level indicator on an audio mixing board",
+      "homepage": "https://github.com/fulldecent/FDBarGauge"
+    },
+    {
+      "title": "FDChessboardView",
+      "category": "games",
+      "description": "A view controller for chess boards",
+      "homepage": "https://github.com/fulldecent/FDChessboardView"
+    },
+    {
+      "title": "FDSoundActivatedRecorder",
+      "category": "audio",
+      "description": "Start recording when the user speaks.",
+      "homepage": "https://github.com/fulldecent/FDSoundActivatedRecorder"
+    },
+    {
+      "title": "FDTake",
+      "category": "camera",
+      "description": "Easily take a photo or video or choose from library.",
+      "homepage": "https://github.com/fulldecent/FDTake"
+    },
+    {
+      "title": "FDTextFieldTableViewCell",
+      "category": "uitableview",
+      "description": "Adds a UITextField to the cell and places it correctly.",
+      "homepage": "https://github.com/fulldecent/FDTextFieldTableViewCell"
+    },
+    {
+      "title": "FDWaveformView",
+      "category": "audio",
+      "description": "An easy way to display an audio waveform in your app.",
+      "homepage": "https://github.com/fulldecent/FDWaveformView"
+    },
+    {
+      "title": "FileKit",
+      "category": "files",
+      "description": "Simple and expressive file management.",
+      "homepage": "https://github.com/nvzqz/FileKit"
+    },
+    {
+      "title": "FileProvider",
+      "category": "files",
+      "description": "FileManager replacement for Local, iCloud and Remote (WebDAV/FTP/Dropbox/OneDrive/SMB2) files for iOS/tvOS and macOS.",
+      "homepage": "https://github.com/amosavian/FileProvider"
+    },
+    {
+      "title": "FixFlex",
+      "category": "auto-layout",
+      "description": "Declarative autolayout based on NSLayoutAnchor, swifty reimagination of VFL, alternative to UIStackView.",
+      "homepage": "https://github.com/psharanda/FixFlex"
+    },
+    {
+      "title": "FlagAndCountryCode",
+      "category": "utility",
+      "description": "FlagAndCountryCode provides phone codes and flags for every country. Works on UIKit and SwiftUI",
+      "homepage": "https://github.com/exyte/FlagAndCountryCode",
+      "tags": [
+        "swift",
+        "flag",
+        "phone",
+        "country-code"
+      ]
+    },
+    {
+      "title": "FlagKit",
+      "category": "ui",
+      "description": "Beautiful flag icons for usage in apps and on the web.",
+      "homepage": "https://github.com/madebybowtie/FlagKit"
+    },
+    {
+      "title": "Flare",
+      "category": "app-store",
+      "description": "A framework that simplifies working with in-app purchases on iOS, macOS, tvOS, and watchOS, with full support for both StoreKit 1 and StoreKit 2.",
+      "homepage": "https://github.com/space-code/flare"
+    },
+    {
+      "title": "FLCharts",
+      "category": "chart",
+      "description": "Easy to use and highly customizable charts library for iOS.",
+      "homepage": "https://github.com/francescoleoni98/FLCharts",
+      "tags": [
+        "iOS",
+        "swift",
+        "Mac Catalyst"
+      ]
+    },
+    {
+      "title": "FlexibleHeader",
+      "category": "ui",
+      "description": "A container view that responds to scrolling of UIScrollView.",
+      "homepage": "https://github.com/k-lpmg/FlexibleHeader"
+    },
+    {
+      "title": "FlexibleImage",
+      "category": "images",
+      "description": "A simple way to play with images.",
+      "homepage": "https://github.com/kawoou/FlexibleImage"
+    },
+    {
+      "title": "FlexiblePageControl",
+      "category": "pagination",
+      "description": "A flexible UIPageControl like Instagram.",
+      "homepage": "https://github.com/shima11/FlexiblePageControl",
+      "tags": [
+        "iOS",
+        "swift",
+        "pagination",
+        "animation",
+        "pagecontrol",
+        "UIPageControl",
+        "instagram"
+      ]
+    },
+    {
+      "title": "FlexLayout",
+      "category": "layout",
+      "description": "Nice and clean interface to the highly optimized Facebook yoga Flexbox implementation.",
+      "homepage": "https://github.com/layoutBox/FlexLayout"
+    },
+    {
+      "title": "FlightAnimator",
+      "category": "animation",
+      "description": "Natural Blocks Based Core Animation Framework.",
+      "homepage": "https://github.com/AntonTheDev/FlightAnimator"
+    },
+    {
+      "title": "FloatingButton",
+      "category": "button",
+      "description": "Easily customizable floating button menu created with SwiftUI.",
+      "homepage": "https://github.com/exyte/FloatingButton"
+    },
+    {
+      "title": "FloatingLabelTextFieldSwiftUI",
+      "category": "textfield",
+      "description": "FloatingLabelTextFieldSwiftUI is a small and lightweight SwiftUI framework written in completely SwiftUI (not using UIViewRepresentable) that allows to create beautiful and customisable floating label textfield!",
+      "tags": [
+        "floatinglabeltextfield",
+        "swiftui",
+        "textfield",
+        "floatinglabeltextfieldswiftui"
+      ],
+      "homepage": "https://github.com/kishanraja/FloatingLabelTextFieldSwiftUI"
+    },
+    {
+      "title": "FloatRatingView",
+      "category": "ui",
+      "description": "Floating rating system.",
+      "homepage": "https://github.com/glenyi/FloatRatingView"
+    },
+    {
+      "title": "Floaty",
+      "category": "button",
+      "description": "Floating Action Button for iOS.",
+      "homepage": "https://github.com/kciter/Floaty"
+    },
+    {
+      "title": "FlowingMenu",
+      "category": "menu",
+      "description": "Interactive view transition to display menus with flowing and bouncing effects.",
+      "homepage": "https://github.com/yannickl/FlowingMenu"
+    },
+    {
+      "title": "fluent",
+      "category": "orm",
+      "description": "Simple ActiveRecord implementation.",
+      "homepage": "https://github.com/vapor/fluent",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "FluentQuery",
+      "category": "utility",
+      "description": "Powerful and easy to use Query Builder.",
+      "homepage": "https://github.com/MihaelIsaev/FluentQuery",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "Fluid Slider",
+      "category": "ui",
+      "description": "A slider widget with a popup bubble displaying the precise value selected.",
+      "homepage": "https://github.com/Ramotion/fluid-slider"
+    },
+    {
+      "title": "FluidAudio",
+      "category": "audio",
+      "description": "SDK for real-time on-device audio intelligence on iOS/macOS (diarization, identification, VAD, separation, embeddings, ASR), with CoreML models converted directly from PyTorch to leverage Apple Neural Engine performance.",
+      "homepage": "https://github.com/FluidInference/FluidAudio"
+    },
+    {
+      "title": "FlyoverKit",
+      "category": "maps",
+      "description": "FlyoverKit enables you to present stunning 360° flyover views on your MKMapView with zero effort while maintaining full configuration possibilities.",
+      "homepage": "https://github.com/SvenTiigi/FlyoverKit"
+    },
+    {
+      "title": "FMPhotoPicker",
+      "category": "images",
+      "description": "A modern, simple and zero-dependency photo picker with an elegant and customizable image editor.",
+      "homepage": "https://github.com/congnd/FMPhotoPicker"
+    },
+    {
+      "title": "folding-cell",
+      "category": "uitableview",
+      "description": "Folding cell transition.",
+      "homepage": "https://github.com/Ramotion/folding-cell"
+    },
+    {
+      "title": "FontAwesome.swift",
+      "category": "fonts",
+      "description": "Use FontAwesome in your projects.",
+      "homepage": "https://github.com/thii/FontAwesome.swift"
+    },
+    {
+      "title": "FontBlaster",
+      "category": "fonts",
+      "description": "Programmatically load custom fonts into your iOS app.",
+      "homepage": "https://github.com/ArtSabintsev/FontBlaster"
+    },
+    {
+      "title": "Forked",
+      "category": "misc",
+      "description": "Generalized approach to managing shared data in Swift applications to support Local-first apps.",
+      "homepage": "https://github.com/drewmccormack/Forked",
+      "tags": [
+        "swift",
+        "codable"
+      ]
+    },
+    {
+      "title": "Former",
+      "category": "form",
+      "description": "A fully customizable library for easy creating UITableView based form.",
+      "homepage": "https://github.com/ra1028/Former"
+    },
+    {
+      "title": "FormValidatorSwift",
+      "category": "validation",
+      "description": "Allows you to validate inputs of text fields and text views in a convenient way.",
+      "homepage": "https://github.com/ustwo/formvalidator-swift"
+    },
+    {
+      "title": "FrameLayoutKit",
+      "category": "layout",
+      "description": "This framework supports complex layouts, including chaining and nesting layout with simple and intuitive operand & DSL syntax.",
+      "homepage": "https://github.com/kennic/FrameLayoutKit"
+    },
+    {
+      "title": "FSPagerView",
+      "category": "uicollectionview",
+      "description": "Elegant Screen Slide Library. It is extremely helpful for making Banner View、Product Show、Welcome/Guide Pages、Screen/ViewController Sliders.",
+      "homepage": "https://github.com/WenchaoD/FSPagerView",
+      "tags": [
+        "infnite-scroll",
+        "banner-view",
+        "banner-slider",
+        "banner",
+        "uicollectionview",
+        "pages"
+      ]
+    },
+    {
+      "title": "Fugen",
+      "category": "misc",
+      "description": "A command line tool for exporting resources and generating code from your Figma files.",
+      "homepage": "https://github.com/almazrafi/Fugen",
+      "tags": [
+        "figma",
+        "figma-export",
+        "design-tokens",
+        "design-systems",
+        "xcode-assets",
+        "codegenerator"
+      ]
+    },
+    {
+      "title": "FullscreenPopup",
+      "category": "alert",
+      "description": "Present any popup above NavigationBar in SwiftUI",
+      "homepage": "https://github.com/Ryu0118/swift-fullscreen-popup",
+      "tags": [
+        "swift",
+        "swiftui",
+        "iOS",
+        "macOS",
+        "tvOS",
+        "popup"
+      ]
+    },
+    {
+      "title": "Fusuma",
+      "category": "camera",
+      "description": "Instagram-like photo browser and a camera feature.",
+      "homepage": "https://github.com/ytakzk/Fusuma"
+    },
+    {
+      "title": "FutureKit",
+      "category": "events",
+      "description": "Future/Promises Library.",
+      "homepage": "https://github.com/FutureKit/FutureKit"
+    },
+    {
+      "title": "Futures",
+      "category": "concurrency",
+      "description": "Lightweight promises for iOS, macOS, tvOS, watchOS, and server-side.",
+      "homepage": "https://github.com/davidask/Futures",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "Fuzi",
+      "category": "html",
+      "description": "A fast & lightweight XML/HTML parser with XPath & CSS support.",
+      "homepage": "https://github.com/cezheng/Fuzi"
+    },
+    {
+      "title": "GaugeKit",
+      "category": "ui",
+      "description": "Customizable gauges. Easy reproduce Apple's style gauges.",
+      "homepage": "https://github.com/skywinder/GaugeKit"
+    },
+    {
+      "title": "GCDTimer",
+      "category": "thread",
+      "description": "A well-tested GCD timer.",
+      "homepage": "https://github.com/hemantasapkota/GCDTimer"
+    },
+    {
+      "title": "Gecco",
+      "category": "walkthrough",
+      "description": "Spotlight view for iOS.",
+      "homepage": "https://github.com/xai3/Gecco"
+    },
+    {
+      "title": "Gedatsu",
+      "category": "logging",
+      "description": "Provide readable format about AutoLayout error console log.",
+      "homepage": "https://github.com/bannzai/gedatsu"
+    },
+    {
+      "title": "Gemini",
+      "category": "animation",
+      "description": "Gemini is rich scroll based animation framework.",
+      "homepage": "https://github.com/shoheiyokoyama/Gemini"
+    },
+    {
+      "title": "GEOSwift",
+      "category": "maps",
+      "description": "Make it easier to work with geographic models and calculate intersections, overlapping, projections etc.",
+      "homepage": "https://github.com/GEOSwift/GEOSwift"
+    },
+    {
+      "title": "Getting Started",
+      "category": "official-guides",
+      "description": "Find information about the how to use the Swift programming language.",
+      "homepage": "https://www.swift.org/getting-started/"
+    },
+    {
+      "title": "gifu",
+      "category": "images",
+      "description": "Highly performant animated GIF support for iOS.",
+      "homepage": "https://github.com/kaishin/gifu"
+    },
+    {
+      "title": "GitHubAPI",
+      "category": "api",
+      "description": "Implementation of GitHub REST API v3.",
+      "homepage": "https://github.com/serhii-londar/GithubAPI"
+    },
+    {
+      "title": "GitHubRestAPISwiftOpenAPI",
+      "category": "api",
+      "description": "Scheduled generated GitHub's REST API as Swift code from OpenAPI specification.",
+      "homepage": "https://github.com/Wei18/github-rest-api-swift-openapi"
+    },
+    {
+      "title": "glide engine",
+      "category": "game-engine",
+      "description": "SpriteKit and GameplayKit based engine for making 2d games, with practical examples and tutorials.",
+      "homepage": "https://github.com/cocoatoucher/Glide",
+      "tags": [
+        "platformer",
+        "side",
+        "scroller",
+        "tilemap",
+        "tiles",
+        "spritekit"
+      ]
+    },
+    {
+      "title": "Gliding Collection",
+      "category": "uicollectionview",
+      "description": "Gliding Collection is a smooth, flowing, customizable decision for a UICollectionView Controller.",
+      "homepage": "https://github.com/Ramotion/gliding-collection"
+    },
+    {
+      "title": "GlitchLabel",
+      "category": "label",
+      "description": "Glitching UILabel for iOS.",
+      "homepage": "https://github.com/kciter/GlitchLabel"
+    },
+    {
+      "title": "GMarkdown",
+      "category": "text",
+      "description": "Markdown rendering library for iOS with support for tables, LaTeX, Mermaid, and code highlighting.",
+      "homepage": "https://github.com/GIKICoder/GMarkdown"
+    },
+    {
+      "title": "GMStepper",
+      "category": "ui",
+      "description": "A stepper with a sliding label in the middle.",
+      "homepage": "https://github.com/gmertk/GMStepper"
+    },
+    {
+      "title": "GoodExtensions-iOS",
+      "category": "utility",
+      "description": "📑 GoodExtensions is a collection of useful and frequently used extensions.",
+      "homepage": "https://github.com/GoodRequest/GoodExtensions-iOS",
+      "tags": [
+        "swift",
+        "iOS",
+        "utility"
+      ]
+    },
+    {
+      "title": "GoodNetworking",
+      "category": "network",
+      "description": "📡 GoodNetworking simplifies HTTP networking.",
+      "homepage": "https://github.com/GoodRequest/GoodNetworking",
+      "tags": [
+        "swift",
+        "iOS",
+        "networking"
+      ]
+    },
+    {
+      "title": "GoodPersistence",
+      "category": "keychain",
+      "description": "💾 GoodPersistence simplifies caching data in keychain and UserDefaults. Using a property wrappers.",
+      "homepage": "https://github.com/GoodRequest/GoodPersistence",
+      "tags": [
+        "swift",
+        "iOS",
+        "persistence",
+        "userdefaults",
+        "keychain"
+      ]
+    },
+    {
+      "title": "GoodProvider",
+      "category": "uicollectionview",
+      "description": "🚀 UITableView and UICollectionView provider to simplify basic scenarios of showing the data.",
+      "homepage": "https://github.com/GoodRequest/GRProvider",
+      "tags": [
+        "swift",
+        "iOS",
+        "UITableView",
+        "UICollectionView"
+      ]
+    },
+    {
+      "title": "GoodReactor",
+      "category": "patterns",
+      "description": "⚛️ GoodReactor is a Redux-inspired Reactor framework for communication between the View Model, View Controller, and Coordinator.",
+      "homepage": "https://github.com/GoodRequest/GoodReactor",
+      "tags": [
+        "swift",
+        "iOS",
+        "reactorKit"
+      ]
+    },
+    {
+      "title": "GoodUIKit",
+      "category": "utility",
+      "description": "📑 GoodUIKit is an extensions library filled with reusable UI snippets for faster and more efficient development.",
+      "homepage": "https://github.com/GoodRequest/GoodUIKit",
+      "tags": [
+        "swift",
+        "iOS",
+        "uikit"
+      ]
+    },
+    {
+      "title": "Google",
+      "category": "style-guides",
+      "description": "This style guide is based on Apple’s excellent Swift standard library style and also incorporates feedback from usage across multiple Swift projects within Google.",
+      "homepage": "https://google.github.io/swift/"
+    },
+    {
+      "title": "GPUImage 2",
+      "category": "images",
+      "description": "GPUImage 2 is a BSD-licensed framework for GPU-accelerated video and image processing.",
+      "homepage": "https://github.com/BradLarson/GPUImage2"
+    },
+    {
+      "title": "GPUImage 3",
+      "category": "images",
+      "description": "GPUImage 3 is a BSD-licensed framework for GPU-accelerated video and image processing using Metal.",
+      "homepage": "https://github.com/BradLarson/GPUImage3"
+    },
+    {
+      "title": "GradientLoadingBar",
+      "category": "hud",
+      "description": "An animated gradient loading bar.",
+      "homepage": "https://github.com/fxm90/GradientLoadingBar"
+    },
+    {
+      "title": "GradientProgressBar",
+      "category": "ui",
+      "description": "An animated gradient progress bar.",
+      "homepage": "https://github.com/fxm90/GradientProgressBar"
+    },
+    {
+      "title": "Gradients",
+      "category": "colors",
+      "description": "A curated collection of splendid 180+ gradients.",
+      "homepage": "https://github.com/Gradients/Gradients"
+    },
+    {
+      "title": "Graph",
+      "category": "core-data",
+      "description": "An elegant data-driven framework for Core Data.",
+      "homepage": "https://github.com/CosmicMind/Graph"
+    },
+    {
+      "title": "GravitySlider",
+      "category": "uicollectionview",
+      "description": "Beautiful alternative to the standard UICollectionView flow layout.",
+      "homepage": "https://github.com/ApplikeySolutions/GravitySlider"
+    },
+    {
+      "title": "GRDB.swift",
+      "category": "sqlite",
+      "description": "A versatile SQLite toolkit.",
+      "homepage": "https://github.com/groue/GRDB.swift"
+    },
+    {
+      "title": "Grid",
+      "category": "layout",
+      "description": "The most powerful Grid container missed in SwiftUI.",
+      "homepage": "https://github.com/exyte/Grid",
+      "tags": [
+        "swiftui",
+        "swift-library",
+        "grid-container"
+      ]
+    },
+    {
+      "title": "GridView",
+      "category": "uitableview",
+      "description": "Can be customized as a time table, spreadsheet, paging and more.",
+      "homepage": "https://github.com/KyoheiG3/GridView"
+    },
+    {
+      "title": "GRMustache",
+      "category": "ui",
+      "description": "Flexible Mustache templates.",
+      "homepage": "https://github.com/groue/GRMustache.swift"
+    },
+    {
+      "title": "GroupWork",
+      "category": "concurrency",
+      "description": "Easy concurrent, asynchronous tasks.",
+      "homepage": "https://github.com/quanvo87/GroupWork",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "GrowingTextView",
+      "category": "ui",
+      "description": "UITextView that supports auto growing, placeholder and length limit.",
+      "homepage": "https://github.com/KennethTsang/GrowingTextView",
+      "tags": [
         "uitextview",
         "growing",
         "placeholder",
@@ -5311,159 +3531,56 @@
       ]
     },
     {
-      "title":"SwiftySound",
-      "category":"audio",
-      "description":"Simple library that lets you play sounds with a single line of code.",
-      "homepage":"https://github.com/adamcichy/SwiftySound"
+      "title": "GSMessage",
+      "category": "alert",
+      "description": "A simple style messages/notifications for iOS 7+.",
+      "homepage": "https://github.com/wxxsw/GSMessages"
     },
     {
-      "title":"Magnetic",
-      "category":"ui",
-      "description":"SpriteKit Floating Bubble Picker (inspired by Apple Music).",
-      "homepage":"https://github.com/efremidze/Magnetic",
-      "tags":[
-        "spritekit",
-        "floating",
-        "bubble",
-        "picker",
-        "applemusic",
-        "swift"
+      "title": "Guaka",
+      "category": "command-line",
+      "description": "The smart and beautiful (POSIX compliant) command line framework.",
+      "homepage": "https://github.com/nsomar/Guaka",
+      "tags": [
+        "linux"
       ]
     },
     {
-      "title":"async+",
-      "category":"concurrency",
-      "description":"A chainable interface for Swift 5.5's async/await.",
-      "homepage":"https://github.com/async-plus/async-plus",
-      "tags":[
-        "linux",
-        "macOS",
-        "iOS",
-        "tvOS",
-        "watchOS",
-        "5.5"
-      ]
+      "title": "GuillotineMenu",
+      "category": "menu",
+      "description": "Guillotine style menu.",
+      "homepage": "https://github.com/Yalantis/GuillotineMenu"
     },
     {
-      "title":"AsyncNinja",
-      "category":"concurrency",
-      "description":"A complete set of concurrency and reactive programming primitives.",
-      "homepage":"https://github.com/AsyncNinja/AsyncNinja",
-      "tags":[
-        "swift",
-        "concurrency",
-        "future",
-        "channel",
-        "async",
-        "functional",
-        "reactive"
-      ]
+      "title": "Hacking With Swift",
+      "category": "third-party-guides",
+      "description": "Complete training course that teaches app development through 30 hands-on projects, for free.",
+      "homepage": "https://www.hackingwithswift.com"
     },
     {
-      "title":"AsyncQueue",
-      "category":"concurrency",
-      "description":"A library of queues that enable sending ordered tasks from synchronous to asynchronous contexts.",
-      "homepage":"https://github.com/dfed/swift-async-queue",
-      "tags":[
-        "linux",
-        "macOS",
-        "iOS",
-        "tvOS",
-        "watchOS",
-        "visionOS",
-        "6.0"
-      ]
+      "title": "HaishinKit",
+      "category": "streaming",
+      "description": "Camera and Microphone streaming library via RTMP, HLS for iOS, macOS, tvOS.",
+      "homepage": "https://github.com/HaishinKit/HaishinKit.swift"
     },
     {
-      "title":"EFQRCode",
-      "category":"barcode",
-      "description":"A better way to operate quick response code.",
-      "homepage":"https://github.com/EFPrefix/EFQRCode",
-      "tags":[
-        "swift",
-        "qrcode",
-        "barcode",
-        "generator",
-        "recognizer"
-      ]
+      "title": "HandyJSON",
+      "category": "json",
+      "description": "A handy JSON-object serialization/deserialization library.",
+      "homepage": "https://github.com/alibaba/handyjson"
     },
     {
-      "title":"LoginKit",
-      "category":"authentication",
-      "description":"LoginKit is a quick and easy way to add a Login/Signup UX to your iOS app.",
-      "homepage":"https://github.com/IcaliaLabs/LoginKit"
+      "title": "HanekeSwift",
+      "category": "images",
+      "description": "A lightweight generic cache for iOS with extra love for images.",
+      "homepage": "https://github.com/Haneke/HanekeSwift"
     },
     {
-      "title":"CollectionViewShelfLayout",
-      "category":"uicollectionview",
-      "description":"A UICollectionViewLayout subclass displays its items as rows of items similar to the App Store Feature tab without a nested UITableView/UICollectionView hack.",
-      "homepage":"https://github.com/pitiphong-p/CollectionViewShelfLayout"
-    },
-    {
-      "title":"SwiftSpreadsheet",
-      "category":"uicollectionview",
-      "description":"Fully customizable spreadsheet CollectionViewLayout.",
-      "homepage":"https://github.com/stuffrabbit/SwiftSpreadsheet"
-    },
-    {
-      "title":"SimpleSource",
-      "category":"uicollectionview",
-      "description":"Easy and type-safe iOS table and collection views.",
-      "homepage":"https://github.com/Squarespace/simple-source "
-    },
-    {
-      "title":"SwiftyOnboard",
-      "category":"walkthrough",
-      "description":"An iOS framework that allows developers to create beautiful onboarding experiences.",
-      "homepage":"https://github.com/juanpablofernandez/SwiftyOnboard"
-    },
-    {
-      "title":"Cluster",
-      "category":"maps",
-      "description":"Easy Map Annotation Clustering.",
-      "homepage":"https://github.com/efremidze/Cluster",
-      "tags":[
-        "map",
-        "cluster",
-        "annotations",
-        "swift",
-        "mapkit"
-      ]
-    },
-    {
-      "title":"BMPlayer",
-      "category":"video",
-      "description":"A video player for iOS, based on AVPlayer, support the horizontal, vertical screen. support adjust volume, brigtness and seek by slide.",
-      "homepage":"https://github.com/BrikerMan/BMPlayer",
-      "tags":[
-        "swift",
-        "avplayer",
-        "video-player",
-        "ios-swift",
-        "carthage"
-      ]
-    },
-    {
-      "title":"TextFieldCounter",
-      "category":"textfield",
-      "description":"UITextField character counter with lovable UX.",
-      "homepage":"https://github.com/serralvo/TextFieldCounter",
-      "tags":[
-        "textfield"
-      ]
-    },
-    {
-      "title":"BouncyLayout",
-      "category":"uicollectionview",
-      "description":"Collection view layout that makes your cells bounce.",
-      "homepage":"https://github.com/roberthein/BouncyLayout"
-    },
-    {
-      "title":"Haptica",
-      "category":"haptic-feedback",
-      "description":"Easy Haptic Feedback Generator.",
-      "homepage":"https://github.com/efremidze/Haptica",
-      "tags":[
+      "title": "Haptica",
+      "category": "haptic-feedback",
+      "description": "Easy Haptic Feedback Generator.",
+      "homepage": "https://github.com/efremidze/Haptica",
+      "tags": [
         "haptic",
         "taptic",
         "vibrate",
@@ -5472,552 +3589,575 @@
       ]
     },
     {
-      "title":"NotificationBanner",
-      "category":"alert",
-      "description":"The easiest way to display highly customizable in app notification banners in iOS.",
-      "homepage":"https://github.com/Daltron/NotificationBanner"
+      "title": "Harbeth",
+      "category": "images",
+      "description": "Metal API for GPU accelerated Graphics and Video and Camera filter framework.",
+      "homepage": "https://github.com/yangKJ/Harbeth"
     },
     {
-      "title":"Pageboy",
-      "category":"pagination",
-      "description":"A simple, highly informative page view controller.",
-      "homepage":"https://github.com/uias/Pageboy",
-      "tags":[
-        "pagination",
-        "paging",
-        "uipageviewcontroller",
-        "pager",
-        "swift"
-      ]
+      "title": "Heimdallr.swift",
+      "category": "network",
+      "description": "Easy to use OAuth 2 library for iOS.",
+      "homepage": "https://github.com/trivago/Heimdallr.swift"
     },
     {
-      "title":"Tabman",
-      "category":"tab",
-      "description":"A powerful paging view controller with indicator bar.",
-      "homepage":"https://github.com/uias/Tabman",
-      "tags":[
-        "uitabbar",
-        "tabbar",
-        "uipageviewcontroller",
-        "pager",
-        "swift"
-      ]
-    },
-    {
-      "title":"CardTabBar",
-      "category":"tab",
-      "description":"Adding animation to iOS tabbar items.",
-      "homepage":"https://github.com/yusadogru/CardTabBar",
-      "tags":[
-        "uitabbar",
-        "tabbar",
-        "cardTabBar",
-        "uitabbaritem",
-        "uitabbarviewcontroller",
-        "swift"
-      ]
-    },
-    {
-      "title":"SpreadsheetView",
-      "category":"ui",
-      "description":"Full configurable spreadsheet view user interfaces for iOS applications.",
-      "homepage":"https://github.com/kishikawakatsumi/SpreadsheetView",
-      "tags":[
-        "spreadsheet"
-      ]
-    },
-    {
-      "title":"LicensePlist",
-      "category":"ui",
-      "description":"A command-line tool that automatically generates a Plist of all your dependencies.",
-      "homepage":"https://github.com/mono0926/LicensePlist",
-      "tags":[
-        "license",
-        "ui"
-      ]
-    },
-    {
-      "title":"FSPagerView",
-      "category":"uicollectionview",
-      "description":"Elegant Screen Slide Library. It is extremely helpful for making Banner View、Product Show、Welcome/Guide Pages、Screen/ViewController Sliders.",
-      "homepage":"https://github.com/WenchaoD/FSPagerView",
-      "tags":[
-        "infnite-scroll",
-        "banner-view",
-        "banner-slider",
-        "banner",
-        "uicollectionview",
-        "pages"
-      ]
-    },
-    {
-      "title":"CBPinEntryView",
-      "category":"textfield",
-      "description":"Easy to use, very customisable pin entry.",
-      "homepage":"https://github.com/Fawxy/CBPinEntryView"
-    },
-    {
-      "title":"GMarkdown",
-      "category":"text",
-      "description":"Markdown rendering library for iOS with support for tables, LaTeX, Mermaid, and code highlighting.",
-      "homepage":"https://github.com/GIKICoder/GMarkdown"
-    },
-    {
-      "title":"MarkdownView",
-      "category":"text",
-      "description":"iOS Markdown view.",
-      "homepage":"https://github.com/keitaoouchi/MarkdownView"
-    },
-    {
-      "title":"SwiftCssParser",
-      "category":"template",
-      "description":"Extensible CSS parser.",
-      "homepage":"https://github.com/100mango/SwiftCssParser"
-    },
-    {
-      "title":"Themes",
-      "category":"styling",
-      "description":"Theme management.",
-      "homepage":"https://github.com/onmyway133/EasyTheme"
-    },
-    {
-      "title":"FanMenu",
-      "category":"menu",
-      "description":"Menu with a circular layout based on Macaw.",
-      "homepage":"https://github.com/exyte/fan-menu"
-    },
-    {
-      "title":"Umbrella",
-      "category":"analytics",
-      "description":"Analytics abstraction layer.",
-      "homepage":"https://github.com/devxoul/Umbrella"
-    },
-    {
-      "title":"LGButton",
-      "category":"button",
-      "description":"A fully customisable subclass of the native UIControl which allows you to create beautiful buttons without writing any line of code.",
-      "homepage":"https://github.com/loregr/LGButton"
-    },
-    {
-      "title":"ImageViewer",
-      "category":"images",
-      "description":"An image viewer à la Twitter.",
-      "homepage":"https://github.com/Krisiacik/ImageViewer"
-    },
-    {
-      "title":"Zip Foundation",
-      "category":"zip",
-      "description":"A library to create, read and modify ZIP archive files.",
-      "homepage":"https://github.com/weichsel/ZIPFoundation"
-    },
-    {
-      "title":"Bluejay",
-      "category":"bluetooth",
-      "description":"A simple framework for building reliable Bluetooth LE apps.",
-      "homepage":"https://github.com/steamclock/bluejay"
-    },
-    {
-      "title":"PryntTrimmerView",
-      "category":"video",
-      "description":"Trim and crop videos.",
-      "homepage":"https://github.com/HHK1/PryntTrimmerView"
-    },
-    {
-      "title":"GridView",
-      "category":"uitableview",
-      "description":"Can be customized as a time table, spreadsheet, paging and more.",
-      "homepage":"https://github.com/KyoheiG3/GridView"
-    },
-    {
-      "title":"StepProgressView",
-      "category":"ui",
-      "description":"Step-by-step progress view with labels and shapes. A good replacement for UIActivityIndicatorView and UIProgressView.",
-      "homepage":"https://github.com/yonat/StepProgressView"
-    },
-    {
-      "title":"MultiToggleButton",
-      "category":"button",
-      "description":"A UIButton subclass that implements tap-to-toggle button text (like the camera flash and timer buttons).",
-      "homepage":"https://github.com/yonat/MultiToggleButton"
-    },
-    {
-      "title":"AGCircularPicker",
-      "category":"ui",
-      "description":"Helpful component for creating a controller aimed to manage any calculated parameter.",
-      "homepage":"https://github.com/agilie/AGCircularPicker",
-      "tags":[
-        "iOS",
-        "swift",
-        "color",
-        "circular-picker",
-        "picker"
-      ]
-    },
-    {
-      "title":"ParallaxHeader",
-      "category":"uitableview",
-      "description":"Simple way to add parallax header to UIScrollView/UITableView.",
-      "homepage":"https://github.com/romansorochak/ParallaxHeader"
-    },
-    {
-      "title":"DeckTransition",
-      "category":"ui",
-      "description":"A library to recreate the iOS 10 Apple Music now playing transition.",
-      "homepage":"https://github.com/HarshilShah/DeckTransition"
-    },
-    {
-      "title":"MessageKit",
-      "category":"chat",
-      "description":"A community-driven replacement for JSQMessagesViewController.",
-      "homepage":"https://github.com/MessageKit/MessageKit"
-    },
-    {
-      "title":"Inkwell",
-      "category":"fonts",
-      "description":"An inkwell to use custom fonts on the fly.",
-      "homepage":"https://github.com/ninjaprox/Inkwell"
-    },
-    {
-      "title":"InstantSearch iOS",
-      "category":"ui",
-      "description":"A library of widgets and helpers to build instant-search features on iOS.",
-      "homepage":"https://github.com/algolia/instantsearch-ios"
-    },
-    {
-      "title":"XcodeGen",
-      "category":"misc",
-      "description":"Tool for generating Xcode projects from a YAML file and your project directory.",
-      "homepage":"https://github.com/yonaskolb/XcodeGen"
-    },
-    {
-      "title":"ARKit-CoreLocation",
-      "category":"augmented-reality",
-      "description":"Combines the high accuracy of AR with the scale of GPS data.",
-      "homepage":"https://github.com/AndrewHartAR/ARKit-CoreLocation"
-    },
-    {
-      "title":"ARKit-Navigation",
-      "category":"augmented-reality",
-      "description":"Navigation in augmented reality with MapKit.",
-      "homepage":"https://github.com/chriswebb09/ARKitNavigationDemo"
-    },
-    {
-      "title":"ShadowsocksX-NG",
-      "category":"network",
-      "description":"A fast tunnel proxy that helps you bypass firewalls.",
-      "homepage":"https://github.com/shadowsocks/ShadowsocksX-NG"
-    },
-    {
-      "title":"LocoKit",
-      "category":"maps",
-      "description":"A location and activity recording framework for iOS.",
-      "homepage":"https://github.com/sobri909/LocoKit"
-    },
-    {
-      "title":"AwesomeSpotlightView",
-      "category":"walkthrough",
-      "description":"Create tutorial or coach tour.",
-      "homepage":"https://github.com/aleksandrshoshiashvili/AwesomeSpotlightView"
-    },
-    {
-      "title":"Stencil",
-      "category":"template",
-      "description":"Simple and powerful template language.",
-      "homepage":"https://github.com/stencilproject/Stencil"
-    },
-    {
-      "title":"ShadowView",
-      "category":"ui",
-      "description":"Make shadows management easy on UIView.",
-      "homepage":"https://github.com/PierrePerrin/ShadowView"
-    },
-    {
-      "title":"TransitionButton",
-      "category":"button",
-      "description":"UIButton subclass for loading and transition animation.",
-      "homepage":"https://github.com/AladinWay/TransitionButton"
-    },
-    {
-      "title":"UltraDrawerView",
-      "category":"ui",
-      "description":"Lightweight, fast and customizable Drawer View implementation identical to Apple Maps, Stocks and etc.",
-      "homepage":"https://github.com/super-ultra/UltraDrawerView"
-    },
-    {
-      "title":"UIDeviceComplete",
-      "category":"device",
-      "description":"UIDevice extensions that fill in the missing pieces.",
-      "homepage":"https://github.com/Nirma/UIDeviceComplete"
-    },
-    {
-      "title":"Cassowary",
-      "category":"auto-layout",
-      "description":"A linear constraint solving library using the same algorithm as AutoLayout.",
-      "homepage":"https://github.com/tribalworldwidelondon/CassowarySwift",
-      "tags":[
-        "cassowary",
-        "constraints",
-        "autolayout"
-      ]
-    },
-    {
-      "title":"Observable",
-      "category":"events",
-      "description":"The easiest way to observe values.",
-      "homepage":"https://github.com/roberthein/Observable",
-      "tags":[
-        "observable",
-        "observer",
-        "reactive"
-      ]
-    },
-    {
-      "title":"AZTableViewController",
-      "category":"uitableview",
-      "description":"Elegant and easy way to integrate pagination with placeholder views.",
-      "homepage":"https://github.com/AfrozZaheer/AZTableViewController"
-    },
-    {
-      "title":"HGPlaceholders",
-      "category":"uitableview",
-      "description":"Nice library to show placeholders and Empty States for any UITableView/UICollectionView in your project.",
-      "homepage":"https://github.com/HamzaGhazouani/HGPlaceholders"
-    },
-    {
-      "title":"DefaultsKit",
-      "category":"key-value-store",
-      "description":"Simple, Strongly Typed UserDefaults for iOS, macOS and tvOS.",
-      "homepage":"https://github.com/nmdias/DefaultsKit"
-    },
-    {
-      "title":"iCard",
-      "category":"payment",
-      "description":"Bank Card Generator using SnapKit DSL.",
-      "homepage":"https://github.com/eliakorkmaz/iCard"
-    },
-    {
-      "title":"MMPlayerView",
-      "category":"video",
-      "description":"Custom AVPlayerLayer on view and transition player with good effect like YouTube and Facebook.",
-      "homepage":"https://github.com/MillmanY/MMPlayerView"
-    },
-    {
-      "title":"SpotifyLogin",
-      "category":"authentication",
-      "description":"Authenticate with the Spotify API.",
-      "homepage":"https://github.com/spotify/SpotifyLogin"
-    },
-    {
-      "title":"VegaScroll",
-      "category":"uicollectionview",
-      "description":"Lightweight animation flowlayout for UICollectionView.",
-      "homepage":"https://github.com/AppliKeySolutions/VegaScroll"
-    },
-    {
-      "title":"MediaBrowser",
-      "category":"ui",
-      "description":"Simple iOS photo and video browser with optional grid view, captions and selections.",
-      "homepage":"https://github.com/younatics/MediaBrowser"
-    },
-    {
-      "title":"Mint",
-      "category":"dependency-managers",
-      "description":"A package manager that installs and runs Swift command line tools.",
-      "homepage":"https://github.com/yonaskolb/Mint"
-    },
-    {
-      "title":"SwiftSoup",
-      "category":"html",
-      "description":"HTML Parser, with best of DOM, CSS, and jquery.",
-      "homepage":"https://github.com/scinfu/SwiftSoup",
-      "tags":[
+      "title": "HeliumLogger",
+      "category": "logging",
+      "description": "IBM's lightweight logging framework.",
+      "homepage": "https://github.com/Kitura/HeliumLogger",
+      "tags": [
         "linux"
       ]
     },
     {
-      "title":"BulletinBoard",
-      "category":"ui",
-      "description":"Generates and manages contextual cards displayed at the bottom of the screen.",
-      "homepage":"https://github.com/alexaubry/BulletinBoard"
+      "title": "Hero",
+      "category": "transition",
+      "description": "Elegant transition library for iOS.",
+      "homepage": "https://github.com/HeroTransitions/Hero"
     },
     {
-      "title":"LifetimeTracker",
-      "category":"utility",
-      "description":"Surface retain cycle / memory issues right as you develop your application.",
-      "homepage":"https://github.com/krzysztofzablocki/LifetimeTracker"
+      "title": "HGCircularSlider",
+      "category": "ui",
+      "description": "A custom reusable circular slider control for iOS application.",
+      "homepage": "https://github.com/HamzaGhazouani/HGCircularSlider"
     },
     {
-      "title":"ShelfView-iOS",
-      "category":"uicollectionview",
-      "description":"iOS custom view to display books on shelf.",
-      "homepage":"https://github.com/tdscientist/ShelfView-iOS"
+      "title": "HGPlaceholders",
+      "category": "uitableview",
+      "description": "Nice library to show placeholders and Empty States for any UITableView/UICollectionView in your project.",
+      "homepage": "https://github.com/HamzaGhazouani/HGPlaceholders"
     },
     {
-      "title":"Bamboo",
-      "category":"auto-layout",
-      "description":"Auto Layout (and manual layout) in one line.",
-      "homepage":"https://github.com/wordlessj/Bamboo"
+      "title": "HHFloatingView",
+      "category": "menu",
+      "description": "An easy to use and setup floating view for your app.",
+      "homepage": "https://github.com/hemangshah/HHFloatingView"
     },
     {
-      "title":"Conferences.digital",
-      "category":"third-party-guides",
-      "description":"Watch conference videos in a native macOS app.",
-      "homepage":"https://github.com/zagahr/Conferences.digital"
+      "title": "HHTabBarView",
+      "category": "tab",
+      "description": "A lightweight customized tab bar view.",
+      "homepage": "https://github.com/hemangshah/HHTabBarView"
     },
     {
-      "title":"Cachyr",
-      "category":"cache",
-      "description":"A small key-value data cache for iOS, macOS and tvOS.",
-      "homepage":"https://github.com/nrkno/yr-cachyr"
+      "title": "HidesNavigationBarWhenPushed",
+      "category": "ui",
+      "description": "A library, which adds the ability to hide navigation bar when view controller is pushed via hidesNavigationBarWhenPushed flag.",
+      "homepage": "https://github.com/gontovnik/HidesNavigationBarWhenPushed"
     },
     {
-      "title":"Closures",
-      "category":"utility",
-      "description":"Swifty closures for UIKit and Foundation.",
-      "homepage":"https://github.com/vhesener/Closures"
+      "title": "Highlighter",
+      "category": "utility",
+      "description": "Highlight whatever you want! Highlighter will magically find UI objects such as UILabel, UITextView, UITexTfield, UIButton in your UITableViewCell or other Class.",
+      "homepage": "https://github.com/younatics/Highlighter"
     },
     {
-      "title":"Corridor",
-      "category":"dependency-injection",
-      "description":"A Coreader-like Dependency Injection μFramework.",
-      "homepage":"https://github.com/symentis/Corridor"
+      "title": "Himotoki",
+      "category": "json",
+      "description": "A type-safe JSON decoding library.",
+      "homepage": "https://github.com/ikesyo/Himotoki"
     },
     {
-      "title":"SwiftyUI",
-      "category":"ui",
-      "description":"High performance and lightweight UIView, UIImage, UIImageView, UIlabel, UIButton and more.",
-      "homepage":"https://github.com/haoking/SwiftyUI"
-    },
-    {
-      "title":"BigInt",
-      "category":"math",
-      "description":"Arbitrary-precision arithmetic.",
-      "homepage":"https://github.com/attaswift/BigInt"
-    },
-    {
-      "title":"KALoader",
-      "category":"ui",
-      "description":"Beautiful animated placeholders for showing loading of data.",
-      "homepage":"https://github.com/Kirillzzy/KALoader"
-    },
-    {
-      "title":"CardsLayout",
-      "category":"uicollectionview",
-      "description":"Nice card-designed custom CollectionView layout.",
-      "homepage":"https://github.com/filletofish/CardsLayout"
-    },
-    {
-      "title":"GravitySlider",
-      "category":"uicollectionview",
-      "description":"Beautiful alternative to the standard UICollectionView flow layout.",
-      "homepage":"https://github.com/ApplikeySolutions/GravitySlider"
-    },
-    {
-      "title":"WhatsNewKit",
-      "category":"utility",
-      "description":"Showcase your awesome new app features.",
-      "homepage":"https://github.com/SvenTiigi/WhatsNewKit"
-    },
-    {
-      "title":"WhatsNew",
-      "category":"utility",
-      "description":"Showcase new features after an app update similar to Pages, Numbers and Keynote.",
-      "homepage":"https://github.com/BalestraPatrick/WhatsNew"
-    },
-    {
-      "title":"TSAO",
-      "category":"utility",
-      "description":"Type-Safe Associated Objects.",
-      "homepage":"https://github.com/lilyball/swift-tsao"
-    },
-    {
-      "title":"AXPhotoViewer",
-      "category":"images",
-      "description":"An iPhone/iPad photo gallery viewer, useful for viewing a large (or small!) number of photos.",
-      "homepage":"https://github.com/alexhillc/AXPhotoViewer"
-    },
-    {
-      "title":"SkeletonView",
-      "category":"ui",
-      "description":"An elegant way to show users that something is happening and also prepare them to which contents he is waiting.",
-      "homepage":"https://github.com/Juanpe/SkeletonView"
-    },
-    {
-      "title":"RxWebSocket",
-      "category":"socket",
-      "description":"Reactive WebSockets.",
-      "homepage":"https://github.com/fjcaetano/RxWebSocket",
-      "tags":[
-        "reactive",
-        "rxswift"
+      "title": "HorizonCalendar",
+      "category": "calendar",
+      "description": "A declarative, performant, iOS calendar UI component that supports use cases ranging from simple date pickers all the way up to fully-featured calendar apps.",
+      "homepage": "https://github.com/airbnb/HorizonCalendar",
+      "tags": [
+        "calendar",
+        "airbnb",
+        "declerative"
       ]
     },
     {
-      "title":"ReCaptcha",
-      "category":"authentication",
-      "description":"[In]visible ReCaptcha for iOS.",
-      "homepage":"https://github.com/fjcaetano/ReCaptcha",
-      "tags":[
-        "google",
-        "reactive",
-        "rxswift",
-        "webview"
+      "title": "HorizontalDial",
+      "category": "ui",
+      "description": "A horizontal scroll dial like Instagram.",
+      "homepage": "https://github.com/kciter/HorizontalDial"
+    },
+    {
+      "title": "HPParallaxHeader",
+      "category": "ui",
+      "description": "Simple parallax header for UIScrollView.",
+      "homepage": "https://github.com/ngochiencse/HPParallaxHeader"
+    },
+    {
+      "title": "HTYTextField",
+      "category": "textfield",
+      "description": "A UITextField with bouncy placeholder.",
+      "homepage": "https://github.com/hanton/HTYTextField"
+    },
+    {
+      "title": "Hue",
+      "category": "colors",
+      "description": "Hue is the all-in-one coloring utility that you'll ever need.",
+      "homepage": "https://github.com/zenangst/Hue"
+    },
+    {
+      "title": "Hydra",
+      "category": "concurrency",
+      "description": "Promises & Await - Write better async code.",
+      "homepage": "https://github.com/malcommac/Hydra"
+    },
+    {
+      "title": "HypeUI",
+      "category": "auto-layout",
+      "description": "🌺 HypeUI is a implementation of Apple's SwiftUI DSL style based on UIKit",
+      "homepage": "https://github.com/hyperconnect/HypeUI"
+    },
+    {
+      "title": "IBAnimatable",
+      "category": "animation",
+      "description": "Design and prototype UI, interaction, navigation, transition and animation for App Store ready Apps in Interface Builder with IBAnimatable.",
+      "homepage": "https://github.com/IBAnimatable/IBAnimatable"
+    },
+    {
+      "title": "IBLinter",
+      "category": "quality",
+      "description": "A linter tool for Interface Builder.",
+      "homepage": "https://github.com/IBDecodable/IBLinter"
+    },
+    {
+      "title": "IBLocalizable",
+      "category": "localization",
+      "description": "Localize your views directly in Interface Builder with IBLocalizable.",
+      "homepage": "https://github.com/PiXeL16/IBLocalizable"
+    },
+    {
+      "title": "iCard",
+      "category": "payment",
+      "description": "Bank Card Generator using SnapKit DSL.",
+      "homepage": "https://github.com/eliakorkmaz/iCard"
+    },
+    {
+      "title": "IDZSwiftCommonCrypto",
+      "category": "cryptography",
+      "description": "A wrapper for Apple's Common Crypto library.",
+      "homepage": "https://github.com/iosdevzone/IDZSwiftCommonCrypto"
+    },
+    {
+      "title": "IGColorPicker",
+      "category": "ui",
+      "description": "A customizable color picker for iOS.",
+      "homepage": "https://github.com/iGenius-Srl/IGColorPicker",
+      "tags": [
+        "iOS",
+        "swift",
+        "color",
+        "color-picker",
+        "picker"
       ]
     },
     {
-      "title":"FlowingMenu",
-      "category":"menu",
-      "description":"Interactive view transition to display menus with flowing and bouncing effects.",
-      "homepage":"https://github.com/yannickl/FlowingMenu"
+      "title": "IGStoryButtonKit",
+      "category": "button",
+      "description": "Easy-to-use button with rich animation inspired by instagram stories.",
+      "homepage": "https://github.com/KaoruMuta/IGStoryButtonKit"
     },
     {
-      "title":"Windless",
-      "category":"ui",
-      "description":"Windless makes it easy to implement invisible layout loading view.",
-      "homepage":"https://github.com/ParkGwangBeom/Windless"
+      "title": "IHKeyboardAvoiding",
+      "category": "keyboard",
+      "description": "An elegant solution for keeping any UIView visible when the keyboard is being shown. No UIScrollView required.",
+      "homepage": "https://github.com/IdleHandsApps/IHKeyboardAvoiding",
+      "tags": [
+        "iOS",
+        "swift",
+        "keyboard"
+      ]
     },
     {
-      "title":"CalendarView",
-      "category":"calendar",
-      "description":"Calendar Component, It features both vertical and horizontal layout (and scrolling) and the display of native calendar events.",
-      "homepage":"https://github.com/mmick66/CalendarView"
+      "title": "ImageDetect",
+      "category": "images",
+      "description": "Detect and crop faces, barcodes and texts in image with iOS 11 Vision API.",
+      "homepage": "https://github.com/Feghal/ImageDetect"
     },
     {
-      "title":"Mandoline",
-      "category":"ui",
-      "description":"An iOS picker view to serve all your 'picking' needs.",
-      "homepage":"https://github.com/blueapron/Mandoline"
+      "title": "ImageLoader",
+      "category": "images",
+      "description": "A lightweight and fast image loader for iOS.",
+      "homepage": "https://github.com/hirohisa/ImageLoaderSwift"
     },
     {
-      "title":"YMTreeMap",
-      "category":"ui",
-      "description":"Treemap / Heatmap layout engine, based on Squarified.",
-      "homepage":"https://github.com/yahoo/YMTreeMap"
+      "title": "ImageScout",
+      "category": "images",
+      "description": "Implementation of [fastimage](https://pypi.org/project/fastimage/0.2.1/) - supports PNG, GIF, and JPEG.",
+      "homepage": "https://github.com/kaishin/ImageScout"
     },
     {
-      "title":"VueFlux",
-      "category":"events",
-      "description":"Unidirectional Data Flow State Management Architecture - Inspired by Vuex and Flux.",
-      "homepage":"https://github.com/ra1028/VueFlux"
+      "title": "ImageTransition",
+      "category": "transition",
+      "description": "ImageTransition is a library for smooth animation of images during transitions.",
+      "homepage": "https://github.com/shtnkgm/ImageTransition"
     },
     {
-      "title":"Ciao",
-      "category":"network",
-      "description":"Publish and discover services using mDNS (Bonjour, Zeroconf).",
-      "homepage":"https://github.com/AlTavares/Ciao"
+      "title": "ImageViewer",
+      "category": "images",
+      "description": "An image viewer à la Twitter.",
+      "homepage": "https://github.com/Krisiacik/ImageViewer"
     },
     {
-      "title":"Chronology",
-      "category":"date",
-      "description":"Building a better date/time library.",
-      "homepage":"https://github.com/davedelong/time"
+      "title": "ImagineEngine",
+      "category": "game-engine-2d",
+      "description": "Blazing fasst 2D gaming engine.",
+      "homepage": "https://github.com/JohnSundell/ImagineEngine"
     },
     {
-      "title":"L10n-swift",
-      "category":"localization",
-      "description":"Localization of an application with ability to change language \"on the fly\" and support for plural forms in any language.",
-      "homepage":"https://github.com/Decybel07/L10n-swift",
-      "tags":[
+      "title": "ImgixSwift",
+      "category": "images",
+      "description": "Easily update image urls to be fast and responsive.",
+      "homepage": "https://github.com/imgix/imgix-swift"
+    },
+    {
+      "title": "InAppPurchase",
+      "category": "app-store",
+      "description": "A Simple, Lightweight and Safe framework for In App Purchase.",
+      "homepage": "https://github.com/jinSasaki/InAppPurchase"
+    },
+    {
+      "title": "IncrementableLabel",
+      "category": "label",
+      "description": "An UILabel subclass to (de)increment numbers in an UILabel.",
+      "homepage": "https://github.com/tbaranes/IncrementableLabel"
+    },
+    {
+      "title": "Inkwell",
+      "category": "fonts",
+      "description": "An inkwell to use custom fonts on the fly.",
+      "homepage": "https://github.com/ninjaprox/Inkwell"
+    },
+    {
+      "title": "Input Mask",
+      "category": "validation",
+      "description": "Pattern-based user input formatter, parser and validator for iOS.",
+      "homepage": "https://github.com/RedMadRobot/input-mask-ios"
+    },
+    {
+      "title": "InputBarAccessoryView",
+      "category": "chat",
+      "description": "A simple and easily customizable InputAccessoryView for making powerful input bars with autocomplete and attachments.",
+      "homepage": "https://github.com/nathantannar4/InputBarAccessoryView"
+    },
+    {
+      "title": "Insert3D",
+      "category": "ui-3d",
+      "description": "The fastest 🚀 way to embed a 3D model.",
+      "homepage": "https://github.com/Viktoo/Insert3D"
+    },
+    {
+      "title": "InstantSearch iOS",
+      "category": "ui",
+      "description": "A library of widgets and helpers to build instant-search features on iOS.",
+      "homepage": "https://github.com/algolia/instantsearch-ios"
+    },
+    {
+      "title": "Instructions",
+      "category": "walkthrough",
+      "description": "A library to create app walkthroughs and guided tours.",
+      "homepage": "https://github.com/ephread/Instructions"
+    },
+    {
+      "title": "InteractiveSideMenu",
+      "category": "menu",
+      "description": "Customizable iOS Interactive Side Menu.",
+      "homepage": "https://github.com/handsomecode/InteractiveSideMenu"
+    },
+    {
+      "title": "Interpolate",
+      "category": "animation",
+      "description": "Interpolation framework for creating interactive gesture-driven animations.",
+      "homepage": "https://github.com/marmelroy/Interpolate"
+    },
+    {
+      "title": "Introducing SwiftUI",
+      "category": "official-guides",
+      "description": "Official SwiftUI tutorial with 4+ hours of content and interactive tutorials.",
+      "homepage": "https://developer.apple.com/tutorials/swiftui"
+    },
+    {
+      "title": "IoniconsKit",
+      "category": "fonts",
+      "description": "Use ionicons as UIImage / UIFont in your projects.",
+      "homepage": "https://github.com/keitaoouchi/IoniconsKit"
+    },
+    {
+      "title": "iOS project template",
+      "category": "boilerplates",
+      "description": "iOS project template with fastlane lanes, Travis CI jobs and GitHub integrations of Codecov, HoundCI for SwiftLint and Danger.",
+      "homepage": "https://github.com/messeb/ios-project-template"
+    },
+    {
+      "title": "iPages",
+      "category": "pagination",
+      "description": "Quickly implement swipable page views in SwiftUI 📝.",
+      "homepage": "https://github.com/blsage/iPages",
+      "tags": [
+        "iOS",
+        "swift",
+        "pagination",
+        "swiftui",
+        "pagecontrol",
+        "UIPageControl",
+        "UIPageViewController"
+      ]
+    },
+    {
+      "title": "IQKeyboardManager",
+      "category": "keyboard",
+      "description": "Codeless drop-in universal library allows to prevent issues of keyboard sliding up and cover UITextField/UITextView.",
+      "homepage": "https://github.com/hackiftekhar/IQKeyboardManager"
+    },
+    {
+      "title": "ISEmojiView",
+      "category": "keyboard",
+      "description": "Emoji Keyboard for iOS",
+      "homepage": "https://github.com/isaced/ISEmojiView",
+      "tags": [
+        "swift",
+        "emoji"
+      ]
+    },
+    {
+      "title": "iTextField ⌨️",
+      "category": "textfield",
+      "description": "A fully-wrapped `UITextField` that works entirely in SwiftUI 🦅.",
+      "homepage": "https://github.com/blsage/iTextField",
+      "tags": [
+        "iOS",
+        "swift",
+        "swiftui",
+        "textfield",
+        "UITextField",
+        "viewmodifiers"
+      ]
+    },
+    {
+      "title": "JASON",
+      "category": "json",
+      "description": "JSON parsing with outstanding performances and convenient operators.",
+      "homepage": "https://github.com/delba/JASON"
+    },
+    {
+      "title": "jazzy",
+      "category": "documentation",
+      "description": "Soulful docs.",
+      "homepage": "https://github.com/realm/jazzy/"
+    },
+    {
+      "title": "Jelly",
+      "category": "transition",
+      "description": "Jelly provides custom view controller transitions with just a few lines of code.",
+      "homepage": "https://github.com/SebastianBoldt/Jelly"
+    },
+    {
+      "title": "JLStickerTextView",
+      "category": "images",
+      "description": "A UIImageView allow you to add multiple Label (multiple line text support) on it, you can edit, rotate, resize the Label as you want with one finger ,then render the text on Image.",
+      "homepage": "https://github.com/Textcat/JLStickerTextView"
+    },
+    {
+      "title": "JOSESwift",
+      "category": "cryptography",
+      "description": "A framework for the JOSE standards JWS, JWE, and JWK.",
+      "homepage": "https://github.com/airsidemobile/JOSESwift"
+    },
+    {
+      "title": "JSONHelper",
+      "category": "json",
+      "description": "Lightning fast JSON deserialization and value conversion library for iOS & OS X.",
+      "homepage": "https://github.com/isair/JSONHelper"
+    },
+    {
+      "title": "JSONNeverDie",
+      "category": "json",
+      "description": "Auto reflection tool from JSON to Model, user friendly JSON encoder / decoder, aims to never die.",
+      "homepage": "https://github.com/johnlui/JSONNeverDie"
+    },
+    {
+      "title": "JSQCoreDataKit",
+      "category": "core-data",
+      "description": "A swifter Core Data stack.",
+      "homepage": "https://github.com/jessesquires/JSQCoreDataKit"
+    },
+    {
+      "title": "JTAppleCalendar",
+      "category": "calendar",
+      "description": "UI calendar handler.",
+      "homepage": "https://github.com/patchthecode/JTAppleCalendar"
+    },
+    {
+      "title": "Just",
+      "category": "network",
+      "description": "HTTP for Humans (a python-requests style HTTP library).",
+      "homepage": "https://github.com/dduan/Just",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "JustPersist",
+      "category": "core-data",
+      "description": "Easiest and safest way to do persistence on iOS with Core Data support out of the box.",
+      "homepage": "https://github.com/justeat/JustPersist"
+    },
+    {
+      "title": "JWSETKit",
+      "category": "cryptography",
+      "description": "JOSE library with JWS, JWT, JWE, and JWK support.",
+      "homepage": "https://github.com/amosavian/JWSETKit"
+    },
+    {
+      "title": "KALoader",
+      "category": "ui",
+      "description": "Beautiful animated placeholders for showing loading of data.",
+      "homepage": "https://github.com/Kirillzzy/KALoader"
+    },
+    {
+      "title": "Kamagari",
+      "category": "alert",
+      "description": "Simple UIAlertController builder class.",
+      "homepage": "https://github.com/tasanobu-zz/Kamagari"
+    },
+    {
+      "title": "Kanna",
+      "category": "html",
+      "description": "Another XML/HTML parser.",
+      "homepage": "https://github.com/tid-kijyun/Kanna"
+    },
+    {
+      "title": "Kanvas",
+      "category": "images",
+      "description": "A iOS library for adding effects, drawings, text, stickers, and making GIFs from existing media or the camera.",
+      "homepage": "https://github.com/tumblr/kanvas-ios"
+    },
+    {
+      "title": "Katana",
+      "category": "events",
+      "description": "Write apps a la React and Redux.",
+      "homepage": "https://github.com/BendingSpoons/katana-swift"
+    },
+    {
+      "title": "KDEDateLabel",
+      "category": "label",
+      "description": "An UILabel subclass that updates itself to make time ago's format easier.",
+      "homepage": "https://github.com/delannoyk/KDEDateLabel"
+    },
+    {
+      "title": "KeyboardHideManager",
+      "category": "keyboard",
+      "description": "Codeless manager to hide keyboard by tapping on views for iOS.",
+      "homepage": "https://github.com/bonyadmitr/KeyboardHideManager",
+      "tags": [
+        "iOS",
+        "swift",
+        "keyboard"
+      ]
+    },
+    {
+      "title": "KeyboardShortcuts",
+      "category": "keyboard",
+      "description": "Add user-customizable global keyboard shortcuts to your macOS app. Includes a Cocoa and SwiftUI component.",
+      "homepage": "https://github.com/sindresorhus/KeyboardShortcuts",
+      "tags": [
+        "swiftui",
+        "swift-package-manager",
+        "swift-library",
+        "macos",
+        "hotkey",
+        "shortcut"
+      ]
+    },
+    {
+      "title": "keychain-swift",
+      "category": "keychain",
+      "description": "Helper functions for saving text in Keychain securely for iOS, OS X, tvOS and watchOS.",
+      "homepage": "https://github.com/evgenyneu/keychain-swift"
+    },
+    {
+      "title": "KeychainAccess",
+      "category": "keychain",
+      "description": "Simple wrapper for Keychain that works on iOS and OS X.",
+      "homepage": "https://github.com/kishikawakatsumi/KeychainAccess"
+    },
+    {
+      "title": "KeyPathKit",
+      "category": "other-data",
+      "description": "KeyPathKit provides a seamless syntax to manipulate data using typed keypaths.",
+      "homepage": "https://github.com/vincent-pradeilles/KeyPathKit"
+    },
+    {
+      "title": "Kingfisher",
+      "category": "images",
+      "description": "Image download and caching.",
+      "homepage": "https://github.com/onevcat/Kingfisher"
+    },
+    {
+      "title": "Kitsunebi",
+      "category": "video",
+      "description": "Overlay alpha channel video animation player view using OpenGLES.",
+      "homepage": "https://github.com/noppefoxwolf/Kitsunebi"
+    },
+    {
+      "title": "Kitura",
+      "category": "webserver",
+      "description": "IBM's web framework and server for web services.",
+      "homepage": "https://github.com/Kitura/Kitura",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "KMNavigationBarTransition",
+      "category": "ui",
+      "description": "A drop-in universal library helps you to manage the navigation bar styles and makes transition animations smooth between different navigation bar styles while pushing or popping a view controller for all orientations.",
+      "homepage": "https://github.com/MoZhouqi/KMNavigationBarTransition"
+    },
+    {
+      "title": "KMPlaceholderTextView",
+      "category": "ui",
+      "description": "A UITextView subclass that adds support for multiline placeholder.",
+      "homepage": "https://github.com/MoZhouqi/KMPlaceholderTextView"
+    },
+    {
+      "title": "KRProgressHUD",
+      "category": "hud",
+      "description": "A beautiful and customizable progress HUD.",
+      "homepage": "https://github.com/krimpedance/KRProgressHUD"
+    },
+    {
+      "title": "KVConstraintKit",
+      "category": "auto-layout",
+      "description": "An Impressive Autolayout DSL for iOS, tvOS & OSX.",
+      "homepage": "https://github.com/keshavvishwkarma/KVConstraintKit"
+    },
+    {
+      "title": "KVKCalendar",
+      "category": "calendar",
+      "description": "A most fully customization calendar for Apple platforms 📅",
+      "homepage": "https://github.com/kvyatkovskys/KVKCalendar",
+      "tags": [
+        "uikit",
+        "iOS",
+        "calendar",
+        "swiftui"
+      ]
+    },
+    {
+      "title": "KWDrawerController",
+      "category": "menu",
+      "description": "Drawer view controller that easy to use.",
+      "homepage": "https://github.com/Kawoou/KWDrawerController"
+    },
+    {
+      "title": "KZFileWatchers",
+      "category": "files",
+      "description": "A micro-framework for observing file changes, both local and remote.",
+      "homepage": "https://github.com/krzysztofzablocki/KZFileWatchers"
+    },
+    {
+      "title": "L10n-swift",
+      "category": "localization",
+      "description": "Localization of an application with ability to change language \"on the fly\" and support for plural forms in any language.",
+      "homepage": "https://github.com/Decybel07/L10n-swift",
+      "tags": [
         "l10n",
         "localization",
         "plurals",
@@ -6028,35 +4168,2073 @@
       ]
     },
     {
-      "title":"CountryPickerView",
-      "category":"ui",
-      "description":"A simple, customizable view for efficiently collecting country information in iOS apps.",
-      "homepage":"https://github.com/kizitonwose/CountryPickerView"
+      "title": "L10nLint",
+      "category": "quality",
+      "description": "A linter tool for Localizable.strings.",
+      "homepage": "https://github.com/s2mr/L10nLint"
     },
     {
-      "title":"Sprinter",
-      "category":"text",
-      "description":"A library for formatting strings.",
-      "homepage":"https://github.com/nicklockwood/Sprinter"
+      "title": "Latch",
+      "category": "keychain",
+      "description": "A simple Keychain Wrapper for iOS.",
+      "homepage": "https://github.com/endocrimes/Latch"
     },
     {
-      "title":"CollectionViewSlantedLayout",
-      "category":"uicollectionview",
-      "description":"UICollectionViewLayout to show slanted content.",
-      "homepage":"https://github.com/yacir/CollectionViewSlantedLayout"
+      "title": "LaunchAtLogin",
+      "category": "system",
+      "description": "Easily add 'Launch at Login' functionality to your sandboxed macOS app.",
+      "homepage": "https://github.com/sindresorhus/LaunchAtLogin-Legacy"
     },
     {
-      "title":"Sukari",
-      "category":"Syntactic Sugar",
-      "description":"Sweet Syntactic Sugar.",
-      "homepage":"https://github.com/christopherkarani/Sukari"
+      "title": "LayoutLess",
+      "category": "layout",
+      "description": "Write less UI Code.",
+      "homepage": "https://github.com/DeclarativeHub/Layoutless",
+      "swift": 4
     },
     {
-      "title":"Shiny",
-      "category":"ui",
-      "description":"Iridescent Effect View (inspired by Apple Pay Cash).",
-      "homepage":"https://github.com/efremidze/Shiny",
-      "tags":[
+      "title": "LeeGo",
+      "category": "ui",
+      "description": "Declarative, configurable & highly reusable UI development as making Lego bricks.",
+      "homepage": "https://github.com/wangshengjia/LeeGo"
+    },
+    {
+      "title": "LeetCode-Swift",
+      "category": "other-data",
+      "description": "Solutions to LeetCode interview questions.",
+      "homepage": "https://github.com/soapyigu/LeetCode-Swift"
+    },
+    {
+      "title": "LetterAvatarKit",
+      "category": "images",
+      "description": "A UIImage extension that generates letter-based avatars.",
+      "homepage": "https://github.com/vpeschenkov/LetterAvatarKit"
+    },
+    {
+      "title": "LGButton",
+      "category": "button",
+      "description": "A fully customisable subclass of the native UIControl which allows you to create beautiful buttons without writing any line of code.",
+      "homepage": "https://github.com/loregr/LGButton"
+    },
+    {
+      "title": "LicensePlist",
+      "category": "ui",
+      "description": "A command-line tool that automatically generates a Plist of all your dependencies.",
+      "homepage": "https://github.com/mono0926/LicensePlist",
+      "tags": [
+        "license",
+        "ui"
+      ]
+    },
+    {
+      "title": "LifetimeTracker",
+      "category": "utility",
+      "description": "Surface retain cycle / memory issues right as you develop your application.",
+      "homepage": "https://github.com/krzysztofzablocki/LifetimeTracker"
+    },
+    {
+      "title": "Lightbox",
+      "category": "images",
+      "description": "A convenient and easy to use image viewer for your iOS app.",
+      "homepage": "https://github.com/hyperoslo/Lightbox"
+    },
+    {
+      "title": "Lightning",
+      "category": "webserver",
+      "description": "Multiplatform Single-threaded Non-blocking Web and Networking Framework.",
+      "homepage": "https://github.com/skylab-inc/Lightning",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "LightRoute",
+      "category": "app-routing",
+      "description": "Routing between VIPER modules.",
+      "homepage": "https://github.com/SpectralDragon/LiteRoute"
+    },
+    {
+      "title": "LightweightObservable",
+      "category": "events",
+      "description": "A lightweight implementation of an observable sequence that you can subscribe to.",
+      "homepage": "https://github.com/fxm90/LightweightObservable",
+      "tags": [
+        "swift",
+        "observable",
+        "observer",
+        "reactive"
+      ]
+    },
+    {
+      "title": "LineNoise",
+      "category": "command-line",
+      "description": "A zero-dependency replacement for readline.",
+      "homepage": "https://github.com/andybest/linenoise-swift",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "LinkedIn",
+      "category": "style-guides",
+      "description": "LinkedIn's Official Style Guide.",
+      "homepage": "https://github.com/linkedin/swift-style-guide"
+    },
+    {
+      "title": "LinkedInSignIn",
+      "category": "authentication",
+      "description": "Simple view controller to log in and retrieve an access token from LinkedIn.",
+      "homepage": "https://github.com/serhii-londar/LinkedInSignIn"
+    },
+    {
+      "title": "Linker",
+      "category": "app-routing",
+      "description": "Lightweight way to handle internal and external deeplinks for iOS.",
+      "homepage": "https://github.com/MaksimKurpa/Linker"
+    },
+    {
+      "title": "LiquidLoader",
+      "category": "ui",
+      "description": "Spinner loader components with liquid animation.",
+      "homepage": "https://github.com/yoavlt/LiquidLoader"
+    },
+    {
+      "title": "LiquidSwipe",
+      "category": "transition",
+      "description": "Liquid navigation animation",
+      "homepage": "https://github.com/exyte/LiquidSwipe"
+    },
+    {
+      "title": "Live",
+      "category": "streaming",
+      "description": "Demonstrate how to build a live broadcast app.",
+      "homepage": "https://github.com/ltebean/Live"
+    },
+    {
+      "title": "LoadingShimmer",
+      "category": "ui",
+      "description": "An easy way to add a shimmering effect to any view with just one line of code. It is useful as an unobtrusive loading indicator.",
+      "homepage": "https://github.com/jogendra/LoadingShimmer"
+    },
+    {
+      "title": "Loaf",
+      "category": "alert",
+      "description": "A simple framework for easy iOS Toasts.",
+      "homepage": "https://github.com/schmidyy/Loaf",
+      "tags": [
+        "toast",
+        "alert"
+      ]
+    },
+    {
+      "title": "LocalizationKit",
+      "category": "localization",
+      "description": "Realtime dynamic localization of your app with remote management so you can manage maintain and deploy translations without resubmitting app.",
+      "homepage": "https://github.com/willpowell8/LocalizationKit_iOS",
+      "tags": [
+        "extensions",
+        "ios"
+      ]
+    },
+    {
+      "title": "Localize",
+      "category": "localization",
+      "description": "Localize apps using e.g. regular expressions in Localizable.strings.",
+      "homepage": "https://github.com/andresilvagomez/Localize"
+    },
+    {
+      "title": "Localize-Swift",
+      "category": "localization",
+      "description": "Localize apps using e.g. regular expressions in Localizable.strings.",
+      "homepage": "https://github.com/marmelroy/Localize-Swift"
+    },
+    {
+      "title": "Locatable",
+      "category": "dependency-injection",
+      "description": "A micro-framework that leverages Property Wrappers to implement the Service Locator pattern.",
+      "homepage": "https://github.com/vincent-pradeilles/locatable",
+      "tags": [
+        "swift",
+        "dependency",
+        "property wrapper"
+      ]
+    },
+    {
+      "title": "Locheck",
+      "category": "localization",
+      "description": "Validate .strings and .stringsdict files for errors",
+      "homepage": "https://github.com/Asana/locheck"
+    },
+    {
+      "title": "LocoKit",
+      "category": "maps",
+      "description": "A location and activity recording framework for iOS.",
+      "homepage": "https://github.com/sobri909/LocoKit"
+    },
+    {
+      "title": "LoginKit",
+      "category": "authentication",
+      "description": "LoginKit is a quick and easy way to add a Login/Signup UX to your iOS app.",
+      "homepage": "https://github.com/IcaliaLabs/LoginKit"
+    },
+    {
+      "title": "lottie-ios",
+      "category": "animation",
+      "description": "An iOS library to natively render After Effects vector animations.",
+      "homepage": "https://github.com/airbnb/lottie-ios",
+      "tags": [
+        "swift",
+        "animation"
+      ]
+    },
+    {
+      "title": "LTHRadioButton",
+      "category": "button",
+      "description": "A radio button with a pretty animation.",
+      "homepage": "https://github.com/rolandleth/LTHRadioButton"
+    },
+    {
+      "title": "LTMorphingLabel",
+      "category": "label",
+      "description": "Graceful morphing effects for UILabel.",
+      "homepage": "https://github.com/lexrus/LTMorphingLabel"
+    },
+    {
+      "title": "Luminous",
+      "category": "device",
+      "description": "Get everything you need to know about the device.",
+      "homepage": "https://github.com/andrealufino/Luminous",
+      "tags": [
+        "device",
+        "system"
+      ]
+    },
+    {
+      "title": "Lumos",
+      "category": "utility",
+      "description": "An easy-to-use API for Objective-C runtime functions.",
+      "homepage": "https://github.com/sushinoya/Lumos"
+    },
+    {
+      "title": "Macaw",
+      "category": "ui",
+      "description": "Powerful and easy-to-use vector graphics library with SVG support.",
+      "homepage": "https://github.com/exyte/macaw"
+    },
+    {
+      "title": "Magnetic",
+      "category": "ui",
+      "description": "SpriteKit Floating Bubble Picker (inspired by Apple Music).",
+      "homepage": "https://github.com/efremidze/Magnetic",
+      "tags": [
+        "spritekit",
+        "floating",
+        "bubble",
+        "picker",
+        "applemusic",
+        "swift"
+      ]
+    },
+    {
+      "title": "Malibu",
+      "category": "network",
+      "description": "A networking library built on promises.",
+      "homepage": "https://github.com/hyperoslo/Malibu"
+    },
+    {
+      "title": "Mandoline",
+      "category": "ui",
+      "description": "An iOS picker view to serve all your 'picking' needs.",
+      "homepage": "https://github.com/blueapron/Mandoline"
+    },
+    {
+      "title": "MantleModal",
+      "category": "ui",
+      "description": "A simple modal resource that uses a UIScrollView to allow the user to close the modal by dragging it down.",
+      "homepage": "https://github.com/canalesb93/MantleModal"
+    },
+    {
+      "title": "MapleBacon",
+      "category": "images",
+      "description": "Image download and caching library.",
+      "homepage": "https://github.com/JanGorman/MapleBacon"
+    },
+    {
+      "title": "MarkdownDisplayView",
+      "category": "text",
+      "description": "A Markdown rendering component built on TextKit 2, providing smooth performance, rich customization options, and support for streaming AI-driven conversational interactions.",
+      "homepage": "https://github.com/zjc19891106/MarkdownDisplayView"
+    },
+    {
+      "title": "MarkdownKit",
+      "category": "text",
+      "description": "A simple and customizable Markdown Parser.",
+      "homepage": "https://github.com/bmoliveira/MarkdownKit"
+    },
+    {
+      "title": "MarkdownView",
+      "category": "text",
+      "description": "iOS Markdown view.",
+      "homepage": "https://github.com/keitaoouchi/MarkdownView"
+    },
+    {
+      "title": "MarkyMark",
+      "category": "text",
+      "description": "Converts Markdown into native views or attributed strings.",
+      "homepage": "https://github.com/M2Mobi/Marky-Mark"
+    },
+    {
+      "title": "Material",
+      "category": "ui",
+      "description": "Express your creativity with Material, an animation and graphics framework for Google's Material Design and Apple's Flat UI.",
+      "homepage": "https://github.com/CosmicMind/Material"
+    },
+    {
+      "title": "Material Components for iOS",
+      "category": "ui",
+      "description": "Modular and customizable Material Design UI components.",
+      "homepage": "https://github.com/material-components/material-components-ios"
+    },
+    {
+      "title": "MaterialKit",
+      "category": "ui",
+      "description": "Material design components.",
+      "homepage": "https://github.com/nghialv/MaterialKit"
+    },
+    {
+      "title": "MCScratchImageView",
+      "category": "images",
+      "description": "A custom ImageView that is used to cover the surface of other view like a scratch card, user can swipe the mulch to see the view below.",
+      "homepage": "https://github.com/JaylenCoding/MCScratchImageView"
+    },
+    {
+      "title": "MediaBrowser",
+      "category": "ui",
+      "description": "Simple iOS photo and video browser with optional grid view, captions and selections.",
+      "homepage": "https://github.com/younatics/MediaBrowser"
+    },
+    {
+      "title": "MediaPicker",
+      "category": "camera",
+      "description": "SwiftUI customizable media picker - supports camera and gallery with albums",
+      "homepage": "https://github.com/exyte/mediapicker"
+    },
+    {
+      "title": "MemberwiseInit",
+      "category": "misc",
+      "description": "`@MemberwiseInit` is a Swift Macro that can more often provide your intended `init`, while following the same safe-by-default semantics of Swift’s memberwise initializers.",
+      "homepage": "https://github.com/gohanlon/swift-memberwise-init-macro",
+      "tags": [
+        "swift",
+        "macro",
+        "init",
+        "initializers"
+      ]
+    },
+    {
+      "title": "MemoryCache",
+      "category": "cache",
+      "description": "Type-safe memory cache.",
+      "homepage": "https://github.com/yysskk/MemoryCache",
+      "tags": [
+        "cache",
+        "utility"
+      ]
+    },
+    {
+      "title": "MenuItemKit",
+      "category": "menu",
+      "description": "`UIMenuItem` with image and block (closure) support.",
+      "homepage": "https://github.com/cxa/MenuItemKit"
+    },
+    {
+      "title": "merchantkit",
+      "category": "app-store",
+      "description": "A modern In-App Purchases management framework for iOS.",
+      "homepage": "https://github.com/benjaminmayo/merchantkit"
+    },
+    {
+      "title": "MessageKit",
+      "category": "chat",
+      "description": "A community-driven replacement for JSQMessagesViewController.",
+      "homepage": "https://github.com/MessageKit/MessageKit"
+    },
+    {
+      "title": "MessengerKit",
+      "category": "chat",
+      "description": "A UI framework for building messenger interfaces.",
+      "homepage": "https://github.com/steve228uk/MessengerKit"
+    },
+    {
+      "title": "MFCard",
+      "category": "payment",
+      "description": "Easily integrate Credit Card payments in iOS App.",
+      "homepage": "https://github.com/MobileFirstInc/MFCard"
+    },
+    {
+      "title": "MijickCamera",
+      "category": "camera",
+      "description": "Camera made simple. Fully customizable camera library that significantly reduces implementation time and effort.",
+      "homepage": "https://github.com/Mijick/Camera"
+    },
+    {
+      "title": "MijickNavigattie",
+      "category": "transition",
+      "description": "Easy navigation with SwiftUI.",
+      "homepage": "https://github.com/Mijick/NavigationView",
+      "tags": [
+        "swift",
+        "swiftui",
+        "iOS",
+        "transition",
+        "navigation"
+      ]
+    },
+    {
+      "title": "MijickPopups",
+      "category": "alert",
+      "description": "Popups, popovers, sheets, alerts, toasts, banners, (...) presentation made simple.",
+      "homepage": "https://github.com/Mijick/Popups",
+      "tags": [
+        "swiftui",
+        "swift-package-manager",
+        "swift-library",
+        "popupview",
+        "popup"
+      ]
+    },
+    {
+      "title": "Mint",
+      "category": "dependency-managers",
+      "description": "A package manager that installs and runs Swift command line tools.",
+      "homepage": "https://github.com/yonaskolb/Mint"
+    },
+    {
+      "title": "MisterFusion",
+      "category": "auto-layout",
+      "description": "DSL for AutoLayout, supports Size Class.",
+      "homepage": "https://github.com/marty-suzuki/MisterFusion"
+    },
+    {
+      "title": "MJMaterialSwitch",
+      "category": "switch",
+      "description": "A Customizable Switch UI for iOS, Inspired from Google's Material Design.",
+      "homepage": "https://github.com/JaleelNazir/MJMaterialSwitch",
+      "tags": [
+        "switch",
+        "material-ui",
+        "animation",
+        "material-design",
+        "uicontrol",
+        "swift",
+        "ios"
+      ]
+    },
+    {
+      "title": "MMPlayerView",
+      "category": "video",
+      "description": "Custom AVPlayerLayer on view and transition player with good effect like YouTube and Facebook.",
+      "homepage": "https://github.com/MillmanY/MMPlayerView"
+    },
+    {
+      "title": "Moa",
+      "category": "images",
+      "description": "An image download extension of the image view for iOS, tvOS and macOS.",
+      "homepage": "https://github.com/evgenyneu/moa"
+    },
+    {
+      "title": "MobilePlayer",
+      "category": "video",
+      "description": "A powerful and completely customizable media player for iOS.",
+      "homepage": "https://github.com/sahin/mobileplayer-ios"
+    },
+    {
+      "title": "Mocker",
+      "category": "command-line",
+      "description": "Docker-compatible container CLI for macOS, built on Apple's Containerization framework.",
+      "homepage": "https://github.com/us/mocker",
+      "tags": [
+        "macOS",
+        "docker",
+        "containers"
+      ]
+    },
+    {
+      "title": "Mocker",
+      "category": "mock",
+      "description": "Mock Alamofire and URLSession requests without touching your code implementation",
+      "homepage": "https://github.com/WeTransfer/Mocker",
+      "tags": [
+        "alamofire",
+        "urlsession",
+        "mock"
+      ]
+    },
+    {
+      "title": "Mockingbird",
+      "category": "mock",
+      "description": "Simplify software testing, by easily mocking any system using HTTP/HTTPS, allowing a team to test and develop against a service that is not complete, unstable or just to reproduce planned cases.",
+      "homepage": "https://github.com/Farfetch/mockingbird"
+    },
+    {
+      "title": "Mockingjay",
+      "category": "mock",
+      "description": "An elegant library for stubbing HTTP requests with ease.",
+      "homepage": "https://github.com/kylef/Mockingjay"
+    },
+    {
+      "title": "Mockit",
+      "category": "mock",
+      "description": "A simple mocking framework, inspired by the famous Mockito for Java.",
+      "homepage": "https://github.com/sabirvirtuoso/Mockit"
+    },
+    {
+      "title": "MockSwift",
+      "category": "mock",
+      "description": "Mock Framework that uses the power of property wrappers.",
+      "homepage": "https://github.com/leoture/MockSwift"
+    },
+    {
+      "title": "Model-View-Presenter template",
+      "category": "boilerplates",
+      "description": "A flexible and easy template created to speed up the development of your iOS application based on the MVP pattern.",
+      "homepage": "https://github.com/onl1ner/ios-mvp-template"
+    },
+    {
+      "title": "Model2App",
+      "category": "misc",
+      "description": "Turn your data model into a working CRUD app.",
+      "homepage": "https://github.com/Q-Mobile/Model2App"
+    },
+    {
+      "title": "ModelAssistant",
+      "category": "multi-database",
+      "description": "Elegant library to manage the interactions between view and model.",
+      "homepage": "https://github.com/ssamadgh/ModelAssistant",
+      "tags": [
+        "swift",
+        "uitableview",
+        "uicollectionview",
+        "ios"
+      ]
+    },
+    {
+      "title": "ModernAVPlayer",
+      "category": "audio",
+      "description": "Persistence AVPlayer to resume playback after bad network connection even in background mode.",
+      "homepage": "https://github.com/noreasonprojects/ModernAVPlayer",
+      "tags": [
+        "swift",
+        "reachability",
+        "network",
+        "avplayer",
+        "player",
+        "hls",
+        "mp3",
+        "wav",
+        "aiff"
+      ]
+    },
+    {
+      "title": "MonarchRouter",
+      "category": "app-routing",
+      "description": "Declarative state- and URL-based router. Complex automatic View Controllers hierarchy transitions. Time-tested server-side conventions.",
+      "homepage": "https://github.com/nikans/MonarchRouter",
+      "tags": [
+        "routing",
+        "router",
+        "swift",
+        "ios",
+        "declarative",
+        "state-based",
+        "url",
+        "redux",
+        "reactive"
+      ]
+    },
+    {
+      "title": "MongoKitten",
+      "category": "mongodb",
+      "description": "MongoDB Connector.",
+      "homepage": "https://github.com/orlandos-nl/MongoKitten",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "Monstra",
+      "category": "cache",
+      "description": "Memory cache framework with TTL, priority-based eviction, and avalanche protection.",
+      "homepage": "https://github.com/yangchenlarkin/Monstra"
+    },
+    {
+      "title": "Mortar",
+      "category": "auto-layout",
+      "description": "A concise but flexible DSL for creating Auto Layout constraints and adding subviews.",
+      "homepage": "https://github.com/jmfieldman/Mortar"
+    },
+    {
+      "title": "Moya",
+      "category": "network",
+      "description": "Network abstraction layer.",
+      "homepage": "https://github.com/Moya/Moya"
+    },
+    {
+      "title": "MPParallaxView",
+      "category": "ui",
+      "description": "Apple TV Parallax effect.",
+      "homepage": "https://github.com/DroidsOnRoids/MPParallaxView"
+    },
+    {
+      "title": "MultiPeer",
+      "category": "network",
+      "description": "A wrapper for the MultipeerConnectivity framework for automatic offline data transmission between devices.",
+      "homepage": "https://github.com/dingwilson/MultiPeer"
+    },
+    {
+      "title": "MultiSelectSegmentedControl",
+      "category": "ui",
+      "description": "UISegmentedControl remake that supports selecting multiple segments, vertical stacking, combining text and images.",
+      "homepage": "https://github.com/yonat/MultiSelectSegmentedControl"
+    },
+    {
+      "title": "MultiSlider",
+      "category": "ui",
+      "description": "UISlider clone with multiple thumbs and values, range highlight, optional snap intervals, optional value labels, either vertical or horizontal.",
+      "homepage": "https://github.com/yonat/MultiSlider"
+    },
+    {
+      "title": "MultiToggleButton",
+      "category": "button",
+      "description": "A UIButton subclass that implements tap-to-toggle button text (like the camera flash and timer buttons).",
+      "homepage": "https://github.com/yonat/MultiToggleButton"
+    },
+    {
+      "title": "MuscleMap",
+      "category": "ui",
+      "description": "Render interactive human body muscle maps with SwiftUI and UIKit.",
+      "homepage": "https://github.com/melihcolpan/MuscleMap"
+    },
+    {
+      "title": "MusicKit",
+      "category": "audio",
+      "description": "A framework for composing and transforming music.",
+      "homepage": "https://github.com/0thernet/MusicKit"
+    },
+    {
+      "title": "MusicPlayerTransition",
+      "category": "transition",
+      "description": "Custom interactive transition like Apple Music iOS App.",
+      "homepage": "https://github.com/xxxAIRINxxx/MusicPlayerTransition"
+    },
+    {
+      "title": "Mussel",
+      "category": "testing",
+      "description": "A framework for easily testing Push Notifications, Universal Links and Routing in XCUITests.",
+      "homepage": "https://github.com/UrbanCompass/Mussel"
+    },
+    {
+      "title": "MXParallaxHeader",
+      "category": "ui",
+      "description": "Simple parallax header for UIScrollView.",
+      "homepage": "https://github.com/maxep/MXParallaxHeader"
+    },
+    {
+      "title": "MySQL Swift",
+      "category": "sql-drivers",
+      "description": "MySQL client library.",
+      "homepage": "https://github.com/novi/mysql-swift",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "MZFormSheetPresentationController",
+      "category": "ui",
+      "description": "Provides an alternative to the native iOS UIModalPresentationFormSheet, adding support for iPhone and additional opportunities to setup controller size and feel form sheet.",
+      "homepage": "https://github.com/m1entus/MZFormSheetPresentationController"
+    },
+    {
+      "title": "Nantes",
+      "category": "label",
+      "description": "TTTAttributedLabel replacement.",
+      "homepage": "https://github.com/instacart/Nantes"
+    },
+    {
+      "title": "NavigationTransitions",
+      "category": "transition",
+      "description": "Pure SwiftUI Navigation transitions.",
+      "homepage": "https://github.com/davdroman/swiftui-navigation-transitions"
+    },
+    {
+      "title": "nef",
+      "category": "command-line",
+      "description": "A set of command line tools that lets you have compile time verification of your documentation written as Xcode Playground.",
+      "homepage": "https://github.com/bow-swift/nef",
+      "tags": [
+        "macOS"
+      ]
+    },
+    {
+      "title": "Neon",
+      "category": "layout",
+      "description": "A powerful programmatic UI layout framework.",
+      "homepage": "https://github.com/mamaral/Neon"
+    },
+    {
+      "title": "Netfox",
+      "category": "network",
+      "description": "A lightweight, one line setup, network debugging library.",
+      "homepage": "https://github.com/kasketis/netfox"
+    },
+    {
+      "title": "Netswift",
+      "category": "network",
+      "description": "A type-safe, high-level networking solution.",
+      "homepage": "https://github.com/MrSkwiggs/Netswift",
+      "tags": [
+        "swift",
+        "declarative",
+        "protocols",
+        "structured",
+        "urlsession"
+      ]
+    },
+    {
+      "title": "NeumorphismKit",
+      "category": "ui",
+      "description": "Neumorphism framework for UIKit.",
+      "homepage": "https://github.com/y-okudera/NeumorphismKit",
+      "tags": [
+        "neumorphism",
+        "uicomponents",
+        "swift",
+        "ios",
+        "storyboard"
+      ]
+    },
+    {
+      "title": "NextGrowingTextView",
+      "category": "ui",
+      "description": "The next in the generations of 'growing textviews' optimized for iOS 7 and above.",
+      "homepage": "https://github.com/FluidGroup/NextGrowingTextView"
+    },
+    {
+      "title": "NextLevel",
+      "category": "camera",
+      "description": "Rad Media Capture.",
+      "homepage": "https://github.com/NextLevel/NextLevel"
+    },
+    {
+      "title": "NextLevelSessionExporter",
+      "category": "video",
+      "description": "Export and transcode media.",
+      "homepage": "https://github.com/NextLevel/NextLevelSessionExporter"
+    },
+    {
+      "title": "NFDownloadButton",
+      "category": "button",
+      "description": "Revamped Download Button. It's kinda a reverse engineering of Netflix's app download button.",
+      "homepage": "https://github.com/LeonardoCardoso/NFDownloadButton"
+    },
+    {
+      "title": "Nimble",
+      "category": "testing",
+      "description": "A matcher framework.",
+      "homepage": "https://github.com/Quick/Nimble"
+    },
+    {
+      "title": "NKVPhonePicker",
+      "category": "phone-numbers",
+      "description": "An UITextField subclass to simplify country code's picking.",
+      "homepage": "https://github.com/NikKovIos/NKVPhonePicker"
+    },
+    {
+      "title": "NorthLayout",
+      "category": "auto-layout",
+      "description": "Fast path to layout using Visual Format Language (VFL) with extended syntax.",
+      "homepage": "https://github.com/banjun/NorthLayout"
+    },
+    {
+      "title": "Notepad",
+      "category": "text",
+      "description": "A fully themeable markdown editor with live syntax highlighting.",
+      "homepage": "https://github.com/ruddfawcett/Notepad"
+    },
+    {
+      "title": "NoticeObserveKit",
+      "category": "events",
+      "description": "NoticeObserveKit is type-safe NotificationCenter wrapper that associates notice type with info type.",
+      "homepage": "https://github.com/marty-suzuki/NoticeObserveKit"
+    },
+    {
+      "title": "NotificationBanner",
+      "category": "alert",
+      "description": "The easiest way to display highly customizable in app notification banners in iOS.",
+      "homepage": "https://github.com/Daltron/NotificationBanner"
+    },
+    {
+      "title": "Notificationz",
+      "category": "events",
+      "description": "Helping you own `NSNotificationCenter` by providing a simple, customizable adapter.",
+      "homepage": "https://github.com/SwiftKitz/Notificationz"
+    },
+    {
+      "title": "Noze.io",
+      "category": "webserver",
+      "description": "Evented I/O streams like Node.js.",
+      "homepage": "https://github.com/NozeIO/Noze.io",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "Nuke",
+      "category": "images",
+      "description": "Advanced framework for loading, caching, processing, displaying and preheating images.",
+      "homepage": "https://github.com/kean/Nuke"
+    },
+    {
+      "title": "NVActivityIndicatorView",
+      "category": "ui",
+      "description": "Collection of nice loading animations.",
+      "homepage": "https://github.com/ninjaprox/NVActivityIndicatorView"
+    },
+    {
+      "title": "NVDate",
+      "category": "date",
+      "description": "Date extension library.",
+      "homepage": "https://github.com/novalagung/nvdate"
+    },
+    {
+      "title": "OAuth2",
+      "category": "network",
+      "description": "oauth2 auth lib.",
+      "homepage": "https://github.com/p2/OAuth2"
+    },
+    {
+      "title": "OAuthSwift",
+      "category": "network",
+      "description": "OAuth library for iOS.",
+      "homepage": "https://github.com/OAuthSwift/OAuthSwift"
+    },
+    {
+      "title": "OBCalendar",
+      "category": "calendar",
+      "description": "OBCalendar is designed for simplicity and customization, it allows you to build beautiful and functional calendar interfaces effortlessly.",
+      "homepage": "https://github.com/oBilet/OBCalendar"
+    },
+    {
+      "title": "ObjectForm",
+      "category": "form",
+      "description": "A simple yet powerful library to build form for your class models.",
+      "homepage": "https://github.com/haojianzong/ObjectForm"
+    },
+    {
+      "title": "ObjectiveKit",
+      "category": "utility",
+      "description": "API for Objective C runtime functions.",
+      "homepage": "https://github.com/marmelroy/ObjectiveKit"
+    },
+    {
+      "title": "ObjectMapper",
+      "category": "json",
+      "description": "JSON object mapper.",
+      "homepage": "https://github.com/tristanhimmelman/ObjectMapper"
+    },
+    {
+      "title": "Observable",
+      "category": "events",
+      "description": "The easiest way to observe values.",
+      "homepage": "https://github.com/roberthein/Observable",
+      "tags": [
+        "observable",
+        "observer",
+        "reactive"
+      ]
+    },
+    {
+      "title": "OcticonsKit",
+      "category": "fonts",
+      "description": "Use Octicons as UIImage / UIFont in your projects.",
+      "homepage": "https://github.com/keitaoouchi/OcticonsKit"
+    },
+    {
+      "title": "OEMentions",
+      "category": "text",
+      "description": "An easy way to add mentions to uitextview like Facebook and Instagram.",
+      "homepage": "https://github.com/omar14/OEMentions",
+      "tags": [
+        "Swift",
+        "UITextView",
+        "UITableView"
+      ]
+    },
+    {
+      "title": "OHHTTPStubs",
+      "category": "testing",
+      "description": "A testing library designed to stub your network requests easily.",
+      "homepage": "https://github.com/AliSoftware/OHHTTPStubs"
+    },
+    {
+      "title": "OKTableViewLiaison",
+      "category": "uitableview",
+      "description": "Framework to help you better manage UITableViews.",
+      "homepage": "https://github.com/okcupid/OKTableViewLiaison"
+    },
+    {
+      "title": "OnboardKit",
+      "category": "walkthrough",
+      "description": "Customisable user onboarding for your iOS app.",
+      "homepage": "https://github.com/NikolaKirev/OnboardKit"
+    },
+    {
+      "title": "OneWay",
+      "category": "events",
+      "description": "State management with unidirectional data flow.",
+      "homepage": "https://github.com/DevYeom/OneWay"
+    },
+    {
+      "title": "Online Swift Playground",
+      "category": "repl",
+      "description": "Online Swift Playground.",
+      "homepage": "http://online.swiftplayground.run",
+      "tags": [
+        "swift",
+        "repl",
+        "playground"
+      ]
+    },
+    {
+      "title": "Open Source Updates for Swift Projects",
+      "category": "newsletter",
+      "description": "A bi-weekly newsletter to give you the latest updates on popular and unknown open source projects written or related to Swift.",
+      "homepage": "https://ossp-updates.beehiiv.com/"
+    },
+    {
+      "title": "open-source-ios-apps",
+      "category": "other-awesome-lists",
+      "description": "A collaborative list of open-source iOS Apps.",
+      "homepage": "https://github.com/dkhamsing/open-source-ios-apps"
+    },
+    {
+      "title": "open-source-mac-os-apps",
+      "category": "other-awesome-lists",
+      "description": "Awesome list of open source applications for macOS.",
+      "homepage": "https://github.com/serhii-londar/open-source-mac-os-apps"
+    },
+    {
+      "title": "OpenAI",
+      "category": "ai",
+      "description": "Swift package for OpenAI public API.",
+      "homepage": "https://github.com/MacPaw/OpenAI"
+    },
+    {
+      "title": "OpenCombine",
+      "category": "events",
+      "description": "Open source implementation of Apple's Combine framework for processing values over time.",
+      "homepage": "https://github.com/OpenCombine/OpenCombine"
+    },
+    {
+      "title": "OpenSourceController",
+      "category": "utility",
+      "description": "The simplest way to display the librarie's licences used in your application.",
+      "homepage": "https://github.com/floriangbh/OpenSourceController"
+    },
+    {
+      "title": "OverlayContainer",
+      "category": "ui",
+      "description": "OverlayContainer makes it easier to develop overlay based interfaces, such as the one presented in the Apple Maps or Stocks apps.",
+      "homepage": "https://github.com/applidium/OverlayContainer"
+    },
+    {
+      "title": "Pageboy",
+      "category": "pagination",
+      "description": "A simple, highly informative page view controller.",
+      "homepage": "https://github.com/uias/Pageboy",
+      "tags": [
+        "pagination",
+        "paging",
+        "uipageviewcontroller",
+        "pager",
+        "swift"
+      ]
+    },
+    {
+      "title": "PageController",
+      "category": "pagination",
+      "description": "Infinite paging controller.",
+      "homepage": "https://github.com/hirohisa/PageController"
+    },
+    {
+      "title": "Pagemenu",
+      "category": "menu",
+      "description": "Pagination enabled view controller.",
+      "homepage": "https://github.com/PageMenu/PageMenu"
+    },
+    {
+      "title": "PagingKit",
+      "category": "menu",
+      "description": "PagingKit provides customizable menu UI.",
+      "homepage": "https://github.com/kazuhiro4949/PagingKit"
+    },
+    {
+      "title": "Panels",
+      "category": "menu",
+      "description": "Panels is a framework to easily add sliding panels to your application.",
+      "homepage": "https://github.com/antoniocasero/Panels"
+    },
+    {
+      "title": "PanSlip",
+      "category": "transition",
+      "description": "Use PanGesture to dismiss view on UIViewController and UIView.",
+      "homepage": "https://github.com/k-lpmg/PanSlip"
+    },
+    {
+      "title": "paper-switch",
+      "category": "switch",
+      "description": "RAMPaperSwitch is a material design UI module which paints over the parent view when the switch is turned on.",
+      "homepage": "https://github.com/Ramotion/paper-switch"
+    },
+    {
+      "title": "PaperOnboarding",
+      "category": "walkthrough",
+      "description": "PaperOnboarding is a material design UI slider.",
+      "homepage": "https://github.com/Ramotion/paper-onboarding"
+    },
+    {
+      "title": "ParallaxHeader",
+      "category": "uitableview",
+      "description": "Simple way to add parallax header to UIScrollView/UITableView.",
+      "homepage": "https://github.com/romansorochak/ParallaxHeader"
+    },
+    {
+      "title": "Parchment",
+      "category": "menu",
+      "description": "A paging view controller with a highly customizable menu, built on UICollectionView.",
+      "homepage": "https://github.com/rechsteiner/Parchment",
+      "swift": 4
+    },
+    {
+      "title": "Parsey",
+      "category": "text",
+      "description": "Parser combinator framework that supports source location tracking, backtracking prevention, and rich error messages.",
+      "homepage": "https://github.com/rxwei/Parsey"
+    },
+    {
+      "title": "Partition Kit",
+      "category": "ui",
+      "description": "A SwiftUI Library for creating resizable partitions for View Content.",
+      "homepage": "https://github.com/kieranb662/PartitionKit",
+      "tags": [
+        "swiftui",
+        "swift-package-manager",
+        "swift-library"
+      ]
+    },
+    {
+      "title": "PassportScanner",
+      "category": "images",
+      "description": "Scan the MRZ code of a passport and extract the first name, last name, passport number, nationality, date of birth, expiration date and personal number.",
+      "homepage": "https://github.com/evermeer/PassportScanner"
+    },
+    {
+      "title": "PasswordTextField",
+      "category": "textfield",
+      "description": "A custom TextField with a switchable icon which shows or hides the password and enforces good password policies.",
+      "homepage": "https://github.com/PiXeL16/PasswordTextField"
+    },
+    {
+      "title": "Pastel",
+      "category": "animation",
+      "description": "Gradient animation effect like Instagram.",
+      "homepage": "https://github.com/cruisediary/Pastel",
+      "tags": [
+        "swift",
+        "animation",
+        "instagram"
+      ],
+      "swift": 4
+    },
+    {
+      "title": "PathKit",
+      "category": "files",
+      "description": "Effortless path operations.",
+      "homepage": "https://github.com/kylef/PathKit",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "Pathos",
+      "category": "files",
+      "description": "Efficient Unix file management.",
+      "homepage": "https://github.com/dduan/Pathos",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "PDFGenerator",
+      "category": "pdf",
+      "description": "A simple Generator of PDF. Generate PDF from view(s) or image(s).",
+      "homepage": "https://github.com/sgr-ksmt/PDFGenerator"
+    },
+    {
+      "title": "Pencil",
+      "category": "other-data",
+      "description": "Write any value to file.",
+      "homepage": "https://github.com/naru-jpn/pencil"
+    },
+    {
+      "title": "Percentage",
+      "category": "utility",
+      "description": "Make percentages more readable and type-safe.",
+      "homepage": "https://github.com/sindresorhus/Percentage"
+    },
+    {
+      "title": "Perfect",
+      "category": "webserver",
+      "description": "Server-side Swift. The Perfect library, application server, connectors and example apps.",
+      "homepage": "https://github.com/PerfectlySoft/Perfect",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "Perfect-CRUD",
+      "category": "orm",
+      "description": "CRUD is an object-relational mapping (ORM) system using Codable protocol.",
+      "homepage": "https://github.com/PerfectlySoft/Perfect-CRUD",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "Perfect-MongoDB",
+      "category": "mongodb",
+      "description": "A stand-alone wrapper around the mongo-c client library, enabling access to MongoDB servers.",
+      "homepage": "https://github.com/PerfectlySoft/Perfect-MongoDB",
+      "tags": [
+        "linux",
+        "macOS"
+      ]
+    },
+    {
+      "title": "Perfect-MySQL",
+      "category": "sql-drivers",
+      "description": "A stand-alone wrapper around the MySQL client library, enabling access to MySQL servers.",
+      "homepage": "https://github.com/PerfectlySoft/Perfect-MySQL",
+      "tags": [
+        "linux",
+        "macOS"
+      ]
+    },
+    {
+      "title": "Perfect-Notifications",
+      "category": "messaging-protocol",
+      "description": "iOS Notifications for Linux and OS X.",
+      "homepage": "https://github.com/PerfectlySoft/Perfect-Notifications"
+    },
+    {
+      "title": "Perfect-PostgreSQL",
+      "category": "sql-drivers",
+      "description": "A stand-alone wrapper around the libpq client library, enabling access to PostgreSQL servers.",
+      "homepage": "https://github.com/PerfectlySoft/Perfect-PostgreSQL",
+      "tags": [
+        "linux",
+        "macOS"
+      ]
+    },
+    {
+      "title": "Periphery",
+      "category": "utility",
+      "description": "A tool to identify unused code in Swift projects.",
+      "homepage": "https://github.com/peripheryapp/periphery"
+    },
+    {
+      "title": "Permission",
+      "category": "permissions",
+      "description": "A unified API to ask for permissions on iOS.",
+      "homepage": "https://github.com/delba/Permission"
+    },
+    {
+      "title": "Persei",
+      "category": "uitableview",
+      "description": "Animated top menu for UITableView / UICollectionView / UIScrollView.",
+      "homepage": "https://github.com/Yalantis/Persei"
+    },
+    {
+      "title": "PersistenceKit",
+      "category": "multi-database",
+      "description": "Store and retrieve Codable objects to various persistence layers, in a couple lines of code!",
+      "homepage": "https://github.com/Teknasyon-Teknoloji/PersistenceKit",
+      "tags": [
+        "swift",
+        "filemanager",
+        "userdefaults",
+        "keychain",
+        "ios",
+        "macos",
+        "tvos",
+        "watchos"
+      ]
+    },
+    {
+      "title": "PhoneNumberKit",
+      "category": "phone-numbers",
+      "description": "Framework for parsing, formatting and validating international phone numbers. Inspired by Google's libphonenumber.",
+      "homepage": "https://github.com/marmelroy/PhoneNumberKit"
+    },
+    {
+      "title": "PinLayout",
+      "category": "layout",
+      "description": "Fast Views layouting without auto layout. No magic, pure code, full control and blazing fast. Concise syntax, intuitive, readable & chainable. [iOS/macOS/tvOS]",
+      "homepage": "https://github.com/layoutBox/PinLayout"
+    },
+    {
+      "title": "PinterestSwift",
+      "category": "transition",
+      "description": "Pinterest style transition.",
+      "homepage": "https://github.com/demonnico/PinterestSwift"
+    },
+    {
+      "title": "Pitaya",
+      "category": "network",
+      "description": "HTTP / HTTPS networking library just incidentally execute on machines.",
+      "homepage": "https://github.com/johnlui/Pitaya",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "PKHUD",
+      "category": "hud",
+      "description": "Reimplementation of the Apple HUD.",
+      "homepage": "https://github.com/pkluz/PKHUD"
+    },
+    {
+      "title": "Playbook",
+      "category": "utility",
+      "description": "📘A library for isolated developing UI components and automatically snapshots of them.",
+      "homepage": "https://github.com/playbook-ui/playbook-ios"
+    },
+    {
+      "title": "Player",
+      "category": "video",
+      "description": "iOS video player, simple drop in component for playing and streaming media.",
+      "homepage": "https://github.com/piemonte/Player"
+    },
+    {
+      "title": "PlayerView",
+      "category": "video",
+      "description": "Easy to use video player using a UIView, manage rate of reproduction, screenshots and callbacks-delegate for player state.",
+      "homepage": "https://github.com/davidlondono/PlayerView"
+    },
+    {
+      "title": "Pluralize.swift",
+      "category": "text",
+      "description": "Great String Pluralize Extension.",
+      "homepage": "https://github.com/joshualat/Pluralize.swift"
+    },
+    {
+      "title": "PMAlertController",
+      "category": "alert",
+      "description": "PMAlertController is a great and customizable substitute to UIAlertController.",
+      "homepage": "https://github.com/pmusolino/PMAlertController"
+    },
+    {
+      "title": "PMHTTP",
+      "category": "network",
+      "description": "HTTP framework with a focus on REST and JSON.",
+      "homepage": "https://github.com/postmates/PMHTTP"
+    },
+    {
+      "title": "PMJSON",
+      "category": "json",
+      "description": "JSON encoding/decoding library.",
+      "homepage": "https://github.com/postmates/PMJSON"
+    },
+    {
+      "title": "PMKVObserver",
+      "category": "events",
+      "description": "Modern thread-safe and type-safe key-value observing.",
+      "homepage": "https://github.com/postmates/PMKVObserver/"
+    },
+    {
+      "title": "PMSuperButton",
+      "category": "button",
+      "description": "A powerful UIButton with super powers, customizable from Storyboard.",
+      "homepage": "https://github.com/pmusolino/PMSuperButton"
+    },
+    {
+      "title": "Poi",
+      "category": "animation",
+      "description": "Poi makes you use card UI like tinder UI .You can use it like tableview method.",
+      "homepage": "https://github.com/HideakiTouhara/Poi"
+    },
+    {
+      "title": "PolioPager",
+      "category": "tab",
+      "description": "A flexible TabBarController with search tab like SNKRS.",
+      "homepage": "https://github.com/YuigaWada/PolioPager"
+    },
+    {
+      "title": "PopMenu",
+      "category": "menu",
+      "description": "😎 A cool and customizable popup style action sheet for iOS.",
+      "homepage": "https://github.com/CaliCastle/PopMenu"
+    },
+    {
+      "title": "Popovers",
+      "category": "ui",
+      "description": "A library to present popovers. Simple, modern, and highly customizable. Not boring!",
+      "homepage": "https://github.com/aheze/Popovers"
+    },
+    {
+      "title": "PopupDialog",
+      "category": "alert",
+      "description": "A simple, customizable popup dialog. Replaces UIAlertController alert style.",
+      "homepage": "https://github.com/orderella/PopupDialog"
+    },
+    {
+      "title": "PopupView",
+      "category": "alert",
+      "description": "Toasts and popups library written with SwiftUI.",
+      "homepage": "https://github.com/exyte/PopupView",
+      "tags": [
+        "swiftui",
+        "swift-package-manager",
+        "swift-library"
+      ]
+    },
+    {
+      "title": "Postal",
+      "category": "network",
+      "description": "Framework providing simple access to common email providers.",
+      "homepage": "https://github.com/snipsco/Postal"
+    },
+    {
+      "title": "PredicateFlow",
+      "category": "text",
+      "description": "PredicateFlow is a builder that allows you to write amazing, strong-typed and easy-to-read NSPredicate.",
+      "homepage": "https://github.com/andreadelfante/PredicateFlow"
+    },
+    {
+      "title": "PrediKit",
+      "category": "text",
+      "description": "An NSPredicate DSL for iOS & OS X inspired by SnapKit.",
+      "homepage": "https://github.com/KrakenDev/PrediKit"
+    },
+    {
+      "title": "Preferences",
+      "category": "ui",
+      "description": "Add a preferences window to your macOS app in minutes.",
+      "homepage": "https://github.com/sindresorhus/Settings"
+    },
+    {
+      "title": "Prephirences",
+      "category": "key-value-store",
+      "description": "Manage application preferences, NSUserDefaults, iCloud, Keychain and more.",
+      "homepage": "https://github.com/phimage/Prephirences"
+    },
+    {
+      "title": "Presentation",
+      "category": "animation",
+      "description": "A library to help you to make tutorials, release notes and animated pages.",
+      "homepage": "https://github.com/hyperoslo/Presentation"
+    },
+    {
+      "title": "PrettyColors",
+      "category": "colors",
+      "description": "Styles and colors text in the Terminal with ANSI escape codes. Conforms to ECMA Standard 48.",
+      "homepage": "https://github.com/jdhealy/PrettyColors"
+    },
+    {
+      "title": "Printer",
+      "category": "logging",
+      "description": "A fancy logger for your next app.",
+      "homepage": "https://github.com/hemangshah/printer"
+    },
+    {
+      "title": "PrivacyFlash Pro",
+      "category": "utility",
+      "description": "Generate a privacy policy for your Swift iOS app from its code.",
+      "homepage": "https://github.com/privacy-tech-lab/privacyflash-pro",
+      "tags": [
+        "swift",
+        "iOS",
+        "privacy policy",
+        "privacy"
+      ]
+    },
+    {
+      "title": "Progress.swift",
+      "category": "command-line",
+      "description": "Add beautiful progress bars to your command line.",
+      "homepage": "https://github.com/jkandzi/Progress.swift",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "ProgressIndicatorView",
+      "category": "ui",
+      "description": "A progress indicator view library written in SwiftUI.",
+      "homepage": "https://github.com/exyte/ProgressIndicatorView"
+    },
+    {
+      "title": "PromiseKit",
+      "category": "events",
+      "description": "Async promise programming lib.",
+      "homepage": "https://github.com/mxcl/PromiseKit"
+    },
+    {
+      "title": "protobuf-swift",
+      "category": "utility",
+      "description": "ProtocolBuffers.",
+      "homepage": "https://github.com/alexeyxo/protobuf-swift"
+    },
+    {
+      "title": "Prototope",
+      "category": "utility",
+      "description": "Library of lightweight interfaces for prototyping, bridged to JS.",
+      "homepage": "http://khan.github.io/Prototope/"
+    },
+    {
+      "title": "PryntTrimmerView",
+      "category": "video",
+      "description": "Trim and crop videos.",
+      "homepage": "https://github.com/HHK1/PryntTrimmerView"
+    },
+    {
+      "title": "PullToDismiss",
+      "category": "ui",
+      "description": "You can dismiss modal viewcontroller by pulling scrollview or navigationbar.",
+      "homepage": "https://github.com/sgr-ksmt/PullToDismiss"
+    },
+    {
+      "title": "PullToRefreshSwift",
+      "category": "uitableview",
+      "description": "PullToRefresh library.",
+      "homepage": "https://github.com/dekatotoro/PullToRefreshSwift"
+    },
+    {
+      "title": "Pulsator",
+      "category": "animation",
+      "description": "Pulse animation for iOS.",
+      "homepage": "https://github.com/shu223/pulsator"
+    },
+    {
+      "title": "Puppy",
+      "category": "logging",
+      "description": "A flexible logging library that supports multiple transports and platforms.",
+      "homepage": "https://github.com/sushichop/Puppy",
+      "tags": [
+        "swift",
+        "linux",
+        "macos",
+        "ios",
+        "tvos",
+        "watchos"
+      ]
+    },
+    {
+      "title": "Pure",
+      "category": "dependency-injection",
+      "description": "A way to do a dependency injection without a DI container.",
+      "homepage": "https://github.com/devxoul/Pure"
+    },
+    {
+      "title": "PureLayout",
+      "category": "auto-layout",
+      "description": "The ultimate API for iOS & OS X Auto Layout.",
+      "homepage": "https://github.com/PureLayout/PureLayout"
+    },
+    {
+      "title": "PXGoogleDirections",
+      "category": "api",
+      "description": "Google Directions API helper.",
+      "homepage": "https://github.com/poulpix/PXGoogleDirections"
+    },
+    {
+      "title": "QorumLogs",
+      "category": "logging",
+      "description": "Logging Utility for Xcode & Google Docs.",
+      "homepage": "https://github.com/Esqarrouth/QorumLogs"
+    },
+    {
+      "title": "QRCodeReader.swift",
+      "category": "barcode",
+      "description": "Simple QRCode reader.",
+      "homepage": "https://github.com/yannickl/QRCodeReader.swift"
+    },
+    {
+      "title": "QueryKit",
+      "category": "core-data",
+      "description": "An easy way to play with Core Data filtering.",
+      "homepage": "https://github.com/QueryKit/QueryKit"
+    },
+    {
+      "title": "Queuer",
+      "category": "concurrency",
+      "description": "A queue manager, built on top of OperationQueue and Dispatch (aka GCD).",
+      "homepage": "https://github.com/FabrizioBrancati/Queuer",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "Quick",
+      "category": "testing",
+      "description": "Quick is a behavior-driven development framework.",
+      "homepage": "https://github.com/Quick/Quick",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "QuickTableViewController",
+      "category": "uitableview",
+      "description": "A simple way to create a UITableView for settings.",
+      "homepage": "https://github.com/bcylin/QuickTableViewController"
+    },
+    {
+      "title": "R.swift",
+      "category": "utility",
+      "description": "Tool to get strong typed, autocompleted resources like images, cells and segues.",
+      "homepage": "https://github.com/mac-cain13/R.swift"
+    },
+    {
+      "title": "RadioGroup",
+      "category": "button",
+      "description": "The missing iOS radio buttons group.",
+      "homepage": "https://github.com/yonat/RadioGroup"
+    },
+    {
+      "title": "Rainbow",
+      "category": "logging",
+      "description": "Delightful console output.",
+      "homepage": "https://github.com/onevcat/Rainbow",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "RandomKit",
+      "category": "utility",
+      "description": "Random data generation.",
+      "homepage": "https://github.com/nvzqz/RandomKit/",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "RandomUserSwift",
+      "category": "api",
+      "description": "Framework to Generate Random Users - An Unofficial SDK for randomuser.me.",
+      "homepage": "https://github.com/dingwilson/RandomUserSwift"
+    },
+    {
+      "title": "RangeSeekSlider",
+      "category": "ui",
+      "description": "A customizable range slider like a UISlider for iOS.",
+      "homepage": "https://github.com/WorldDownTown/RangeSeekSlider"
+    },
+    {
+      "title": "Ray Wenderlich Tutorials, Videos, Podcasts and books",
+      "category": "third-party-guides",
+      "description": "High quality programming tutorials.",
+      "homepage": "https://www.kodeco.com"
+    },
+    {
+      "title": "Raylib for Swift",
+      "category": "game-engine",
+      "description": "A Cross-Platform Swift package for Raylib. Builds Raylib from source so no need to fiddle with libraries. Just add as a dependency in you game package and go!",
+      "homepage": "https://github.com/STREGAsGate/Raylib",
+      "tags": [
+        "macOS",
+        "linux",
+        "windows",
+        "swift"
+      ]
+    },
+    {
+      "title": "Raywenderlich",
+      "category": "style-guides",
+      "description": "Raywenderlich guide, a must read.",
+      "homepage": "https://github.com/kodecocodes/swift-style-guide"
+    },
+    {
+      "title": "Reachability.swift",
+      "category": "network",
+      "description": "A replacement for Apple's Reachability with closures.",
+      "homepage": "https://github.com/ashleymills/Reachability.swift"
+    },
+    {
+      "title": "Reactant",
+      "category": "patterns",
+      "description": "Reactant is a reactive architecture for iOS.",
+      "homepage": "https://github.com/Brightify/Reactant"
+    },
+    {
+      "title": "ReactiveAPI",
+      "category": "network",
+      "description": "Write clean, concise and declarative network code relying on URLSession, with the power of RxSwift. Inspired by Retrofit.",
+      "homepage": "https://github.com/sky-uk/ReactiveAPI",
+      "tags": [
+        "swift",
+        "declarative",
+        "rx",
+        "reactive",
+        "urlsession"
+      ]
+    },
+    {
+      "title": "ReactiveCocoa",
+      "category": "events",
+      "description": "ReactiveCocoa (RAC) is a Cocoa framework inspired by Functional Reactive Programming. It provides APIs for composing and transforming streams of values over time.",
+      "homepage": "https://github.com/ReactiveCocoa/ReactiveCocoa"
+    },
+    {
+      "title": "ReactorKit",
+      "category": "events",
+      "description": "A framework for reactive and unidirectional application architecture.",
+      "homepage": "https://github.com/ReactorKit/ReactorKit"
+    },
+    {
+      "title": "ReadabilityKit",
+      "category": "utility",
+      "description": "Preview extractor for news, articles and full-texts.",
+      "homepage": "https://github.com/exyte/ReadabilityKit"
+    },
+    {
+      "title": "Real-time Chat with Firebase",
+      "category": "chat",
+      "description": "Functional real-time chat app with Firebase Firestore using MessageKit.",
+      "homepage": "https://github.com/dopebase/messenger-iOS-chat-swift-firestore"
+    },
+    {
+      "title": "Realm",
+      "category": "realm",
+      "description": "Realm is a mobile database: a replacement for Core Data & SQLite.",
+      "homepage": "https://github.com/realm/realm-swift"
+    },
+    {
+      "title": "RealmWrapper",
+      "category": "realm",
+      "description": "Safe and easy wrappers for RealmSwift.",
+      "homepage": "https://github.com/k-lpmg/RealmWrapper"
+    },
+    {
+      "title": "ReCaptcha",
+      "category": "authentication",
+      "description": "[In]visible ReCaptcha for iOS.",
+      "homepage": "https://github.com/fjcaetano/ReCaptcha",
+      "tags": [
+        "google",
+        "reactive",
+        "rxswift",
+        "webview"
+      ]
+    },
+    {
+      "title": "reddift",
+      "category": "api",
+      "description": "reddit API wrapper.",
+      "homepage": "https://github.com/sonsongithub/reddift"
+    },
+    {
+      "title": "ReduxUI",
+      "category": "patterns",
+      "description": "Redux framework for easy use with SwiftUI.",
+      "homepage": "https://github.com/gre4ixin/ReduxUI"
+    },
+    {
+      "title": "Reel search",
+      "category": "ui",
+      "description": "Option list managed as a reel.",
+      "homepage": "https://github.com/Ramotion/reel-search"
+    },
+    {
+      "title": "ReerCodable",
+      "category": "json",
+      "description": "Codable extensions using Swift macro.",
+      "homepage": "https://github.com/reers/ReerCodable",
+      "tags": [
+        "swift",
+        "codable"
+      ]
+    },
+    {
+      "title": "ReerKit",
+      "category": "utility",
+      "description": "Powerful Swift foundation library of extensions and providing utility functions to supercharge your iOS/macOS/Linux development workflow.",
+      "homepage": "https://github.com/reers/ReerKit",
+      "tags": [
+        "swift",
+        "extensions",
+        "iOS",
+        "macOS",
+        "tvOS"
+      ]
+    },
+    {
+      "title": "Regex by crossroadlabs",
+      "category": "text",
+      "description": "Very easy to use Regular Expressions library with rich functionality. Features both operator `=~` and method based APIs. Unit tests covered.",
+      "homepage": "https://github.com/crossroadlabs/Regex",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "Regex by sindresorhus",
+      "category": "text",
+      "description": "Swifty regular expressions, fully tested & documented, and with correct Unicode handling.",
+      "homepage": "https://github.com/sindresorhus/Regex",
+      "tags": [
+        "regex"
+      ]
+    },
+    {
+      "title": "ResizingTokenField",
+      "category": "ui",
+      "description": "A UICollectionView-based token field which provides intrinsic content height.",
+      "homepage": "https://github.com/tadejr/ResizingTokenField"
+    },
+    {
+      "title": "ResourceKit",
+      "category": "utility",
+      "description": "Enable autocomplete use resources.",
+      "homepage": "https://github.com/bannzai/ResourceKit"
+    },
+    {
+      "title": "ResponseDetective",
+      "category": "network",
+      "description": "A non-intrusive framework for intercepting any outgoing requests and incoming responses between your app and server for debugging purposes.",
+      "homepage": "https://github.com/netguru/ResponseDetective"
+    },
+    {
+      "title": "Result",
+      "category": "utility",
+      "description": "Type modelling the success/failure of arbitrary operations.",
+      "homepage": "https://github.com/antitypical/Result"
+    },
+    {
+      "title": "ReSwift",
+      "category": "events",
+      "description": "Unidirectional Data Flow.",
+      "homepage": "https://github.com/ReSwift/ReSwift"
+    },
+    {
+      "title": "RetroProgress",
+      "category": "ui",
+      "description": "Retro looking progress bar straight from the 90s.",
+      "homepage": "https://github.com/hyperoslo/RetroProgress"
+    },
+    {
+      "title": "RevealingSplashView",
+      "category": "transition",
+      "description": "A Splash view that animates and reveals its content, inspired by the Twitter splash.",
+      "homepage": "https://github.com/PiXeL16/RevealingSplashView"
+    },
+    {
+      "title": "ReverseExtension",
+      "category": "uitableview",
+      "description": "UITableView extension that enables the insertion of cells the from bottom of a table view.",
+      "homepage": "https://github.com/marty-suzuki/ReverseExtension",
+      "tags": [
+        "iOS",
+        "swift",
+        "UITableView"
+      ]
+    },
+    {
+      "title": "Ribbon",
+      "category": "keyboard",
+      "description": "🎀 A simple cross-platform toolbar/custom input accessory view library for iOS & macOS.",
+      "homepage": "https://github.com/chriszielinski/Ribbon"
+    },
+    {
+      "title": "RichEditorView",
+      "category": "text",
+      "description": " RichEditorView is a simple, modular, drop-in UIView subclass for Rich Text Editing.",
+      "homepage": "https://github.com/cjwirth/RichEditorView"
+    },
+    {
+      "title": "RNCryptor",
+      "category": "cryptography",
+      "description": "CCCryptor (Apple's AES encryption) wrappers for iOS and Mac.",
+      "homepage": "https://github.com/RNCryptor/RNCryptor"
+    },
+    {
+      "title": "Rough",
+      "category": "images",
+      "description": "Rough lets you draw in a sketchy, hand-drawn-like, style.",
+      "homepage": "https://github.com/bakhtiyork/Rough",
+      "tags": [
+        "swift",
+        "sketchy",
+        "hand-drawn"
+      ]
+    },
+    {
+      "title": "Rugby",
+      "category": "utility",
+      "description": "🏈 Cache CocoaPods for faster rebuild and indexing Xcode project.",
+      "homepage": "https://github.com/swiftyfinch/Rugby"
+    },
+    {
+      "title": "Runes",
+      "category": "utility",
+      "description": "Functional operators: flatMap, map, apply.",
+      "homepage": "https://github.com/thoughtbot/Runes"
+    },
+    {
+      "title": "RxBluetoothKit",
+      "category": "bluetooth",
+      "description": "iOS & OSX Bluetooth library for RxSwift.",
+      "homepage": "https://github.com/polidea/RxBluetoothKit"
+    },
+    {
+      "title": "RxFlow",
+      "category": "app-routing",
+      "description": "RxFlow is a navigation framework for iOS applications based on a Reactive Flow Coordinator pattern.",
+      "homepage": "https://github.com/RxSwiftCommunity/RxFlow"
+    },
+    {
+      "title": "RxNetworks",
+      "category": "network",
+      "description": "Network API With RxSwift + Moya + HandyJSON + Plugins.",
+      "homepage": "https://github.com/yangKJ/RxNetworks"
+    },
+    {
+      "title": "RxSwift",
+      "category": "events",
+      "description": "Microsoft Reactive Extensions (Rx).",
+      "homepage": "https://github.com/ReactiveX/RxSwift"
+    },
+    {
+      "title": "RxValidator",
+      "category": "validation",
+      "description": "Simple, Extensible, Flexible Validation Checker.",
+      "homepage": "https://github.com/vbmania/RxValidator"
+    },
+    {
+      "title": "RxWebSocket",
+      "category": "socket",
+      "description": "Reactive WebSockets.",
+      "homepage": "https://github.com/fjcaetano/RxWebSocket",
+      "tags": [
+        "reactive",
+        "rxswift"
+      ]
+    },
+    {
+      "title": "SafeDI",
+      "category": "dependency-injection",
+      "description": "Compile-time safe dependency injection.",
+      "homepage": "https://github.com/dfed/safedi"
+    },
+    {
+      "title": "Sage",
+      "category": "games",
+      "description": "A cross-platform chess library.",
+      "homepage": "https://github.com/nvzqz/Sage",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "SamuraiTransition",
+      "category": "transition",
+      "description": "Swift based library providing a collection of ViewController transitions featuring a number of neat cutting animations.",
+      "homepage": "https://github.com/hachinobu/SamuraiTransition",
+      "tags": [
+        "swift",
+        "animation",
+        "UI",
+        "transition"
+      ]
+    },
+    {
+      "title": "SBTUITestTunnel",
+      "category": "testing",
+      "description": "UI testing library for interact with network requests, stub CLLocationManager and UNUserNotificationCenter, and fine grain scrolling in table/collection/scroll views",
+      "homepage": "https://github.com/Subito-it/SBTUITestTunnel"
+    },
+    {
+      "title": "Scaling Header Scroll View",
+      "category": "layout",
+      "description": "A scroll view with a sticky header which shrinks as you scroll. Written with SwiftUI.",
+      "homepage": "https://github.com/exyte/ScalingHeaderScrollView",
+      "tags": [
+        "swiftui",
+        "iOS",
+        "sticky-header",
+        "scaling-header"
+      ]
+    },
+    {
+      "title": "Schedule",
+      "category": "thread",
+      "description": "A missing lightweight task scheduler with an incredibly human-friendly syntax.",
+      "homepage": "https://github.com/luoxiu/Schedule",
+      "tags": [
+        "timer",
+        "gcd",
+        "ios",
+        "macos",
+        "watchos",
+        "tvos",
+        "linux"
+      ]
+    },
+    {
+      "title": "SCLAlertView",
+      "category": "alert",
+      "description": "Animated Alert view.",
+      "homepage": "https://github.com/vikmeup/SCLAlertView-Swift"
+    },
+    {
+      "title": "Scout",
+      "category": "analytics",
+      "description": "Production-grade logging SDK for iOS apps using CloudKit as a backend.",
+      "homepage": "https://github.com/kasianov-mikhail/scout",
+      "tags": [
+        "analytics",
+        "swift",
+        "iOS"
+      ]
+    },
+    {
+      "title": "ScrollableGraphView",
+      "category": "chart",
+      "description": "Adaptive scrollable graph view for iOS to visualise simple discrete datasets.",
+      "homepage": "https://github.com/philackm/ScrollableGraphView"
+    },
+    {
+      "title": "SCrypto",
+      "category": "cryptography",
+      "description": "Elegant interface to access the CommonCrypto routines.",
+      "homepage": "https://github.com/sgl0v/scrypto"
+    },
+    {
+      "title": "SectionedSlider",
+      "category": "ui",
+      "description": "Control Center Slider.",
+      "homepage": "https://github.com/LeonardoCardoso/SectionedSlider"
+    },
+    {
+      "title": "SecureDefaults",
+      "category": "key-value-store",
+      "description": "A lightweight wrapper over UserDefaults & NSUserDefaults with an extra AES-256 encryption layer.",
+      "homepage": "https://github.com/vpeschenkov/SecureDefaults"
+    },
+    {
+      "title": "SecurePropertyStorage",
+      "category": "security",
+      "description": "Helps you define secure storages for your properties using Swift property wrappers.",
+      "homepage": "https://github.com/alexruperez/SecurePropertyStorage",
+      "tags": [
+        "security",
+        "property wrappers",
+        "userdefaults",
+        "keychain",
+        "singleton",
+        "codable",
+        "dependency injection"
+      ]
+    },
+    {
+      "title": "SegmentIO",
+      "category": "menu",
+      "description": "Animated top/bottom segmented menu for iOS.",
+      "homepage": "https://github.com/Yalantis/Segmentio"
+    },
+    {
+      "title": "Sejima",
+      "category": "UI",
+      "description": "Collection of User Interface components.",
+      "homepage": "https://github.com/MoveUpwards/Sejima",
+      "tags": [
+        "UI",
+        "components"
+      ]
+    },
+    {
+      "title": "SelectionDialog",
+      "category": "ui",
+      "description": "Simple selection dialog.",
+      "homepage": "https://github.com/kciter/SelectionDialog"
+    },
+    {
+      "title": "SelectionList",
+      "category": "uitableview",
+      "description": "Simple single-selection or multiple-selection checklist, based on UITableView.",
+      "homepage": "https://github.com/yonat/SelectionList"
+    },
+    {
+      "title": "Sextant",
+      "category": "json",
+      "description": "High performance JSONPath queries",
+      "homepage": "https://github.com/KittyMac/Sextant",
+      "tags": [
+        "linux",
+        "macOS",
+        "iOS",
+        "tvOS"
+      ]
+    },
+    {
+      "title": "ShadowsocksX-NG",
+      "category": "network",
+      "description": "A fast tunnel proxy that helps you bypass firewalls.",
+      "homepage": "https://github.com/shadowsocks/ShadowsocksX-NG"
+    },
+    {
+      "title": "ShadowView",
+      "category": "ui",
+      "description": "Make shadows management easy on UIView.",
+      "homepage": "https://github.com/PierrePerrin/ShadowView"
+    },
+    {
+      "title": "Shallows",
+      "category": "multi-database",
+      "description": "Your lightweight persistence toolbox.",
+      "homepage": "https://github.com/dreymonde/Shallows"
+    },
+    {
+      "title": "Sharaku",
+      "category": "images",
+      "description": "Image filtering UI library like Instagram.",
+      "homepage": "https://github.com/makomori/Sharaku"
+    },
+    {
+      "title": "Sheet",
+      "category": "alert",
+      "description": "Actionsheet with navigation features such as the Flipboard App.",
+      "homepage": "https://github.com/ParkGwangBeom/Sheet"
+    },
+    {
+      "title": "SheetyColors",
+      "category": "colors",
+      "description": "An action sheet styled color picker for iOS.",
+      "homepage": "https://github.com/chrs1885/SheetyColors"
+    },
+    {
+      "title": "ShelfView-iOS",
+      "category": "uicollectionview",
+      "description": "iOS custom view to display books on shelf.",
+      "homepage": "https://github.com/tdscientist/ShelfView-iOS"
+    },
+    {
+      "title": "Shiny",
+      "category": "ui",
+      "description": "Iridescent Effect View (inspired by Apple Pay Cash).",
+      "homepage": "https://github.com/efremidze/Shiny",
+      "tags": [
         "hologram",
         "animation",
         "applepay",
@@ -6064,294 +6242,1813 @@
       ]
     },
     {
-      "title":"URLQueryItemEncoder",
-      "category":"utility",
-      "description":"An Encoder for encoding any Encodable value into an array of URLQueryItem.",
-      "homepage":"https://github.com/pitiphong-p/URLQueryItemEncoder",
-      "tags":[
-        "urlqueryitem",
-        "codable",
-        "encoder",
+      "title": "ShowSomeProgress",
+      "category": "ui",
+      "description": "Animated Progress and Activity Indicators for iOS apps.",
+      "homepage": "https://github.com/stoneburner/ShowSomeProgress"
+    },
+    {
+      "title": "ShowTime",
+      "category": "gesture",
+      "description": "Show off your iOS taps and gestures for demos and videos with just one line of code.",
+      "homepage": "https://github.com/KaneCheshire/ShowTime"
+    },
+    {
+      "title": "Shoyu",
+      "category": "uitableview",
+      "description": "Easier way to represent the structure of UITableView.",
+      "homepage": "https://github.com/xai3/Shoyu"
+    },
+    {
+      "title": "Sica",
+      "category": "animation",
+      "description": "Simple Interface Core Animation. Run type-safe animation sequencially or parallelly.",
+      "homepage": "https://github.com/cats-oss/Sica"
+    },
+    {
+      "title": "SideMenu",
+      "category": "menu",
+      "description": "Simple side menu control for iOS inspired by Facebook. Right and Left sides. No coding required.",
+      "homepage": "https://github.com/jonkykong/SideMenu"
+    },
+    {
+      "title": "Siesta",
+      "category": "network",
+      "description": "Elegant abstraction for REST APIs that untangles stateful messes. An alternative to callback- and delegate-based networking.",
+      "homepage": "https://bustoutsolutions.github.io/siesta/"
+    },
+    {
+      "title": "SigmaSwiftStatistics",
+      "category": "math",
+      "description": "A collection of functions for statistical calculation.",
+      "homepage": "https://github.com/evgenyneu/SigmaSwiftStatistics"
+    },
+    {
+      "title": "Signals",
+      "category": "events",
+      "description": "Replaces delegates and notifications.",
+      "homepage": "https://github.com/artman/Signals"
+    },
+    {
+      "title": "SimplePDF",
+      "category": "pdf",
+      "description": "Create a simple PDF effortlessly.",
+      "homepage": "https://github.com/nRewik/SimplePDF"
+    },
+    {
+      "title": "SimpleSource",
+      "category": "uicollectionview",
+      "description": "Easy and type-safe iOS table and collection views.",
+      "homepage": "https://github.com/Squarespace/simple-source "
+    },
+    {
+      "title": "SimplexArchitecture",
+      "category": "patterns",
+      "description": "A Simple architecture that decouples state changes from SwiftUI's View",
+      "homepage": "https://github.com/Ryu0118/swiftui-simplex-architecture",
+      "tags": [
+        "swift",
+        "swiftui",
+        "iOS",
+        "macOS",
+        "tvOS"
+      ]
+    },
+    {
+      "title": "Siphash",
+      "category": "cryptography",
+      "description": "Simple and secure hashing with the SipHash algorithm.",
+      "homepage": "https://github.com/attaswift/SipHash"
+    },
+    {
+      "title": "Siren",
+      "category": "version-manager",
+      "description": "Notify users when a new version of your app is available and prompt them to upgrade.",
+      "homepage": "https://github.com/ArtSabintsev/Siren"
+    },
+    {
+      "title": "Sizes",
+      "category": "testing",
+      "description": "Test your app on different device and font sizes.",
+      "homepage": "https://github.com/marcosgriselli/Sizes"
+    },
+    {
+      "title": "SkeletonView",
+      "category": "ui",
+      "description": "An elegant way to show users that something is happening and also prepare them to which contents he is waiting.",
+      "homepage": "https://github.com/Juanpe/SkeletonView"
+    },
+    {
+      "title": "Skopelos",
+      "category": "core-data",
+      "description": "A minimalistic, thread safe, non-boilerplate and super easy to use version of Active Record on Core Data.",
+      "homepage": "https://github.com/albertodebortoli/Skopelos"
+    },
+    {
+      "title": "SKPhotoBrowser",
+      "category": "ui",
+      "description": "Simple PhotoBrowser/Viewer inspired by facebook, twitter photo browsers.",
+      "homepage": "https://github.com/suzuki-0000/SKPhotoBrowser"
+    },
+    {
+      "title": "SkyFloatingLabelTextField",
+      "category": "textfield",
+      "description": "A beautiful and flexible text field control implementation of \"Float Label Pattern\".",
+      "homepage": "https://github.com/Skyscanner/SkyFloatingLabelTextField"
+    },
+    {
+      "title": "SlideController",
+      "category": "pagination",
+      "description": "It is a nice alternative for UIPageViewController built using power of generic types. Swipe between pages with an interactive title navigation control. Configure horizontal or vertical chains for unlimited pages amount.",
+      "homepage": "https://github.com/touchlane/SlideController"
+    },
+    {
+      "title": "SlideMenuControllerSwift",
+      "category": "menu",
+      "description": "iOS Slide Menu View based on Google+, iQON, Feedly, Ameba iOS app.",
+      "homepage": "https://github.com/dekatotoro/SlideMenuControllerSwift"
+    },
+    {
+      "title": "SnapKit",
+      "category": "auto-layout",
+      "description": "Autolayout DSL for iOS & OS X.",
+      "homepage": "https://github.com/SnapKit/SnapKit"
+    },
+    {
+      "title": "SnapshotTest",
+      "category": "testing",
+      "description": "Snapshot testing tool for iOS and tvOS.",
+      "homepage": "https://github.com/parski/SnapshotTest",
+      "tags": [
+        "iOS",
+        "tvOS"
+      ]
+    },
+    {
+      "title": "Snowflake",
+      "category": "images",
+      "description": "Work with SVG.",
+      "homepage": "https://github.com/onmyway133/Snowflake"
+    },
+    {
+      "title": "SOAPEngine",
+      "category": "soap",
+      "description": "Generic SOAP client to access SOAP Web Services using iOS, Mac OS X, and Apple TV.",
+      "homepage": "https://github.com/priore/SOAPEngine",
+      "tags": [
+        "swift",
+        "soap",
+        "macos",
+        "ios",
+        "tvos",
+        "xml"
+      ]
+    },
+    {
+      "title": "SociableWeaver",
+      "category": "graphql",
+      "description": "Build declarative GraphQL queries and mutations.",
+      "homepage": "https://github.com/NicholasBellucci/SociableWeaver"
+    },
+    {
+      "title": "Socket.IO",
+      "category": "socket",
+      "description": "Socket.IO client for iOS/OS X.",
+      "homepage": "https://github.com/socketio/socket.io-client-swift",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "sockets",
+      "category": "socket",
+      "description": "TCP, UDP; Client, Server; Linux, OS X.",
+      "homepage": "https://github.com/vapor-community/sockets",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "Solar",
+      "category": "utility",
+      "description": "Calculate sunrise and sunset times given a location.",
+      "homepage": "https://github.com/ceeK/Solar"
+    },
+    {
+      "title": "SolarNetwork",
+      "category": "network",
+      "description": "Elegant network abstraction layer.",
+      "homepage": "https://github.com/ThreeGayHub/SolarNetwork"
+    },
+    {
+      "title": "Soundable",
+      "category": "audio",
+      "description": "Soundable allows you to play sounds, single and in sequence, in a very easy way.",
+      "homepage": "https://github.com/lcardevnas/Soundable",
+      "tags": [
+        "avfoundation",
+        "sound",
+        "audio",
+        "avaudioplayer",
+        "avqueueplayer",
+        "avaudiosession",
+        "ios",
         "swift"
       ]
     },
     {
-      "title":"MCScratchImageView",
-      "category":"images",
-      "description":"A custom ImageView that is used to cover the surface of other view like a scratch card, user can swipe the mulch to see the view below.",
-      "homepage":"https://github.com/JaylenCoding/MCScratchImageView"
-    },
-    {
-      "title":"Ease",
-      "category":"animation",
-      "description":"Animate everything with Ease.",
-      "homepage":"https://github.com/roberthein/Ease"
-    },
-    {
-      "title":"Stylist",
-      "category":"styling",
-      "description":"Define UI styles in a hot-loadable external yaml or json file.",
-      "homepage":"https://github.com/yonaskolb/Stylist"
-    },
-    {
-      "title":"StatusAlert",
-      "category":"alert",
-      "description":"Display Apple system-like self-hiding status alerts without interrupting user flow.",
-      "homepage":"https://github.com/LowKostKustomz/StatusAlert"
-    },
-    {
-      "title":"Beak",
-      "category":"misc",
-      "description":"A command line interface for your Swift scripts.",
-      "homepage":"https://github.com/yonaskolb/Beak"
-    },
-    {
-      "title":"CodableWrappers",
-      "category":"misc",
-      "description":"A Collection of PropertyWrappers to make custom Serialization of Codable Types easy.",
-      "homepage":"https://github.com/GottaGetSwifty/CodableWrappers",
-      "tags":[
-        "swift",
-        "codable",
-        "property-wrappers"
+      "title": "SourceDocs",
+      "category": "documentation",
+      "description": "Generate Markdown reference documentation that lives with your code.",
+      "homepage": "https://github.com/SourceDocs/SourceDocs",
+      "tags": [
+        "documentation",
+        "reference",
+        "markdown",
+        "generator"
       ]
     },
     {
-      "title":"Forked",
-      "category":"misc",
-      "description":"Generalized approach to managing shared data in Swift applications to support Local-first apps.",
-      "homepage":"https://github.com/drewmccormack/Forked",
-      "tags":[
+      "title": "SPAlert",
+      "category": "alert",
+      "description": "Native popup from Apple Music & Feedback in AppStore. Contains Done & Heart presets.",
+      "homepage": "https://github.com/sparrowcode/AlertKit",
+      "tags": [
         "swift",
-        "codable"
+        "UI"
       ]
     },
     {
-      "title":"Fluid Slider",
-      "category":"ui",
-      "description":"A slider widget with a popup bubble displaying the precise value selected.",
-      "homepage":"https://github.com/Ramotion/fluid-slider"
+      "title": "Spectre",
+      "category": "testing",
+      "description": "BDD Framework.",
+      "homepage": "https://github.com/kylef/Spectre",
+      "tags": [
+        "linux"
+      ]
     },
     {
-      "title":"SwiftTips",
-      "category":"third-party-guides",
-      "description":"A collection of useful tips by John Sundell.",
-      "homepage":"https://github.com/JohnSundell/SwiftTips"
+      "title": "Spin",
+      "category": "patterns",
+      "description": "Provides a versatile Feedback Loop implementation working with RxSwift, ReactiveSwift and Combine.",
+      "homepage": "https://github.com/Spinners/Spin.Swift",
+      "tags": [
+        "swift",
+        "feedback-loop",
+        "rxswift",
+        "reactiveswift",
+        "combine"
+      ]
     },
     {
-      "title":"ImagineEngine",
-      "category":"game-engine-2d",
-      "description":"Blazing fasst 2D gaming engine.",
-      "homepage":"https://github.com/JohnSundell/ImagineEngine"
+      "title": "SPLarkController",
+      "category": "transition",
+      "description": "Custom transition between two controller. Translate to top.",
+      "homepage": "https://github.com/ivanvorobei/SPLarkController",
+      "tags": [
+        "swift",
+        "animation",
+        "UI",
+        "transition"
+      ]
     },
     {
-      "title":"Alerts Pickers",
-      "category":"alert",
-      "description":"Advanced usage of UIAlertController with TextField, DatePicker, PickerView, TableView and CollectionView.",
-      "homepage":"https://github.com/dillidon/alerts-and-pickers"
+      "title": "SpotifyLogin",
+      "category": "authentication",
+      "description": "Authenticate with the Spotify API.",
+      "homepage": "https://github.com/spotify/SpotifyLogin"
     },
     {
-      "title":"ASCollectionView",
-      "category":"uicollectionview",
-      "description":"Lightweight custom collection view inspired by Airbnb.",
-      "homepage":"https://github.com/abdullahselek/ASCollectionView",
-      "tags":[
+      "title": "Spots",
+      "category": "ui",
+      "description": "Spots is a view controller framework that makes your setup and future development blazingly fast.",
+      "homepage": "https://github.com/hyperoslo"
+    },
+    {
+      "title": "SPPermission",
+      "category": "permissions",
+      "description": "Simple request permission with native UI and interactive animation.",
+      "homepage": "https://github.com/sparrowcode/PermissionsKit"
+    },
+    {
+      "title": "SpreadsheetView",
+      "category": "ui",
+      "description": "Full configurable spreadsheet view user interfaces for iOS applications.",
+      "homepage": "https://github.com/kishikawakatsumi/SpreadsheetView",
+      "tags": [
+        "spreadsheet"
+      ]
+    },
+    {
+      "title": "Spring",
+      "category": "animation",
+      "description": "A library to simplify iOS animations.",
+      "homepage": "https://github.com/MengTo/Spring"
+    },
+    {
+      "title": "Sprinter",
+      "category": "text",
+      "description": "A library for formatting strings.",
+      "homepage": "https://github.com/nicklockwood/Sprinter"
+    },
+    {
+      "title": "SpriteKit+Spring",
+      "category": "utility",
+      "description": "SpriteKit API reproducing UIView's spring animations with SKAction.",
+      "homepage": "https://github.com/ataugeron/SpriteKit-Spring"
+    },
+    {
+      "title": "SpriteKitEasingSwift",
+      "category": "animation",
+      "description": "Better Easing for SpriteKit.",
+      "homepage": "https://github.com/craiggrummitt/SpriteKitEasingSwift"
+    },
+    {
+      "title": "spruce-ios",
+      "category": "animation",
+      "description": "Choreograph animations on the screen.",
+      "homepage": "https://github.com/willowtreeapps/spruce-ios"
+    },
+    {
+      "title": "SPStorkController",
+      "category": "transition",
+      "description": "Now playing controller from Apple Music. Customisable height.",
+      "homepage": "https://github.com/ivanvorobei/SPStorkController",
+      "tags": [
+        "swift",
+        "animation",
+        "UI",
+        "transition",
+        "apple music"
+      ]
+    },
+    {
+      "title": "SQLite.swift",
+      "category": "sqlite",
+      "description": "Framework wrapping SQLite3. Small. Simple. Safe.",
+      "homepage": "https://github.com/stephencelis/SQLite.swift"
+    },
+    {
+      "title": "SQLiteDB",
+      "category": "sqlite",
+      "description": "SQLite wrapper.",
+      "homepage": "https://github.com/FahimF/SQLiteDB"
+    },
+    {
+      "title": "StackViewController",
+      "category": "stackview",
+      "description": "Simplify the use of UIStackView.",
+      "homepage": "https://github.com/seedco/StackViewController"
+    },
+    {
+      "title": "StarryStars",
+      "category": "ui",
+      "description": "Display & edit ratings, fully customizable from interface builder.",
+      "homepage": "https://github.com/peterprokop/StarryStars"
+    },
+    {
+      "title": "Starscream",
+      "category": "socket",
+      "description": "Websockets for iOS and OSX.",
+      "homepage": "https://github.com/daltoniam/Starscream"
+    },
+    {
+      "title": "StarWars.iOS",
+      "category": "transition",
+      "description": "Transition animation to crumble view-controller into tiny pieces.",
+      "homepage": "https://github.com/Yalantis/StarWars.iOS"
+    },
+    {
+      "title": "StatefulViewController",
+      "category": "ui",
+      "description": "Placeholder views based on content, loading, error or empty states.",
+      "homepage": "https://github.com/aschuch/StatefulViewController"
+    },
+    {
+      "title": "StateViewController",
+      "category": "patterns",
+      "description": "Stateful UIVIewController composition — the MVC cure for Massive View Controllers.",
+      "homepage": "https://github.com/davidask/StateViewController"
+    },
+    {
+      "title": "Static",
+      "category": "layout",
+      "description": "A simple static table views for iOS.",
+      "homepage": "https://github.com/venmo/Static"
+    },
+    {
+      "title": "StatusAlert",
+      "category": "alert",
+      "description": "Display Apple system-like self-hiding status alerts without interrupting user flow.",
+      "homepage": "https://github.com/LowKostKustomz/StatusAlert"
+    },
+    {
+      "title": "Stellar",
+      "category": "animation",
+      "description": "A Physical animation library.",
+      "homepage": "https://github.com/AugustRush/Stellar"
+    },
+    {
+      "title": "Stencil",
+      "category": "template",
+      "description": "Simple and powerful template language.",
+      "homepage": "https://github.com/stencilproject/Stencil"
+    },
+    {
+      "title": "StepProgressView",
+      "category": "ui",
+      "description": "Step-by-step progress view with labels and shapes. A good replacement for UIActivityIndicatorView and UIProgressView.",
+      "homepage": "https://github.com/yonat/StepProgressView"
+    },
+    {
+      "title": "Stevia",
+      "category": "layout",
+      "description": "Elegant view layout for iOS.",
+      "homepage": "https://github.com/freshOS/Stevia"
+    },
+    {
+      "title": "STLocationRequest",
+      "category": "location",
+      "description": "An elegant and simple 3D Flyover Location Request Screen.",
+      "homepage": "https://github.com/SvenTiigi/STLocationRequest"
+    },
+    {
+      "title": "StorageManager",
+      "category": "other-data",
+      "description": "Safe and easy way to use FileManager as Database.",
+      "homepage": "https://github.com/iAmrSalman/StorageManager"
+    },
+    {
+      "title": "Storez",
+      "category": "key-value-store",
+      "description": "Safe, statically-typed, store-agnostic key-value storage.",
+      "homepage": "https://github.com/SwiftKitz/Storez"
+    },
+    {
+      "title": "StringSwitch",
+      "category": "localization",
+      "description": "Easily convert iOS .strings files to Android strings.xml format and vice versa.",
+      "homepage": "https://stringswitch.com"
+    },
+    {
+      "title": "StyledTextKit",
+      "category": "textfield",
+      "description": "Declarative building and fast rendering attributed string library.",
+      "homepage": "https://github.com/GitHawkApp/StyledTextKit"
+    },
+    {
+      "title": "Stylist",
+      "category": "styling",
+      "description": "Define UI styles in a hot-loadable external yaml or json file.",
+      "homepage": "https://github.com/yonaskolb/Stylist"
+    },
+    {
+      "title": "Sugar",
+      "category": "utility",
+      "description": "Something sweet that goes great with your Cocoa.",
+      "homepage": "https://github.com/hyperoslo/Sugar"
+    },
+    {
+      "title": "SugarRecord",
+      "category": "core-data",
+      "description": "Helps with Core Data and Realm.",
+      "homepage": "https://github.com/modo-studio/SugarRecord"
+    },
+    {
+      "title": "SuggestionsKit",
+      "category": "walkthrough",
+      "description": "Library for educating users about features in app.",
+      "homepage": "https://github.com/AlphanumericCharactersOrSingleHyphenz/SuggestionsKit",
+      "tags": [
+        "suggestions",
+        "instructions",
+        "hint",
+        "guide"
+      ]
+    },
+    {
+      "title": "Sukari",
+      "category": "Syntactic Sugar",
+      "description": "Sweet Syntactic Sugar.",
+      "homepage": "https://github.com/christopherkarani/Sukari"
+    },
+    {
+      "title": "Surmagic",
+      "category": "misc",
+      "description": "Create XCFrameworks with ease! A Command Line Tool to create XCFramework for multiple platforms at one shot! iOS, Mac Catalyst, tvOS, macOS, and watchOS.",
+      "homepage": "https://github.com/gurhub/surmagic",
+      "tags": [
+        "xcframework",
+        "fat-framework",
+        "binary-framework",
+        "generate",
+        "iOS",
+        "Mac Catalyst",
+        "macOS",
+        "tvOS",
+        "watchOS",
+        "ci",
+        "swift"
+      ]
+    },
+    {
+      "title": "SVGView",
+      "category": "svg",
+      "description": "SVG parser and renderer written in SwiftUI.",
+      "homepage": "https://github.com/exyte/SVGView"
+    },
+    {
+      "title": "SwagGen",
+      "category": "misc",
+      "description": "A command line tool for generating a REST API from a Swagger spec based off Stencil templates.",
+      "homepage": "https://github.com/yonaskolb/SwagGen",
+      "tags": [
+        "linux",
+        "swagger",
+        "swift",
+        "CI",
+        "generator",
+        "template",
+        "open-api"
+      ]
+    },
+    {
+      "title": "SweetAlert",
+      "category": "alert",
+      "description": "Alert system.",
+      "homepage": "https://github.com/codestergit/SweetAlert-iOS"
+    },
+    {
+      "title": "SweetCurtain",
+      "category": "ui",
+      "description": "Really sweet and easy bottom pullable sheet implementation. You can find a similar implementation in applications like Apple Maps, Find My, Stocks, etc.",
+      "homepage": "https://github.com/ihormalovanyi/SweetCurtain",
+      "tags": [
+        "swift",
+        "pull-up",
+        "curtain",
+        "bottom-sheet",
+        "sliding-menu"
+      ]
+    },
+    {
+      "title": "Swift & SwiftUI Tutorials",
+      "category": "third-party-guides",
+      "description": "SwiftUI learning with Ease.",
+      "homepage": "http://ww1.janeshswift.com"
+    },
+    {
+      "title": "Swift Argument Parser",
+      "category": "command-line",
+      "description": "Straightforward, type-safe argument parsing for Swift.",
+      "homepage": "https://github.com/apple/swift-argument-parser"
+    },
+    {
+      "title": "Swift Education",
+      "category": "third-party-guides",
+      "description": "A community of educators sharing materials for teaching Swift and app development.",
+      "homepage": "https://github.com/swifteducation"
+    },
+    {
+      "title": "Swift for Scripting",
+      "category": "scripting",
+      "description": "A hand-curated collection of useful and informative scripting material.",
+      "homepage": "https://github.com/artemnovichkov/Swift-For-Scripting",
+      "tags": [
+        "swift",
+        "scripting"
+      ]
+    },
+    {
+      "title": "Swift Module Template",
+      "category": "boilerplates",
+      "description": "An opinionated starting point for awesome, reusable modules.",
+      "homepage": "https://github.com/fulldecent/swift6-module-template"
+    },
+    {
+      "title": "swift-algorithm-club",
+      "category": "algorithm",
+      "description": "Algorithms and data structures, with explanations.",
+      "homepage": "https://github.com/kodecocodes/swift-algorithm-club"
+    },
+    {
+      "title": "swift-build",
+      "category": "utility",
+      "description": "GitHub Action for building and testing Swift packages across all platforms.",
+      "homepage": "https://github.com/brightdigit/swift-build",
+      "tags": [
+        "swift",
+        "github"
+      ]
+    },
+    {
+      "title": "swift-colab",
+      "category": "google-colaboratory",
+      "description": "Run Swift in a browser.",
+      "homepage": "https://github.com/philipturner/swift-colab"
+    },
+    {
+      "title": "swift-mod",
+      "category": "quality",
+      "description": "A tool for Swift code modification intermediating between code generation and formatting.",
+      "homepage": "https://github.com/ra1028/swift-mod"
+    },
+    {
+      "title": "swift-mode",
+      "category": "emacs",
+      "description": "Emacs support, including partial flycheck error support.",
+      "homepage": "https://github.com/swift-emacs/swift-mode"
+    },
+    {
+      "title": "swift-package-manager",
+      "category": "dependency-managers",
+      "description": "SPM is the Package Manager for the Swift Programming Language.",
+      "homepage": "https://github.com/swiftlang/swift-package-manager"
+    },
+    {
+      "title": "Swift-Prompts",
+      "category": "alert",
+      "description": "Design custom prompts with a great scope of options to choose from.",
+      "homepage": "https://github.com/GabrielAlva/Swift-Prompts"
+    },
+    {
+      "title": "swift-protobuf",
+      "category": "utility",
+      "description": "A plugin and runtime library for using Google's Protocol Buffer.",
+      "homepage": "https://github.com/apple/swift-protobuf",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "Swift-Sodium",
+      "category": "cryptography",
+      "description": "Interface to the Sodium library for common crypto operations for iOS and OS X.",
+      "homepage": "https://github.com/jedisct1/swift-sodium"
+    },
+    {
+      "title": "swift-testing-expectation",
+      "category": "testing",
+      "description": "Create an asynchronous expectation in Swift Testing.",
+      "homepage": "https://github.com/dfed/swift-testing-expectation"
+    },
+    {
+      "title": "swift-tips",
+      "category": "third-party-guides",
+      "description": "A series of useful tips by Vincent Pradeilles.",
+      "homepage": "https://github.com/vincent-pradeilles/swift-tips"
+    },
+    {
+      "title": "swift-vim",
+      "category": "vim",
+      "description": "Vim runtime files.",
+      "homepage": "https://github.com/keith/swift.vim"
+    },
+    {
+      "title": "SwiftAudioPlayer",
+      "category": "audio",
+      "description": "Simple audio player for iOS that streams and performs realtime audio manipulations with AVAudioEngine.",
+      "homepage": "https://github.com/tanhakabir/SwiftAudioPlayer"
+    },
+    {
+      "title": "SwiftAutoGUI",
+      "category": "utility",
+      "description": "Used to programmatically control the mouse & keyboard. A library for manipulating macOS with Swift.",
+      "homepage": "https://github.com/NakaokaRei/SwiftAutoGUI",
+      "tags": [
+        "swift",
+        "macos"
+      ]
+    },
+    {
+      "title": "SwiftBoost",
+      "category": "utility",
+      "description": "Collection of Swift-extensions to boost development process.",
+      "homepage": "https://github.com/sparrowcode/SwiftBoost",
+      "tags": [
+        "swift",
+        "productivity",
+        "boost"
+      ]
+    },
+    {
+      "title": "Swiftbot",
+      "category": "utility",
+      "description": "run swift code on slack.",
+      "homepage": "https://github.com/noppefoxwolf/Swiftbot"
+    },
+    {
+      "title": "Swiftbrew",
+      "category": "misc",
+      "description": "Homebrew for Swift packages.",
+      "homepage": "https://github.com/swiftbrew/Swiftbrew"
+    },
+    {
+      "title": "SwiftChart",
+      "category": "chart",
+      "description": "A simple line and area charting library for iOS. Supports multiple series, partially filled series and touch events.",
+      "homepage": "https://github.com/gpbl/SwiftChart"
+    },
+    {
+      "title": "SwiftCharts",
+      "category": "chart",
+      "description": "Highly customizable charts for iOS.",
+      "homepage": "https://github.com/ivnsch/SwiftCharts"
+    },
+    {
+      "title": "SwiftCheck",
+      "category": "testing",
+      "description": "A testing library that automatically generates random data for testing program properties.",
+      "homepage": "https://github.com/typelift/SwiftCheck"
+    },
+    {
+      "title": "SwiftCLI",
+      "category": "command-line",
+      "description": "A powerful framework that can be used to develop a CLI.",
+      "homepage": "https://github.com/jakeheis/SwiftCLI",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "SwiftCop",
+      "category": "quality",
+      "description": "A validation library which inspired by the clarity of Ruby On Rails Active Record validations.",
+      "homepage": "https://github.com/andresinaka/SwiftCop"
+    },
+    {
+      "title": "SwiftCoroutine",
+      "category": "concurrency",
+      "description": "Coroutines for iOS, macOS and Linux.",
+      "homepage": "https://github.com/belozierov/SwiftCoroutine",
+      "tags": [
+        "linux",
+        "swift",
+        "coroutine",
+        "coroutines",
+        "await",
+        "async/await"
+      ]
+    },
+    {
+      "title": "SwiftCssParser",
+      "category": "template",
+      "description": "Extensible CSS parser.",
+      "homepage": "https://github.com/100mango/SwiftCssParser"
+    },
+    {
+      "title": "SwiftCurrent",
+      "category": "app-routing",
+      "description": "Manage complex workflows wherever Swift can be built. It comes with built-in support for UIKit, Storyboards, and SwiftUI.",
+      "homepage": "https://github.com/wwt/SwiftCurrent",
+      "tags": [
+        "uikit",
+        "storyboard",
+        "swiftui",
+        "iOS",
+        "watchOS",
+        "tvOS",
+        "macOS",
+        "declarative",
+        "navigation"
+      ]
+    },
+    {
+      "title": "SwiftDate",
+      "category": "date",
+      "description": "Easy NSDate Management.",
+      "homepage": "https://github.com/malcommac/SwiftDate"
+    },
+    {
+      "title": "SwiftDisc",
+      "category": "api",
+      "description": "Discord API library for bots and integrations.",
+      "homepage": "https://github.com/M1tsumi/SwiftDisc"
+    },
+    {
+      "title": "SwiftDoc",
+      "category": "third-party-guides",
+      "description": "Auto-generated documentation.",
+      "homepage": "https://sosumi.ai/"
+    },
+    {
+      "title": "SwiftDraw",
+      "category": "images",
+      "description": "Library that converts SVG images to UIImage, NSImage and generates CoreGraphics source code.",
+      "homepage": "https://github.com/swhitty/SwiftDraw",
+      "tags": [
+        "swift",
         "ios",
-        "customcollectionview",
-        "custom ui"
+        "macos"
       ]
     },
     {
-      "title":"AZCollectionViewController",
-      "category":"uicollectionview",
-      "description":"Easy way to integrate pagination with dummy views in CollectionView, make Instagram Discover withing minutes.",
-      "homepage":"https://github.com/AfrozZaheer/AZCollectionViewController"
+      "title": "SwiftEntryKit",
+      "category": "alert",
+      "description": "A simple and versatile pop-up presenter.",
+      "homepage": "https://github.com/huri000/SwiftEntryKit"
     },
     {
-      "title":"GradientProgressBar",
-      "category":"ui",
-      "description":"An animated gradient progress bar.",
-      "homepage":"https://github.com/fxm90/GradientProgressBar"
-    },
-    {
-      "title":"GradientLoadingBar",
-      "category":"hud",
-      "description":"An animated gradient loading bar.",
-      "homepage":"https://github.com/fxm90/GradientLoadingBar"
-    },
-    {
-      "title":"Thingy",
-      "category":"device",
-      "description":"A modern device detection and querying library.",
-      "homepage":"https://github.com/bojan/Thingy",
-      "tags":[
-        "device",
-        "system"
+      "title": "swifter",
+      "category": "webserver",
+      "description": "Http server with routing handler.",
+      "homepage": "https://github.com/httpswift/swifter",
+      "tags": [
+        "linux"
       ]
     },
     {
-      "title":"NextLevelSessionExporter",
-      "category":"video",
-      "description":"Export and transcode media.",
-      "homepage":"https://github.com/NextLevel/NextLevelSessionExporter"
+      "title": "Swifter Twitter",
+      "category": "api",
+      "description": "Twitter framework.",
+      "homepage": "https://github.com/mattdonnelly/Swifter"
     },
     {
-      "title":"Online Swift Playground",
-      "category":"repl",
-      "description":"Online Swift Playground.",
-      "homepage":"http://online.swiftplayground.run",
-      "tags":[
+      "title": "SwifterSwift",
+      "category": "utility",
+      "description": "A handy collection of more than 500 native extensions to boost your productivity.",
+      "homepage": "https://github.com/SwifterSwift/SwifterSwift",
+      "tags": [
+        "extensions",
+        "ios"
+      ]
+    },
+    {
+      "title": "SwiftEventBus",
+      "category": "events",
+      "description": "A publish/subscribe event bus optimized for iOS.",
+      "homepage": "https://github.com/cesarferreira/SwiftEventBus"
+    },
+    {
+      "title": "SwiftFFmpeg",
+      "category": "video",
+      "description": "A wrapper for the FFmpeg C API.",
+      "homepage": "https://github.com/sunlubo/SwiftFFmpeg"
+    },
+    {
+      "title": "SwiftFiddle",
+      "category": "repl",
+      "description": "Playground for making, sharing, and embedding Swift code.",
+      "homepage": "https://swiftfiddle.com",
+      "tags": [
         "swift",
         "repl",
         "playground"
       ]
     },
     {
-      "title":"ARVideoKit",
-      "category":"augmented-reality",
-      "description":"Capture & record ARKit videos, photos, Live Photos, and GIFs.",
-      "homepage":"https://github.com/AFathi/ARVideoKit",
-      "tags":[
-        "AR",
-        "augmented",
-        "reality",
-        "video"
-      ]
+      "title": "SwiftFormat",
+      "category": "quality",
+      "description": "A code library and command-line formatting tool for reformatting Swift code.",
+      "homepage": "https://github.com/nicklockwood/SwiftFormat"
     },
     {
-      "title":"PredicateFlow",
-      "category":"text",
-      "description":"PredicateFlow is a builder that allows you to write amazing, strong-typed and easy-to-read NSPredicate.",
-      "homepage":"https://github.com/andreadelfante/PredicateFlow"
+      "title": "SwiftGen",
+      "category": "misc",
+      "description": "A suite of tools to auto-generate code for various assets of your project.",
+      "homepage": "https://github.com/SwiftGen/SwiftGen"
     },
     {
-      "title":"Shallows",
-      "category":"multi-database",
-      "description":"Your lightweight persistence toolbox.",
-      "homepage":"https://github.com/dreymonde/Shallows"
+      "title": "SwiftGen-Assets",
+      "category": "images",
+      "description": "A tool to auto-generate `enums` for all your `UIImages` from your Assets Catalogs.",
+      "homepage": "https://github.com/SwiftGen/SwiftGen#assets-catalogs"
     },
     {
-      "title":"Tempura",
-      "category":"events",
-      "description":"A holistic approach to iOS development, inspired by Redux and MVVM.",
-      "homepage":"https://github.com/BendingSpoons/tempura-swift"
+      "title": "SwiftGen-Colors",
+      "category": "colors",
+      "description": "A tool to auto-generate `enums` for your `UIColor` constants.",
+      "homepage": "https://github.com/SwiftGen/SwiftGen#uicolor"
     },
     {
-      "title":"SlideController",
-      "category":"pagination",
-      "description":"It is a nice alternative for UIPageViewController built using power of generic types. Swipe between pages with an interactive title navigation control. Configure horizontal or vertical chains for unlimited pages amount.",
-      "homepage":"https://github.com/touchlane/SlideController"
+      "title": "SwiftGen-L10n",
+      "category": "localization",
+      "description": "A tool to auto-generate `enums` for all your Localizable.strings keys (with appropriate associated values if those strings contains printf-format placeholders like `%@`).",
+      "homepage": "https://github.com/SwiftGen/SwiftGen#localizablestrings"
     },
     {
-      "title":"Croc",
-      "category":"text",
-      "description":"A lightweight Emoji parsing and querying library.",
-      "homepage":"https://github.com/JKalash/Croc",
-      "tags":[
-        "emoji",
-        "croc",
-        "macOS",
-        "iOS",
-        "tvOS"
-      ]
+      "title": "SwiftGen-Storyboard",
+      "category": "utility",
+      "description": "A tool to auto-generate `enums` for all your Storyboards, Scenes and Segues constants + appropriate convenience accessors.",
+      "homepage": "https://github.com/SwiftGen/SwiftGen#uistoryboard"
     },
     {
-      "title":"Blueprints",
-      "category":"uicollectionview",
-      "description":"A framework that is meant to make your life easier when working with collection view flow layouts.",
-      "homepage":"https://github.com/zenangst/Blueprints"
-    },
-    {
-      "title":"Linker",
-      "category":"app-routing",
-      "description":"Lightweight way to handle internal and external deeplinks for iOS.",
-      "homepage":"https://github.com/MaksimKurpa/Linker"
-    },
-    {
-      "title":"Delegated",
-      "category":"utility",
-      "description":"Closure-based delegation without memory leaks.",
-      "homepage":"https://github.com/dreymonde/Delegated",
-      "swift":4
-    },
-    {
-      "title":"LayoutLess",
-      "category":"layout",
-      "description":"Write less UI Code.",
-      "homepage":"https://github.com/DeclarativeHub/Layoutless",
-      "swift":4
-    },
-    {
-      "title":"BlockiesSwift",
-      "category":"images",
-      "description":"Unique blocky identicons/profile picture generator.",
-      "homepage":"https://github.com/Boilertalk/BlockiesSwift",
-      "swift":4,
-      "tags":[
-        "profile-picture",
-        "identicons",
-        "image",
-        "generator"
-      ]
-    },
-    {
-      "title":"RetroProgress",
-      "category":"ui",
-      "description":"Retro looking progress bar straight from the 90s.",
-      "homepage":"https://github.com/hyperoslo/RetroProgress"
-    },
-    {
-      "title":"KeyPathKit",
-      "category":"other-data",
-      "description":"KeyPathKit provides a seamless syntax to manipulate data using typed keypaths.",
-      "homepage":"https://github.com/vincent-pradeilles/KeyPathKit"
-    },
-    {
-      "title":"swift-tips",
-      "category":"third-party-guides",
-      "description":"A series of useful tips by Vincent Pradeilles.",
-      "homepage":"https://github.com/vincent-pradeilles/swift-tips"
-    },
-    {
-      "title":"Localize",
-      "category":"localization",
-      "description":"Localize apps using e.g. regular expressions in Localizable.strings.",
-      "homepage":"https://github.com/andresilvagomez/Localize"
-    },
-    {
-      "title":"StorageManager",
-      "category":"other-data",
-      "description":"Safe and easy way to use FileManager as Database.",
-      "homepage":"https://github.com/iAmrSalman/StorageManager"
-    },
-    {
-      "title":"Dots",
-      "category":"network",
-      "description":"Lightweight Concurrent Networking Framework.",
-      "homepage":"https://github.com/iAmrSalman/Dots"
-    },
-    {
-      "title":"merchantkit",
-      "category":"app-store",
-      "description":"A modern In-App Purchases management framework for iOS.",
-      "homepage":"https://github.com/benjaminmayo/merchantkit"
-    },
-    {
-      "title":"Swift for Scripting",
-      "category":"scripting",
-      "description":"A hand-curated collection of useful and informative scripting material.",
-      "homepage":"https://github.com/artemnovichkov/Swift-For-Scripting",
-      "tags":[
+      "title": "SwiftGodot",
+      "category": "game-engine",
+      "description": "Swift bindings for the Godot game engine to build extensions or act as an api with SwiftGodotKit.",
+      "homepage": "https://migueldeicaza.github.io/SwiftGodotDocs/tutorials/swiftgodot-tutorials/",
+      "tags": [
         "swift",
-        "scripting"
+        "game-engine",
+        "bindings"
       ]
     },
     {
-      "title":"TraceLog",
-      "category":"logging",
-      "description":"Dead Simple: logging the way it's meant to be!  Runs on iOS, macOS, and Linux.",
-      "homepage":"https://github.com/tonystone/tracelog",
-      "tags":[
+      "title": "SwiftGuide CN",
+      "category": "third-party-guides",
+      "description": "A Chinese written guide.",
+      "homepage": "https://github.com/ipader/SwiftGuide"
+    },
+    {
+      "title": "SwiftHEXColors",
+      "category": "colors",
+      "description": "HEX color handling as an extension for UIColor.",
+      "homepage": "https://github.com/thii/SwiftHEXColors"
+    },
+    {
+      "title": "SwiftHTTP",
+      "category": "network",
+      "description": "NSURLSession wrapper.",
+      "homepage": "https://github.com/daltoniam/SwiftHTTP"
+    },
+    {
+      "title": "SwiftIconFont",
+      "category": "fonts",
+      "description": "Fontawesome, Iconic, Ionicons, Octicon ports.",
+      "homepage": "https://github.com/segecey/SwiftIconFont"
+    },
+    {
+      "title": "SwiftIcons",
+      "category": "fonts",
+      "description": "Library for Font Icons: dripicons, emoji, font awesome, icofont, ionicons, linear icons, map icons, material icons, open iconic, state, weather.",
+      "homepage": "https://github.com/ranesr/SwiftIcons"
+    },
+    {
+      "title": "Swiftify",
+      "category": "converters",
+      "description": "Objective-C to Swift online code converter and Xcode extension.",
+      "homepage": "https://swiftify.com/#/converter/code/",
+      "tags": [
+        "extensions",
+        "ios",
+        "macos",
+        "objective-c",
+        "swift"
+      ]
+    },
+    {
+      "title": "SwiftKeychainWrapper",
+      "category": "keychain",
+      "description": "Simple static wrapper for the iOS Keychain to allow you to use it in a similar fashion to user defaults.",
+      "homepage": "https://github.com/jrendel/SwiftKeychainWrapper"
+    },
+    {
+      "title": "SwiftKit",
+      "category": "misc",
+      "description": "Start your next Open-Source Swift Framework 📦.",
+      "homepage": "https://github.com/SvenTiigi/SwiftKit",
+      "tags": [
+        "cli",
+        "swift",
+        "generate",
+        "framework",
+        "xcode",
+        "script",
+        "brew"
+      ]
+    },
+    {
+      "title": "Swiftkube",
+      "category": "api",
+      "description": "Swift client for Kubernetes.",
+      "homepage": "https://github.com/swiftkube/client",
+      "tags": [
+        "linux",
+        "macos",
+        "kubernetes",
+        "cloud"
+      ]
+    },
+    {
+      "title": "SwiftLCS",
+      "category": "algorithm",
+      "description": "implementation of the longest common subsequence (LCS) algorithm.",
+      "homepage": "https://github.com/Frugghi/SwiftLCS",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "SwiftLee",
+      "category": "Newsletter",
+      "description": "A weekly blog about Swift, iOS and Xcode Tips and Tricks.",
+      "homepage": "https://www.avanderlee.com/",
+      "tags": [
+        "swift",
+        "iOS",
+        "swiftui"
+      ]
+    },
+    {
+      "title": "Swiftline",
+      "category": "command-line",
+      "description": "A set of tools to help you create command line applications.",
+      "homepage": "https://github.com/nsomar/Swiftline"
+    },
+    {
+      "title": "SwiftLinkPreview",
+      "category": "utility",
+      "description": "It makes a preview from an url, grabbing all information such as title, relevant texts and images.",
+      "homepage": "https://github.com/LeonardoCardoso/SwiftLinkPreview"
+    },
+    {
+      "title": "SwiftLint",
+      "category": "quality",
+      "description": "A tool to enforce coding conventions.",
+      "homepage": "https://github.com/realm/SwiftLint"
+    },
+    {
+      "title": "SwiftLocation",
+      "category": "ibeacon",
+      "description": "Location & Beacon Monitoring.",
+      "homepage": "https://github.com/malcommac/SwiftLocation"
+    },
+    {
+      "title": "Swiftly",
+      "category": "dependency-managers",
+      "description": "Swift CLI toolchain installer to install different versions of Swift.",
+      "homepage": "https://github.com/swiftlang/swiftly",
+      "tags": [
+        "swift",
+        "dependency",
+        "cli"
+      ]
+    },
+    {
+      "title": "SwiftlySalesforce",
+      "category": "api",
+      "description": "Framework for rapid development of native iOS apps that integrate with Salesforce.",
+      "homepage": "https://github.com/mike4aday/SwiftlySalesforce"
+    },
+    {
+      "title": "SwiftMessages",
+      "category": "alert",
+      "description": "A very flexible message bar for iOS.",
+      "homepage": "https://github.com/SwiftKickMobile/SwiftMessages"
+    },
+    {
+      "title": "SwiftOCR",
+      "category": "ocr",
+      "description": "Neural Network based OCR lib.",
+      "homepage": "https://github.com/NMAC427/SwiftOCR"
+    },
+    {
+      "title": "SwiftOverlays",
+      "category": "alert",
+      "description": "various popups and notifications.",
+      "homepage": "https://github.com/peterprokop/SwiftOverlays"
+    },
+    {
+      "title": "SwiftPlantUML",
+      "category": "utility",
+      "description": "A command-line tool and Swift Package to generate UML class from your Swift source code. Also available as Xcode Source Editor Extension.",
+      "homepage": "https://github.com/MarcoEidinger/SwiftPlantUML"
+    },
+    {
+      "title": "SwiftPlate",
+      "category": "misc",
+      "description": "Easily generate cross platform framework projects from the command line.",
+      "homepage": "https://github.com/JohnSundell/SwiftPlate"
+    },
+    {
+      "title": "SwiftRandom",
+      "category": "utility",
+      "description": "A tiny generator of random data.",
+      "homepage": "https://github.com/thellimist/SwiftRandom"
+    },
+    {
+      "title": "SwiftRater",
+      "category": "utility",
+      "description": "A utility that reminds your iPhone app's users to review the app.",
+      "homepage": "https://github.com/takecian/SwiftRater"
+    },
+    {
+      "title": "SwiftRichString",
+      "category": "text",
+      "description": "Elegant & Painless Attributed Strings Management Library.",
+      "homepage": "https://github.com/malcommac/SwiftRichString"
+    },
+    {
+      "title": "SwiftRouter",
+      "category": "app-routing",
+      "description": "A URL Router for iOS.",
+      "homepage": "https://github.com/skyline75489/SwiftRouter"
+    },
+    {
+      "title": "SwiftShareBubbles",
+      "category": "button",
+      "description": "Animated social share buttons control for iOS.",
+      "homepage": "https://github.com/takecian/SwiftShareBubbles"
+    },
+    {
+      "title": "SwiftShell",
+      "category": "command-line",
+      "description": "A library for creating command-line applications and running shell commands.",
+      "homepage": "https://github.com/kareman/SwiftShell"
+    },
+    {
+      "title": "SwiftSocket",
+      "category": "socket",
+      "description": "Simple TCP socket library.",
+      "homepage": "https://github.com/swiftsocket/SwiftSocket"
+    },
+    {
+      "title": "SwiftSoup",
+      "category": "html",
+      "description": "HTML Parser, with best of DOM, CSS, and jquery.",
+      "homepage": "https://github.com/scinfu/SwiftSoup",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "SwiftSpreadsheet",
+      "category": "uicollectionview",
+      "description": "Fully customizable spreadsheet CollectionViewLayout.",
+      "homepage": "https://github.com/stuffrabbit/SwiftSpreadsheet"
+    },
+    {
+      "title": "SwiftStore",
+      "category": "key-value-store",
+      "description": "A Key-Value store backed by LevelDB.",
+      "homepage": "https://github.com/hemantasapkota/SwiftStore"
+    },
+    {
+      "title": "Swiftstraints",
+      "category": "auto-layout",
+      "description": "Powerful auto-layout framework that lets you write constraints in one line of code.",
+      "homepage": "https://github.com/Skyvive/Swiftstraints"
+    },
+    {
+      "title": "SwiftSVG",
+      "category": "images",
+      "description": "A single pass SVG parser with multiple interface options (String, NS/UIBezierPath, CAShapeLayer, and NS/UIView).",
+      "homepage": "https://github.com/mchoe/SwiftSVG"
+    },
+    {
+      "title": "SwiftTheme",
+      "category": "styling",
+      "description": "Powerful theme/skin manager for iOS 8+.",
+      "homepage": "https://github.com/wxxsw/SwiftTheme"
+    },
+    {
+      "title": "SwiftTips",
+      "category": "third-party-guides",
+      "description": "A collection of useful tips by John Sundell.",
+      "homepage": "https://github.com/JohnSundell/SwiftTips"
+    },
+    {
+      "title": "SwiftTweaks",
+      "category": "utility",
+      "description": "Tweak your iOS app without recompiling.",
+      "homepage": "https://github.com/bryanjclark/SwiftTweaks"
+    },
+    {
+      "title": "SwiftUI Atom Properties",
+      "category": "patterns",
+      "description": "A Reactive Data-Binding and Dependency Injection Library for SwiftUI x Concurrency.",
+      "homepage": "https://github.com/ra1028/swiftui-atom-properties",
+      "tags": [
+        "swift",
+        "swiftui",
+        "architecture"
+      ]
+    },
+    {
+      "title": "SwiftUI-FontIcon",
+      "category": "fonts",
+      "description": "Font icons for SwiftUI: font awesome, ionicons, material icons.",
+      "homepage": "https://github.com/huybuidac/SwiftUIFontIcon"
+    },
+    {
+      "title": "SwiftUICharts",
+      "category": "chart",
+      "description": "A charts / plotting library for SwiftUI. Works on macOS, iOS, watchOS, and tvOS and has accessibility and Localization features built in.",
+      "homepage": "https://github.com/willdale/SwiftUICharts",
+      "tags": [
+        "iOS",
+        "macOS",
+        "tvOS",
+        "watchOS",
+        "swiftui"
+      ]
+    },
+    {
+      "title": "SwiftUIMaterialTabs",
+      "category": "tab",
+      "description": "Material 3-style tabs and Sticky Headers rolled into one SwiftUI library",
+      "homepage": "https://github.com/SwiftKickMobile/SwiftUIMaterialTabs",
+      "tags": [
+        "swiftui",
+        "tab",
+        "ios",
+        "scroll",
+        "header"
+      ]
+    },
+    {
+      "title": "SwiftUIRoutes",
+      "category": "app-routing",
+      "description": "A minimal and flexible router for SwiftUI apps.",
+      "homepage": "https://github.com/gabriel/swiftui-routes"
+    },
+    {
+      "title": "SwiftUISkia",
+      "category": "ui",
+      "description": "Skia based 2d graphics SwiftUI rendering library, based on Rust to implement software rasterization to perform rendering",
+      "homepage": "https://github.com/rustq/swiftui-skia",
+      "tags": [
+        "swift",
+        "swiftui",
+        "skia",
+        "rust"
+      ]
+    },
+    {
+      "title": "SwiftValidator",
+      "category": "validation",
+      "description": "A rule-based validation library.",
+      "homepage": "https://github.com/SwiftValidatorCommunity/SwiftValidator"
+    },
+    {
+      "title": "SwiftValidators",
+      "category": "validation",
+      "description": "String validation for iOS (inspired by validator.js).",
+      "homepage": "https://github.com/gkaimakas/SwiftValidators"
+    },
+    {
+      "title": "SwiftVerbalExpressions",
+      "category": "text",
+      "description": "VerbalExpressions porting.",
+      "homepage": "https://github.com/VerbalExpressions/SwiftVerbalExpressions"
+    },
+    {
+      "title": "SwiftVideoBackground",
+      "category": "video",
+      "description": "Easy to Use UIView subclass for implementating a video background.",
+      "homepage": "https://github.com/dingwilson/SwiftVideoBackground"
+    },
+    {
+      "title": "SwiftWebImage",
+      "category": "images",
+      "description": "🚀SwiftUI Image downloader with performant LRU mem/disk cache.",
+      "homepage": "https://github.com/HotWordland/SwiftWebImage"
+    },
+    {
+      "title": "SwiftWebSocket",
+      "category": "socket",
+      "description": "A high performance WebSocket client library .",
+      "homepage": "https://github.com/tidwall/SwiftWebSocket"
+    },
+    {
+      "title": "Swiftx",
+      "category": "utility",
+      "description": "Functional data types and functions for any project.",
+      "homepage": "https://github.com/typelift/Swiftx"
+    },
+    {
+      "title": "Swifty360Player",
+      "category": "video",
+      "description": "iOS 360-degree video player streaming from an AVPlayer.",
+      "homepage": "https://github.com/abdullahselek/Swifty360Player",
+      "tags": [
+        "iOS",
+        "AVPlayer",
+        "360 video player"
+      ]
+    },
+    {
+      "title": "SwiftyAttributes",
+      "category": "text",
+      "description": "Extensions that make it a breeze to work with attributed strings.",
+      "homepage": "https://github.com/eddiekaiger/SwiftyAttributes"
+    },
+    {
+      "title": "SwiftyBeaver",
+      "category": "logging",
+      "description": "Multi-platform logging during development & release.",
+      "homepage": "https://github.com/SwiftyBeaver/SwiftyBeaver",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "SwiftyBluetooth",
+      "category": "bluetooth",
+      "description": "Simple and reliable closure based wrapper around CoreBluetooth.",
+      "homepage": "https://github.com/jordanebelanger/SwiftyBluetooth"
+    },
+    {
+      "title": "SwiftyComments",
+      "category": "uitableview",
+      "description": "Nested hierarchy of expandable/collapsible cells to easily build elegant discussion threads.",
+      "homepage": "https://github.com/tsucres/SwiftyComments"
+    },
+    {
+      "title": "SwiftyFORM",
+      "category": "form",
+      "description": "Forms that can be validated.",
+      "homepage": "https://github.com/neoneye/SwiftyFORM"
+    },
+    {
+      "title": "SwiftyGestureRecognition",
+      "category": "gesture",
+      "description": "UIGestureRecognizers in Xcode Playgrounds.",
+      "homepage": "https://github.com/b3ll/SwiftyGestureRecognition"
+    },
+    {
+      "title": "SwiftyGif",
+      "category": "images",
+      "description": "High performance GIF engine.",
+      "homepage": "https://github.com/alexiscreuzot/SwiftyGif"
+    },
+    {
+      "title": "SwiftyGPIO",
+      "category": "embedded-systems",
+      "description": "Interact with Linux GPIO/SPI/PWM on ARM.",
+      "homepage": "https://github.com/uraimo/SwiftyGPIO",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "SwiftyInsta",
+      "category": "api",
+      "description": "Private and Tokenless Instagram RESTful API.",
+      "homepage": "https://github.com/TheM4hd1/SwiftyInsta"
+    },
+    {
+      "title": "SwiftyJSON",
+      "category": "json",
+      "description": "A lib for JSON with error handling.",
+      "homepage": "https://github.com/SwiftyJSON/SwiftyJSON"
+    },
+    {
+      "title": "SwiftyJSONAccelerator",
+      "category": "json",
+      "description": "macOS app to generate Swift 5 models for JSON (with Codeable).",
+      "homepage": "https://github.com/insanoid/SwiftyJSONAccelerator"
+    },
+    {
+      "title": "SwiftyOAuth",
+      "category": "network",
+      "description": "A small OAuth library with a built-in set of providers.",
+      "homepage": "https://github.com/delba/SwiftyOAuth"
+    },
+    {
+      "title": "SwiftyOnboard",
+      "category": "walkthrough",
+      "description": "An iOS framework that allows developers to create beautiful onboarding experiences.",
+      "homepage": "https://github.com/juanpablofernandez/SwiftyOnboard"
+    },
+    {
+      "title": "SwiftySound",
+      "category": "audio",
+      "description": "Simple library that lets you play sounds with a single line of code.",
+      "homepage": "https://github.com/adamcichy/SwiftySound"
+    },
+    {
+      "title": "SwiftyStoreKit",
+      "category": "app-store",
+      "description": "Lightweight In App Purchases framework.",
+      "homepage": "https://github.com/bizz84/SwiftyStoreKit"
+    },
+    {
+      "title": "SwiftyTextTable",
+      "category": "command-line",
+      "description": "A lightweight library to generate text tables.",
+      "homepage": "https://github.com/scottrhoyt/SwiftyTextTable",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "SwiftyTimer",
+      "category": "thread",
+      "description": "API for NSTimer.",
+      "homepage": "https://github.com/radex/SwiftyTimer"
+    },
+    {
+      "title": "SwiftyUI",
+      "category": "ui",
+      "description": "High performance and lightweight UIView, UIImage, UIImageView, UIlabel, UIButton and more.",
+      "homepage": "https://github.com/haoking/SwiftyUI"
+    },
+    {
+      "title": "SwiftyUserDefaults",
+      "category": "key-value-store",
+      "description": "Cleaner, nicer syntax for NSUserDefaults.",
+      "homepage": "https://github.com/sunshinejr/SwiftyUserDefaults"
+    },
+    {
+      "title": "SwiftyUtils",
+      "category": "utility",
+      "description": "All the reusable code that we need in each project.",
+      "homepage": "https://github.com/tbaranes/SwiftyUtils"
+    },
+    {
+      "title": "SwiftyWalkthrough",
+      "category": "walkthrough",
+      "description": "The easiest way to create a great walkthrough experience in your apps.",
+      "homepage": "https://github.com/ruipfcosta/SwiftyWalkthrough"
+    },
+    {
+      "title": "SwiftyXML",
+      "category": "xml",
+      "description": "The most swifty way to deal with XML.",
+      "homepage": "https://github.com/chenyunguiMilook/SwiftyXML"
+    },
+    {
+      "title": "Swiftz",
+      "category": "utility",
+      "description": "Functional programming.",
+      "homepage": "https://github.com/typelift/Swiftz"
+    },
+    {
+      "title": "Swimat",
+      "category": "quality",
+      "description": "Xcode plugin to format code.",
+      "homepage": "https://github.com/Jintin/Swimat"
+    },
+    {
+      "title": "Swinject",
+      "category": "dependency-injection",
+      "description": "A dependency injection framework.",
+      "homepage": "https://github.com/Swinject/Swinject"
+    },
+    {
+      "title": "SwipeCellKit",
+      "category": "uitableview",
+      "description": "Swipeable UITableViewCell based on the stock Mail.app.",
+      "homepage": "https://github.com/SwipeCellKit/SwipeCellKit"
+    },
+    {
+      "title": "SwipeMenuViewController",
+      "category": "menu",
+      "description": "Swipable tab and menu View and ViewController.",
+      "homepage": "https://github.com/yysskk/SwipeMenuViewController"
+    },
+    {
+      "title": "SwipyCell",
+      "category": "gesture",
+      "description": "UITableViewCell implementing swiping to trigger actions (known from the Mailbox App).",
+      "homepage": "https://github.com/moritzsternemann/SwipyCell"
+    },
+    {
+      "title": "Switch",
+      "category": "switch",
+      "description": "A switch control with full Interface Builder support.",
+      "homepage": "https://github.com/T-Pham/Switch"
+    },
+    {
+      "title": "SWXMLHash",
+      "category": "xml",
+      "description": "Simple XML parsing.",
+      "homepage": "https://github.com/drmohundro/SWXMLHash"
+    },
+    {
+      "title": "SyntaxKit",
+      "category": "utility",
+      "description": "Generate Swift code programmatically with a declarative syntax.",
+      "homepage": "https://github.com/brightdigit/SyntaxKit"
+    },
+    {
+      "title": "SystemKit",
+      "category": "system",
+      "description": "OS X system library.",
+      "homepage": "https://github.com/beltex/SystemKit/"
+    },
+    {
+      "title": "SYSymbol",
+      "category": "fonts",
+      "description": "All the SFSymbols at your fingertips.",
+      "homepage": "https://github.com/Nirma/SFSymbol"
+    },
+    {
+      "title": "TabBar",
+      "category": "tab",
+      "description": "Highly customizable tab bar for SwiftUI applications.",
+      "homepage": "https://github.com/onl1ner/TabBar",
+      "tags": [
+        "swift",
+        "swiftui",
+        "tab-bar",
+        "iOS"
+      ]
+    },
+    {
+      "title": "Tabman",
+      "category": "tab",
+      "description": "A powerful paging view controller with indicator bar.",
+      "homepage": "https://github.com/uias/Tabman",
+      "tags": [
+        "uitabbar",
+        "tabbar",
+        "uipageviewcontroller",
+        "pager",
+        "swift"
+      ]
+    },
+    {
+      "title": "TabPageViewController",
+      "category": "tab",
+      "description": "Paging view controller and scroll tab view.",
+      "homepage": "https://github.com/EndouMari/TabPageViewController"
+    },
+    {
+      "title": "Tactile",
+      "category": "gesture",
+      "description": "A safer and more idiomatic way to respond to gestures and control events.",
+      "homepage": "https://github.com/delba/Tactile"
+    },
+    {
+      "title": "TagCellLayout",
+      "category": "uicollectionview",
+      "description": "UICollectionView layout for Tags with Left, Center & Right alignments.",
+      "homepage": "https://github.com/riteshhgupta/TagCellLayout"
+    },
+    {
+      "title": "Tagging",
+      "category": "text",
+      "description": "A TextView that provides easy to use tagging feature for Mention or Hashtag.",
+      "homepage": "https://github.com/k-lpmg/Tagging"
+    },
+    {
+      "title": "TagListView",
+      "category": "ui",
+      "description": "Simple but highly customizable iOS tag list view.",
+      "homepage": "https://github.com/ElaWorkshop/TagListView"
+    },
+    {
+      "title": "Tailor",
+      "category": "quality",
+      "description": "Cross-platform static analyzer that helps you to write cleaner code and avoid bugs.",
+      "homepage": "https://github.com/sleekbyte/tailor",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "Telegram Bot SDK",
+      "category": "bots",
+      "description": "Unofficial SDK.",
+      "homepage": "https://github.com/rapierorg/telegram-bot-swift",
+      "tags": [
+        "linux",
+        "iOS",
+        "swift",
+        "bot",
+        "telegram"
+      ]
+    },
+    {
+      "title": "Telegrammer",
+      "category": "bots",
+      "description": "Open-source framework for Telegram Bots developers. It was built on top of Apple/SwiftNIO which help to demonstrate excellent performance.",
+      "homepage": "https://github.com/givip/Telegrammer",
+      "tags": [
+        "linux",
+        "swiftnio",
+        "serverside"
+      ]
+    },
+    {
+      "title": "Temple",
+      "category": "template",
+      "description": "🗂️ Most advanced project and file templates.",
+      "homepage": "https://github.com/GoodRequest/Temple",
+      "tags": [
+        "swift",
+        "iOS",
+        "tempalate",
+        "Xcode"
+      ]
+    },
+    {
+      "title": "Tempura",
+      "category": "events",
+      "description": "A holistic approach to iOS development, inspired by Redux and MVVM.",
+      "homepage": "https://github.com/BendingSpoons/tempura-swift"
+    },
+    {
+      "title": "TermiNetwork",
+      "category": "network",
+      "description": "🌏 A zero-dependency networking solution for building modern and secure iOS, watchOS, macOS and tvOS applications.",
+      "homepage": "https://github.com/billp/TermiNetwork"
+    },
+    {
+      "title": "Texstyle",
+      "category": "text",
+      "description": "Texstyle allows you to format attributed strings easily.",
+      "homepage": "https://github.com/rosberry/texstyle"
+    },
+    {
+      "title": "TextAttributes",
+      "category": "text",
+      "description": "An easier way to compose attributed strings.",
+      "homepage": "https://github.com/delba/TextAttributes"
+    },
+    {
+      "title": "TextBuilder",
+      "category": "text",
+      "description": "Like a SwiftUI ViewBuilder, but for Text.",
+      "homepage": "https://github.com/davdroman/swiftui-text-builder"
+    },
+    {
+      "title": "TextFieldCounter",
+      "category": "textfield",
+      "description": "UITextField character counter with lovable UX.",
+      "homepage": "https://github.com/serralvo/TextFieldCounter",
+      "tags": [
+        "textfield"
+      ]
+    },
+    {
+      "title": "TextFieldEffects",
+      "category": "textfield",
+      "description": "Several ready to use effects for UITextFields.",
+      "homepage": "https://github.com/raulriera/TextFieldEffects"
+    },
+    {
+      "title": "The Composable Architecture",
+      "category": "patterns",
+      "description": "A library for building applications in a consistent and understandable way, with composition, testing, and ergonomics in mind.",
+      "homepage": "https://github.com/pointfreeco/swift-composable-architecture",
+      "tags": [
+        "swift",
+        "ios"
+      ]
+    },
+    {
+      "title": "TheAnimation",
+      "category": "animation",
+      "description": "Type-safe CAAnimation wrapper. It makes preventing to set wrong type values.",
+      "homepage": "https://github.com/marty-suzuki/TheAnimation"
+    },
+    {
+      "title": "Themes",
+      "category": "styling",
+      "description": "Theme management.",
+      "homepage": "https://github.com/onmyway133/EasyTheme"
+    },
+    {
+      "title": "Themis",
+      "category": "cryptography",
+      "description": "Multilanguage framework for making typical encryption schemes easy to use: data at rest, authenticated data exchange, transport protection, authentication, and so on.",
+      "homepage": "https://github.com/cossacklabs/themis"
+    },
+    {
+      "title": "Then",
+      "category": "utility",
+      "description": "Super sweet syntactic sugar for initializers.",
+      "homepage": "https://github.com/devxoul/Then"
+    },
+    {
+      "title": "Thingy",
+      "category": "device",
+      "description": "A modern device detection and querying library.",
+      "homepage": "https://github.com/bojan/Thingy",
+      "tags": [
+        "device",
+        "system"
+      ]
+    },
+    {
+      "title": "Throttler",
+      "category": "concurrency",
+      "description": "Throttle massive number of asynchronous inputs in a single drop of one line API.",
+      "homepage": "https://github.com/boraseoksoon/Throttler",
+      "tags": [
+        "ios",
+        "macos",
+        "tvos",
+        "watchos",
+        "swift"
+      ]
+    },
+    {
+      "title": "Tiercel",
+      "category": "network",
+      "description": "Background downloads, relaunch recovery, resumable transfers, and task management for iOS apps.",
+      "homepage": "https://github.com/Danie1s/Tiercel"
+    },
+    {
+      "title": "Time",
+      "category": "date",
+      "description": "Type-safe time calculations, powered by generics.",
+      "homepage": "https://github.com/dreymonde/Time"
+    },
+    {
+      "title": "Timepiece",
+      "category": "date",
+      "description": "Intuitive NSDate extensions.",
+      "homepage": "https://github.com/naoty/Timepiece"
+    },
+    {
+      "title": "TinyConsole",
+      "category": "logging",
+      "description": "A tiny log console to display information while using your iOS app.",
+      "homepage": "https://github.com/Cosmo/TinyConsole"
+    },
+    {
+      "title": "TinyConstraints",
+      "category": "auto-layout",
+      "description": "TinyConstraints is the syntactic sugar that makes Auto Layout sweeter for human use.",
+      "homepage": "https://github.com/roberthein/TinyConstraints"
+    },
+    {
+      "title": "TinyCrayon",
+      "category": "images",
+      "description": "A smart and easy-to-use image masking and cutout SDK for mobile apps.",
+      "homepage": "https://github.com/TinyCrayon/TinyCrayon-iOS-SDK"
+    },
+    {
+      "title": "TKRadarChart",
+      "category": "chart",
+      "description": "A customizable radar chart.",
+      "homepage": "https://github.com/TBXark/TKRadarChart"
+    },
+    {
+      "title": "Toast-Swift",
+      "category": "alert",
+      "description": "An easy to use library to create iOS 14 and newer style toasts.",
+      "homepage": "https://github.com/BastiaanJansen/Toast-Swift"
+    },
+    {
+      "title": "Toaster",
+      "category": "ui",
+      "description": "Notification toasts.",
+      "homepage": "https://github.com/devxoul/Toaster"
+    },
+    {
+      "title": "Tokamak",
+      "category": "events",
+      "description": "React-like declarative API for building native UI components with easy to use one-way data binding.",
+      "homepage": "https://github.com/TokamakUI/Tokamak",
+      "tags": [
+        "react",
+        "redux"
+      ]
+    },
+    {
+      "title": "TOMLDecoder",
+      "category": "toml",
+      "description": "Latest TOML standard, decoded.",
+      "homepage": "https://github.com/dduan/TOMLDecoder"
+    },
+    {
+      "title": "Tomorrowland",
+      "category": "events",
+      "description": "Lightweight Promises.",
+      "homepage": "https://github.com/lilyball/Tomorrowland"
+    },
+    {
+      "title": "TopicEventBus",
+      "category": "events",
+      "description": "Publish–subscribe design pattern implementation framework, with ability to publish events by topic.",
+      "homepage": "https://github.com/mcmatan/topicEventBus"
+    },
+    {
+      "title": "Toucan",
+      "category": "images",
+      "description": "Image processing api.",
+      "homepage": "https://github.com/gavinbunney/Toucan"
+    },
+    {
+      "title": "TouchBridge",
+      "category": "security",
+      "description": "Use your phone's fingerprint to authenticate on any Mac.",
+      "homepage": "https://github.com/HMAKT99/UnTouchID"
+    },
+    {
+      "title": "Toybox",
+      "category": "misc",
+      "description": "Xcode Playground management made easy.",
+      "homepage": "https://github.com/giginet/Toybox"
+    },
+    {
+      "title": "TPInAppReceipt",
+      "category": "payment",
+      "description": "A lightweight, pure-Swift library for reading and validating Apple In App Purchase Receipt locally.",
+      "homepage": "https://github.com/tikhop/TPInAppReceipt",
+      "tags": [
+        "swift",
+        "ios",
+        "tvos",
+        "watchos",
+        "macos",
+        "inAppReceipt",
+        "inAppPurchase",
+        "StoreKit",
+        "receipt"
+      ]
+    },
+    {
+      "title": "TraceLog",
+      "category": "logging",
+      "description": "Dead Simple: logging the way it's meant to be!  Runs on iOS, macOS, and Linux.",
+      "homepage": "https://github.com/tonystone/tracelog",
+      "tags": [
         "log",
         "logger",
         "logging",
@@ -6370,159 +8067,425 @@
       ]
     },
     {
-      "title":"EasyTransitions",
-      "category":"transition",
-      "description":"A simple way to create custom interactive UIViewController transitions.",
-      "homepage":"https://github.com/marcosgriselli/EasyTransitions",
-      "tags":[
+      "title": "Tracker Aggregator",
+      "category": "analytics",
+      "description": "Versatile analytics abstraction layer.",
+      "homepage": "https://github.com/kafejo/Tracker-Aggregator"
+    },
+    {
+      "title": "Transition",
+      "category": "transition",
+      "description": "Easy interactive interruptible custom ViewController transitions.",
+      "homepage": "https://github.com/Touchwonders/Transition"
+    },
+    {
+      "title": "TransitionButton",
+      "category": "button",
+      "description": "UIButton subclass for loading and transition animation.",
+      "homepage": "https://github.com/AladinWay/TransitionButton"
+    },
+    {
+      "title": "Translatio",
+      "category": "localization",
+      "description": "Super lightweight library that helps you to localize strings, even directly in storyboards.",
+      "homepage": "https://github.com/andrealufino/Translatio",
+      "tags": [
+        "localization",
+        "language",
+        "translation"
+      ]
+    },
+    {
+      "title": "TriLabelView",
+      "category": "label",
+      "description": "A triangle shaped corner label view for iOS.",
+      "homepage": "https://github.com/mukeshthawani/TriLabelView"
+    },
+    {
+      "title": "TRON",
+      "category": "network",
+      "description": "Lightweight network abstraction layer, written on top of Alamofire.",
+      "homepage": "https://github.com/MLSDev/TRON"
+    },
+    {
+      "title": "TrueTime.swift",
+      "category": "date",
+      "description": "Get the true current time impervious to device clock time changes (NTP library).",
+      "homepage": "https://github.com/instacart/TrueTime.swift"
+    },
+    {
+      "title": "TSAO",
+      "category": "utility",
+      "description": "Type-Safe Associated Objects.",
+      "homepage": "https://github.com/lilyball/swift-tsao"
+    },
+    {
+      "title": "Tuist",
+      "category": "misc",
+      "description": "An open source command line tool to create, maintain and interact with your Xcode projects at scale.",
+      "homepage": "https://github.com/tuist/tuist"
+    },
+    {
+      "title": "Twinkle",
+      "category": "ui",
+      "description": "Easy way to make elements in your iOS app twinkle.",
+      "homepage": "https://github.com/piemonte/Twinkle"
+    },
+    {
+      "title": "TwitterTextEditor",
+      "category": "text",
+      "description": "A standalone, flexible API that provides a full featured rich text editor for iOS applications.",
+      "homepage": "https://github.com/twitter/TwitterTextEditor"
+    },
+    {
+      "title": "TypedDate",
+      "category": "date",
+      "description": "Enhancing Date handling by enabling type-level customization of date components",
+      "homepage": "https://github.com/Ryu0118/swift-typed-date",
+      "tags": [
+        "swift",
+        "date",
+        "iOS",
+        "macOS",
+        "tvOS"
+      ]
+    },
+    {
+      "title": "Typhoon",
+      "category": "dependency-injection",
+      "description": "Dependency injection toolkit.",
+      "homepage": "https://github.com/appsquickly/Typhoon"
+    },
+    {
+      "title": "Typist",
+      "category": "keyboard",
+      "description": "Small, drop-in UIKit keyboard manager for iOS apps-helps manage keyboard's screen presence and behavior without notification center.",
+      "homepage": "https://github.com/totocaster/Typist",
+      "tags": [
+        "iOS",
+        "swift",
+        "keyboard"
+      ]
+    },
+    {
+      "title": "TZStackView",
+      "category": "stackview",
+      "description": "An iOS9 UIStackView layout component re-implemented for iOS 7 and 8.",
+      "homepage": "https://github.com/tomvanzummeren/TZStackView"
+    },
+    {
+      "title": "UI Testing Cheat Sheet",
+      "category": "testing",
+      "description": "Answers to common \"How do I test this with UI Testing?\" questions with a working example app.",
+      "homepage": "https://github.com/joemasilotti/UI-Testing-Cheat-Sheet"
+    },
+    {
+      "title": "UICollectionViewSplitLayout",
+      "category": "uicollectionview",
+      "description": "UICollectionViewSplitLayout makes collection view more responsive.",
+      "homepage": "https://github.com/yahoojapan/UICollectionViewSplitLayout"
+    },
+    {
+      "title": "UIColor-Hex-Swift",
+      "category": "colors",
+      "description": "Hex to UIColor converter.",
+      "homepage": "https://github.com/yeahdongcn/UIColor-Hex-Swift"
+    },
+    {
+      "title": "UIDeviceComplete",
+      "category": "device",
+      "description": "UIDevice extensions that fill in the missing pieces.",
+      "homepage": "https://github.com/Nirma/UIDeviceComplete"
+    },
+    {
+      "title": "UIFontComplete",
+      "category": "fonts",
+      "description": "Font management (System & Custom) for iOS and tvOS.",
+      "homepage": "https://github.com/Nirma/UIFontComplete"
+    },
+    {
+      "title": "UIGradient",
+      "category": "colors",
+      "description": "A simple and powerful library for using gradient layer, image, color.",
+      "homepage": "https://github.com/dqhieu/UIGradient"
+    },
+    {
+      "title": "UIImageColors",
+      "category": "images",
+      "description": "iTunes style color fetcher for UIImage.",
+      "homepage": "https://github.com/jathu/UIImageColors"
+    },
+    {
+      "title": "UITextField-Navigation",
+      "category": "textfield",
+      "description": "UITextField-Navigation adds next, previous and done buttons to the keyboard for your UITextFields. Highly customizable.",
+      "homepage": "https://github.com/T-Pham/UITextField-Navigation"
+    },
+    {
+      "title": "UltraDrawerView",
+      "category": "ui",
+      "description": "Lightweight, fast and customizable Drawer View implementation identical to Apple Maps, Stocks and etc.",
+      "homepage": "https://github.com/super-ultra/UltraDrawerView"
+    },
+    {
+      "title": "Umbrella",
+      "category": "analytics",
+      "description": "Analytics abstraction layer.",
+      "homepage": "https://github.com/devxoul/Umbrella"
+    },
+    {
+      "title": "Unrealm",
+      "category": "realm",
+      "description": "Unrealm enables you to easily store Swift native Classes, Structs and Enums into Realm.",
+      "homepage": "https://github.com/matghazaryan/Unrealm",
+      "tags": [
+        "swift",
+        "realm",
+        "data-management",
+        "struct"
+      ]
+    },
+    {
+      "title": "Upsurge",
+      "category": "math",
+      "description": "Simple and fast matrix and vector math.",
+      "homepage": "https://github.com/alejandro-isaza/Upsurge"
+    },
+    {
+      "title": "URLEmbeddedView",
+      "category": "ui",
+      "description": "Automatically caches the object that is confirmed the Open Graph Protocol, and displays it as URL embedded card.",
+      "homepage": "https://github.com/marty-suzuki/URLEmbeddedView"
+    },
+    {
+      "title": "URLNavigator",
+      "category": "app-routing",
+      "description": "Elegant URL Routing.",
+      "homepage": "https://github.com/devxoul/URLNavigator"
+    },
+    {
+      "title": "URLQueryItemEncoder",
+      "category": "utility",
+      "description": "An Encoder for encoding any Encodable value into an array of URLQueryItem.",
+      "homepage": "https://github.com/pitiphong-p/URLQueryItemEncoder",
+      "tags": [
+        "urlqueryitem",
+        "codable",
+        "encoder",
+        "swift"
+      ]
+    },
+    {
+      "title": "UTIKit",
+      "category": "utility",
+      "description": "an UTI (Uniform Type Identifier) wrapper.",
+      "homepage": "https://github.com/cockscomb/UTIKit"
+    },
+    {
+      "title": "UXMPDFKit",
+      "category": "pdf",
+      "description": "A PDF viewer and annotator that can be embedded in iOS applications.",
+      "homepage": "https://github.com/uxmstudio/UXMPDFKit"
+    },
+    {
+      "title": "Vaccine",
+      "category": "utility",
+      "description": "Make your apps immune to recompile-decease.",
+      "homepage": "https://github.com/zenangst/Vaccine"
+    },
+    {
+      "title": "Valet",
+      "category": "keychain",
+      "description": "Valet lets you securely store data in the Keychain without knowing a thing about how the Keychain works. It’s easy. We promise.",
+      "homepage": "https://github.com/square/Valet"
+    },
+    {
+      "title": "ValidatedPropertyKit",
+      "category": "validation",
+      "description": "Easily validate your Properties with Property Wrappers 👮.",
+      "homepage": "https://github.com/SvenTiigi/ValidatedPropertyKit",
+      "tags": [
         "ios",
-        "tvos"
+        "macos",
+        "tvos",
+        "watchos",
+        "swift",
+        "propertywrapper"
       ]
     },
     {
-      "title":"ImageDetect",
-      "category":"images",
-      "description":"Detect and crop faces, barcodes and texts in image with iOS 11 Vision API.",
-      "homepage":"https://github.com/Feghal/ImageDetect"
-    },
-    {
-      "title":"TheAnimation",
-      "category":"animation",
-      "description":"Type-safe CAAnimation wrapper. It makes preventing to set wrong type values.",
-      "homepage":"https://github.com/marty-suzuki/TheAnimation"
-    },
-    {
-      "title":"Poi",
-      "category":"animation",
-      "description":"Poi makes you use card UI like tinder UI .You can use it like tableview method.",
-      "homepage":"https://github.com/HideakiTouhara/Poi"
-    },
-    {
-      "title":"DNWebSocket",
-      "category":"socket",
-      "description":"Object-Oriented, Autobahn tested WebSocket Library (RFC 6455).",
-      "homepage":"https://github.com/GlebRadchenko/DNWebSocket",
-      "tags":[
-        "websocket",
-        "socket",
-        "io",
-        "network",
-        "networking"
-      ]
-    },
-    {
-      "title":"ClassicKit",
-      "category":"ui",
-      "description":"A collection of classic-style UI components.",
-      "homepage":"https://github.com/Baddaboo/ClassicKit"
-    },
-    {
-      "title":"SwiftEntryKit",
-      "category":"alert",
-      "description":"A simple and versatile pop-up presenter.",
-      "homepage":"https://github.com/huri000/SwiftEntryKit"
-    },
-    {
-      "title":"App Architecture",
-      "category":"patterns",
-      "description":"A sample Code of the App Architecture Book.",
-      "homepage":"https://github.com/objcio/app-architecture"
-    },
-    {
-      "title":"Family",
-      "category":"ui",
-      "description":"A child view controller framework that makes setting up your parent controllers as easy as pie.",
-      "homepage":"https://github.com/zenangst/Family"
-    },
-    {
-      "title":"Vaccine",
-      "category":"utility",
-      "description":"Make your apps immune to recompile-decease.",
-      "homepage":"https://github.com/zenangst/Vaccine"
-    },
-    {
-      "title":"Differific",
-      "category":"utility",
-      "description":"A fast and convenient diffing framework.",
-      "homepage":"https://github.com/zenangst/Differific"
-    },
-    {
-      "title":"MessengerKit",
-      "category":"chat",
-      "description":"A UI framework for building messenger interfaces.",
-      "homepage":"https://github.com/steve228uk/MessengerKit"
-    },
-    {
-      "title":"swift-protobuf",
-      "category":"utility",
-      "description":"A plugin and runtime library for using Google's Protocol Buffer.",
-      "homepage":"https://github.com/apple/swift-protobuf",
-      "tags":[
+      "title": "Vapor",
+      "category": "webserver",
+      "description": "Elegant web framework that works on iOS, OS X, and Ubuntu.",
+      "homepage": "https://github.com/vapor/vapor",
+      "tags": [
         "linux"
       ]
     },
     {
-      "title":"VerticalCardSwiper",
-      "category":"cards",
-      "description":"A marriage between the Shazam Discover UI and Tinder, built with UICollectionView.",
-      "homepage":"https://github.com/JoniVR/VerticalCardSwiper"
+      "title": "VEditorKit",
+      "category": "text",
+      "description": "Lightweight and Powerful Editor Kit.",
+      "homepage": "https://github.com/GeekTree0101/VEditorKit"
     },
     {
-      "title":"LoadingShimmer",
-      "category":"ui",
-      "description":"An easy way to add a shimmering effect to any view with just one line of code. It is useful as an unobtrusive loading indicator.",
-      "homepage":"https://github.com/jogendra/LoadingShimmer"
+      "title": "VegaScroll",
+      "category": "uicollectionview",
+      "description": "Lightweight animation flowlayout for UICollectionView.",
+      "homepage": "https://github.com/AppliKeySolutions/VegaScroll"
     },
     {
-      "title":"Telegrammer",
-      "category":"bots",
-      "description":"Open-source framework for Telegram Bots developers. It was built on top of Apple/SwiftNIO which help to demonstrate excellent performance.",
-      "homepage":"https://github.com/givip/Telegrammer",
-      "tags":[
-        "linux",
-        "swiftnio",
-        "serverside"
-      ]
-    },
-    {
-      "title":"example-ios-apps",
-      "category":"other-awesome-lists",
-      "description":"An amazing list for people who are beginners and learning ios development and for ios developers who need any example app or feature.",
-      "homepage":"https://github.com/jogendra/example-ios-apps"
-    },
-    {
-      "title":"Crossroad",
-      "category":"app-routing",
-      "description":":oncoming_bus: Crossroad is an URL router focused on handling Custom URL Schemes.",
-      "homepage":"https://github.com/giginet/Crossroad"
-    },
-    {
-      "title":"Sica",
-      "category":"animation",
-      "description":"Simple Interface Core Animation. Run type-safe animation sequencially or parallelly.",
-      "homepage":"https://github.com/cats-oss/Sica"
-    },
-    {
-      "title":"StyledTextKit",
-      "category":"textfield",
-      "description":"Declarative building and fast rendering attributed string library.",
-      "homepage":"https://github.com/GitHawkApp/StyledTextKit"
-    },
-    {
-      "title":"Perfect-CRUD",
-      "category":"orm",
-      "description":"CRUD is an object-relational mapping (ORM) system using Codable protocol.",
-      "homepage":"https://github.com/PerfectlySoft/Perfect-CRUD",
-      "tags":[
+      "title": "Venice",
+      "category": "concurrency",
+      "description": "Communicating sequential processes (CSP), Linux ready.",
+      "homepage": "https://github.com/Zewo/Venice",
+      "tags": [
         "linux"
       ]
     },
     {
-      "title":"Wormholy",
-      "category":"network",
-      "description":"iOS network debugging, like a wizard 🧙‍.",
-      "homepage":"https://github.com/pmusolino/Wormholy",
-      "tags":[
+      "title": "Version",
+      "category": "version-manager",
+      "description": "Version represents and compares semantic versions.",
+      "homepage": "https://github.com/mrackwitz/Version"
+    },
+    {
+      "title": "Version Tracker Swift",
+      "category": "version-manager",
+      "description": "Versions tracker for your iOS, OS X, and tvOS app.",
+      "homepage": "https://github.com/tbaranes/VersionTrackerSwift"
+    },
+    {
+      "title": "VerticalCardSwiper",
+      "category": "cards",
+      "description": "A marriage between the Shazam Discover UI and Tinder, built with UICollectionView.",
+      "homepage": "https://github.com/JoniVR/VerticalCardSwiper"
+    },
+    {
+      "title": "ViewAnimator",
+      "category": "animation",
+      "description": "Brings your UI to life with just one line.",
+      "homepage": "https://github.com/marcosgriselli/ViewAnimator"
+    },
+    {
+      "title": "vim-polyglot",
+      "category": "vim",
+      "description": "Language pack for vim that includes vim-swift.",
+      "homepage": "https://github.com/sheerun/vim-polyglot"
+    },
+    {
+      "title": "Viperit",
+      "category": "patterns",
+      "description": "Viper Framework for iOS.",
+      "homepage": "https://github.com/ferranabello/Viperit"
+    },
+    {
+      "title": "VisualEffectView",
+      "category": "blur",
+      "description": "UIVisualEffectView subclass with tint color.",
+      "homepage": "https://github.com/efremidze/VisualEffectView"
+    },
+    {
+      "title": "VKPinCodeView",
+      "category": "textfield",
+      "description": "Simple and elegant UI component for input PIN.",
+      "homepage": "https://github.com/Sunspension/VKPinCodeView",
+      "tags": [
+        "swift",
+        "UI",
+        "PIN"
+      ]
+    },
+    {
+      "title": "voice-overlay-ios",
+      "category": "audio",
+      "description": "An overlay that gets your user’s voice permission and input as text in a customizable UI.",
+      "homepage": "https://github.com/algolia/voice-overlay-ios"
+    },
+    {
+      "title": "VueFlux",
+      "category": "events",
+      "description": "Unidirectional Data Flow State Management Architecture - Inspired by Vuex and Flux.",
+      "homepage": "https://github.com/ra1028/VueFlux"
+    },
+    {
+      "title": "Watchdog",
+      "category": "logging",
+      "description": "Utility for logging excessive blocking on the main thread.",
+      "homepage": "https://github.com/wojteklu/Watchdog"
+    },
+    {
+      "title": "WatchdogInspector",
+      "category": "logging",
+      "description": "A logging tool to show the current framerate (fps) in the status bar of your iOS app.",
+      "homepage": "https://github.com/tapwork/WatchdogInspector"
+    },
+    {
+      "title": "WeakableSelf",
+      "category": "utility",
+      "description": "A micro-framework to encapsulate [weak self] and guard statements within closures.",
+      "homepage": "https://github.com/vincent-pradeilles/weakable-self"
+    },
+    {
+      "title": "Weaver",
+      "category": "dependency-injection",
+      "description": "A declarative, easy-to-use and safe Dependency Injection framework.",
+      "homepage": "https://github.com/scribd/Weaver"
+    },
+    {
+      "title": "WhatsNew",
+      "category": "utility",
+      "description": "Showcase new features after an app update similar to Pages, Numbers and Keynote.",
+      "homepage": "https://github.com/BalestraPatrick/WhatsNew"
+    },
+    {
+      "title": "WhatsNewKit",
+      "category": "utility",
+      "description": "Showcase your awesome new app features.",
+      "homepage": "https://github.com/SvenTiigi/WhatsNewKit"
+    },
+    {
+      "title": "When",
+      "category": "events",
+      "description": "A lightweight implementation of Promises.",
+      "homepage": "https://github.com/vadymmarkov/When"
+    },
+    {
+      "title": "Willow",
+      "category": "logging",
+      "description": "Willow is a powerful, yet lightweight logging library.",
+      "homepage": "https://github.com/Nike-Inc/Willow"
+    },
+    {
+      "title": "Windless",
+      "category": "ui",
+      "description": "Windless makes it easy to implement invisible layout loading view.",
+      "homepage": "https://github.com/ParkGwangBeom/Windless"
+    },
+    {
+      "title": "WKZombie",
+      "category": "html",
+      "description": "Headless browser.",
+      "homepage": "https://github.com/mkoehnke/WKZombie"
+    },
+    {
+      "title": "WLEmptyState",
+      "category": "uitableview",
+      "description": "A component that lets you customize the view when the dataset of UITableView is empty.",
+      "homepage": "https://github.com/WizelineLabs/WLEmptyState"
+    },
+    {
+      "title": "Workaholic",
+      "category": "calendar",
+      "description": "A GitHub-like work contribution timeline.",
+      "homepage": "https://github.com/hemangshah/Workaholic"
+    },
+    {
+      "title": "Wormholy",
+      "category": "network",
+      "description": "iOS network debugging, like a wizard 🧙‍.",
+      "homepage": "https://github.com/pmusolino/Wormholy",
+      "tags": [
         "network",
         "debugger",
         "log",
@@ -6537,2145 +8500,219 @@
       ]
     },
     {
-      "title":"DebugSwift",
-      "category":"debug",
-      "description":"DebugSwift is a comprehensive toolkit designed to simplify and enhance the debugging process for Swift-based applications. Whether you're troubleshooting issues or optimizing performance, DebugSwift provides a set of powerful features to make your debugging experience more efficient.",
-      "homepage":"https://github.com/DebugSwift/DebugSwift",
-      "tags":[
-        "debug",
-        "network",
-        "debugger",
-        "log",
-        "logger",
-        "logging",
-        "logging-library",
-        "layout-debugger",
-        "leak-detection",
-        "crashlytics",
-        "performance-analysis"
-      ]
+      "title": "WSTagsField",
+      "category": "ui",
+      "description": "An iOS text field that represents different Tags.",
+      "homepage": "https://github.com/whitesmith/WSTagsField"
     },
     {
-      "title":"Awesome iOS Interview",
-      "category":"other-awesome-lists",
-      "description":"List of the questions that helps you to prepare for the interview.",
-      "homepage":"https://github.com/dashvlas/awesome-ios-interview",
-      "tags":[
-        "interview",
-        "ios-developer",
-        "question list"
-      ]
+      "title": "xc",
+      "category": "misc",
+      "description": "A tool to open the Xcode project file by the specified version.",
+      "homepage": "https://github.com/s2mr/xc"
     },
     {
-      "title":"FluentQuery",
-      "category":"utility",
-      "description":"Powerful and easy to use Query Builder.",
-      "homepage":"https://github.com/MihaelIsaev/FluentQuery",
-      "tags":[
-        "linux"
-      ]
+      "title": "xcbeautify",
+      "category": "misc",
+      "description": "Little beautifier tool for xcodebuild.",
+      "homepage": "https://github.com/cpisciotta/xcbeautify"
     },
     {
-      "title":"EtherWalletKit",
-      "category":"utility",
-      "description":"Ethereum Wallet Toolkit for iOS - You can implement Ethereum wallet without a server and blockchain knowledge.",
-      "homepage":"https://github.com/SteadyAction/EtherWalletKit",
-      "tags":[
-        "ethereum",
-        "wallet",
-        "ethereum-wallet",
-        "swift",
-        "ios",
-        "blockchain",
-        "coin",
-        "token",
-        "crypto",
-        "cryptocurrency",
-        "cryptowallet"
-      ]
+      "title": "XCGLogger",
+      "category": "logging",
+      "description": "Full featured & Configurable logging utility with log levels, timestamps, and line numbers.",
+      "homepage": "https://github.com/DaveWoodCom/XCGLogger"
     },
     {
-      "title":"Cabbage",
-      "category":"video",
-      "description":"A video composition framework build on top of AVFoundation.",
-      "homepage":"https://github.com/VideoFlint/Cabbage"
+      "title": "XcodeGen",
+      "category": "misc",
+      "description": "Tool for generating Xcode projects from a YAML file and your project directory.",
+      "homepage": "https://github.com/yonaskolb/XcodeGen"
     },
     {
-      "title":"Schedule",
-      "category":"thread",
-      "description":"A missing lightweight task scheduler with an incredibly human-friendly syntax.",
-      "homepage":"https://github.com/luoxiu/Schedule",
-      "tags":[
-        "timer",
-        "gcd",
-        "ios",
-        "macos",
-        "watchos",
-        "tvos",
-        "linux"
-      ]
+      "title": "xcodeproj",
+      "category": "misc",
+      "description": "A library to read, update and write Xcode projects and workspaces.",
+      "homepage": "https://github.com/tuist/xcodeproj"
     },
     {
-      "title":"ExpandableButton",
-      "category":"button",
-      "description":"Customizable and easy to use expandable button.",
-      "homepage":"https://github.com/DimaMishchenko/ExpandableButton",
-      "tags":[
-        "swift",
-        "button",
-        "uibutton",
-        "expandable",
-        "ui",
-        "ios"
-      ]
+      "title": "xcprofiler",
+      "category": "benchmark",
+      "description": "Command line utility to profile compilation time.",
+      "homepage": "https://github.com/giginet/xcprofiler"
     },
     {
-      "title":"MJMaterialSwitch",
-      "category":"switch",
-      "description":"A Customizable Switch UI for iOS, Inspired from Google's Material Design.",
-      "homepage":"https://github.com/JaleelNazir/MJMaterialSwitch",
-      "tags":[
-        "switch",
-        "material-ui",
-        "animation",
-        "material-design",
-        "uicontrol",
-        "swift",
-        "ios"
-      ]
+      "title": "XCTest",
+      "category": "testing",
+      "description": "The XCTest Project, A Swift core library for providing unit test support.",
+      "homepage": "https://github.com/swiftlang/swift-corelibs-xctest"
     },
     {
-      "title":"DifferenceKit",
-      "category":"utility",
-      "description":"💻 A fast and flexible O(n) difference algorithm framework.",
-      "homepage":"https://github.com/ra1028/DifferenceKit"
+      "title": "XestiMonitors",
+      "category": "utility",
+      "description": "An extensible monitoring framework.",
+      "homepage": "https://github.com/eBardX/XestiMonitors"
     },
     {
-      "title":"Disk",
-      "category":"other-data",
-      "description":"Delightful framework for iOS to easily persist structs, images, and data.",
-      "homepage":"https://github.com/saoudrizwan/Disk"
+      "title": "XLActionController",
+      "category": "alert",
+      "description": "Fully customizable and extensible action sheet controller.",
+      "homepage": "https://github.com/xmartlabs/XLActionController"
     },
     {
-      "title":"OKTableViewLiaison",
-      "category":"uitableview",
-      "description":"Framework to help you better manage UITableViews.",
-      "homepage":"https://github.com/okcupid/OKTableViewLiaison"
+      "title": "XLPagerTabStrip",
+      "category": "menu",
+      "description": "Android PagerTabStrip for iOS.",
+      "homepage": "https://github.com/xmartlabs/XLPagerTabStrip"
     },
     {
-      "title":"SwiftyComments",
-      "category":"uitableview",
-      "description":"Nested hierarchy of expandable/collapsible cells to easily build elegant discussion threads.",
-      "homepage":"https://github.com/tsucres/SwiftyComments"
+      "title": "XMLCoder",
+      "category": "xml",
+      "description": "XMLEncoder & XMLDecoder based on Codable protocols from the standard library.",
+      "homepage": "https://github.com/CoreOffice/XMLCoder"
     },
     {
-      "title":"ESTabBarController",
-      "category":"tab",
-      "description":"A highly customizable TabBarController component, which is inherited from UITabBarController.",
-      "homepage":"https://github.com/eggswift/ESTabBarController"
-    },
-    {
-      "title":"FlexiblePageControl",
-      "category":"pagination",
-      "description":"A flexible UIPageControl like Instagram.",
-      "homepage":"https://github.com/shima11/FlexiblePageControl",
-      "tags":[
-        "iOS",
-        "swift",
-        "pagination",
-        "animation",
-        "pagecontrol",
-        "UIPageControl",
-        "instagram"
-      ]
-    },
-    {
-      "title":"InputBarAccessoryView",
-      "category":"chat",
-      "description":"A simple and easily customizable InputAccessoryView for making powerful input bars with autocomplete and attachments.",
-      "homepage":"https://github.com/nathantannar4/InputBarAccessoryView"
-    },
-    {
-      "title":"Sheet",
-      "category":"alert",
-      "description":"Actionsheet with navigation features such as the Flipboard App.",
-      "homepage":"https://github.com/ParkGwangBeom/Sheet"
-    },
-    {
-      "title":"voice-overlay-ios",
-      "category":"audio",
-      "description":"An overlay that gets your user’s voice permission and input as text in a customizable UI.",
-      "homepage":"https://github.com/algolia/voice-overlay-ios"
-    },
-    {
-      "title":"ModernAVPlayer",
-      "category":"audio",
-      "description":"Persistence AVPlayer to resume playback after bad network connection even in background mode.",
-      "homepage":"https://github.com/noreasonprojects/ModernAVPlayer",
-      "tags":[
-        "swift",
-        "reachability",
-        "network",
-        "avplayer",
-        "player",
-        "hls",
-        "mp3",
-        "wav",
-        "aiff"
-      ]
-    },
-    {
-      "title":"LightRoute",
-      "category":"app-routing",
-      "description":"Routing between VIPER modules.",
-      "homepage":"https://github.com/SpectralDragon/LiteRoute"
-    },
-    {
-      "title":"Viperit",
-      "category":"patterns",
-      "description":"Viper Framework for iOS.",
-      "homepage":"https://github.com/ferranabello/Viperit"
-    },
-    {
-      "title":"ReduxUI",
-      "category":"patterns",
-      "description":"Redux framework for easy use with SwiftUI.",
-      "homepage":"https://github.com/gre4ixin/ReduxUI"
-    },
-    {
-      "title":"Lumos",
-      "category":"utility",
-      "description":"An easy-to-use API for Objective-C runtime functions.",
-      "homepage":"https://github.com/sushinoya/Lumos"
-    },
-    {
-      "title":"Panels",
-      "category":"menu",
-      "description":"Panels is a framework to easily add sliding panels to your application.",
-      "homepage":"https://github.com/antoniocasero/Panels"
-    },
-    {
-      "title":"Kitsunebi",
-      "category":"video",
-      "description":"Overlay alpha channel video animation player view using OpenGLES.",
-      "homepage":"https://github.com/noppefoxwolf/Kitsunebi"
-    },
-    {
-      "title":"CleanArchitectureRxSwift",
-      "category":"patterns",
-      "description":"Example of Clean Architecture of iOS app using RxSwift.",
-      "homepage":"https://github.com/sergdort/ModernCleanArchitectureSwiftUI"
-    },
-    {
-      "title":"LinkedInSignIn",
-      "category":"authentication",
-      "description":"Simple view controller to log in and retrieve an access token from LinkedIn.",
-      "homepage":"https://github.com/serhii-londar/LinkedInSignIn"
-    },
-    {
-      "title":"Reactant",
-      "category":"patterns",
-      "description":"Reactant is a reactive architecture for iOS.",
-      "homepage":"https://github.com/Brightify/Reactant"
-    },
-    {
-      "title":"HaishinKit",
-      "category":"streaming",
-      "description":"Camera and Microphone streaming library via RTMP, HLS for iOS, macOS, tvOS.",
-      "homepage":"https://github.com/HaishinKit/HaishinKit.swift"
-    },
-    {
-      "title":"XCTest",
-      "category":"testing",
-      "description":"The XCTest Project, A Swift core library for providing unit test support.",
-      "homepage":"https://github.com/swiftlang/swift-corelibs-xctest"
-    },
-    {
-      "title":"Defaults",
-      "category":"key-value-store",
-      "description":"Strongly-typed UserDefaults with support for Codable and key observation.",
-      "homepage":"https://github.com/sindresorhus/Defaults"
-    },
-    {
-      "title":"Preferences",
-      "category":"ui",
-      "description":"Add a preferences window to your macOS app in minutes.",
-      "homepage":"https://github.com/sindresorhus/Settings"
-    },
-    {
-      "title":"LaunchAtLogin",
-      "category":"system",
-      "description":"Easily add 'Launch at Login' functionality to your sandboxed macOS app.",
-      "homepage":"https://github.com/sindresorhus/LaunchAtLogin-Legacy"
-    },
-    {
-      "title":"DockProgress",
-      "category":"ui",
-      "description":"Show progress in your macOS app's Dock icon.",
-      "homepage":"https://github.com/sindresorhus/DockProgress"
-    },
-    {
-      "title":"OnboardKit",
-      "category":"walkthrough",
-      "description":"Customisable user onboarding for your iOS app.",
-      "homepage":"https://github.com/NikolaKirev/OnboardKit"
-    },
-    {
-      "title":"CircularProgress",
-      "category":"ui",
-      "description":"Circular progress indicator for your macOS app.",
-      "homepage":"https://github.com/sindresorhus/CircularProgress"
-    },
-    {
-      "title":"CircularRangeSlider",
-      "category":"ui",
-      "description":"A customizable SwiftUI component for selecting a range of values using a circular slider.",
-      "homepage":"https://github.com/diegotid/circular-range-slider"
-    },
-    {
-      "title":"PersistenceKit",
-      "category":"multi-database",
-      "description":"Store and retrieve Codable objects to various persistence layers, in a couple lines of code!",
-      "homepage":"https://github.com/Teknasyon-Teknoloji/PersistenceKit",
-      "tags":[
-        "swift",
-        "filemanager",
-        "userdefaults",
-        "keychain",
-        "ios",
-        "macos",
-        "tvos",
-        "watchos"
-      ]
-    },
-    {
-      "title":"Rough",
-      "category":"images",
-      "description":"Rough lets you draw in a sketchy, hand-drawn-like, style.",
-      "homepage":"https://github.com/bakhtiyork/Rough",
-      "tags":[
-        "swift",
-        "sketchy",
-        "hand-drawn"
-      ]
-    },
-    {
-      "title":"iOS project template",
-      "category":"boilerplates",
-      "description":"iOS project template with fastlane lanes, Travis CI jobs and GitHub integrations of Codecov, HoundCI for SwiftLint and Danger.",
-      "homepage":"https://github.com/messeb/ios-project-template"
-    },
-    {
-      "title":"Brightroom",
-      "category":"images",
-      "description":"An image editor and engine using CoreImage.",
-      "homepage":"https://github.com/FluidGroup/Brightroom"
-    },
-    {
-      "title":"UICollectionViewSplitLayout",
-      "category":"uicollectionview",
-      "description":"UICollectionViewSplitLayout makes collection view more responsive.",
-      "homepage":"https://github.com/yahoojapan/UICollectionViewSplitLayout"
-    },
-    {
-      "title":"AHDownloadButton",
-      "category":"button",
-      "description":"Customizable download button with progress and transition animations. It is based on Apple's App Store download button.",
-      "homepage":"https://github.com/amerhukic/AHDownloadButton"
-    },
-    {
-      "title":"PaperOnboarding",
-      "category":"walkthrough",
-      "description":"PaperOnboarding is a material design UI slider.",
-      "homepage":"https://github.com/Ramotion/paper-onboarding"
-    },
-    {
-      "title":"CircleMenu",
-      "category":"menu",
-      "description":"CircleMenu is a simple, elegant UI menu with a circular layout and material design animations.",
-      "homepage":"https://github.com/Ramotion/circle-menu"
-    },
-    {
-      "title":"GitHubRestAPISwiftOpenAPI",
-      "category":"api",
-      "description":"Scheduled generated GitHub's REST API as Swift code from OpenAPI specification.",
-      "homepage":"https://github.com/Wei18/github-rest-api-swift-openapi"
-    },
-    {
-      "title":"GitHubAPI",
-      "category":"api",
-      "description":"Implementation of GitHub REST API v3.",
-      "homepage":"https://github.com/serhii-londar/GithubAPI"
-    },
-    {
-      "title":"Gliding Collection",
-      "category":"uicollectionview",
-      "description":"Gliding Collection is a smooth, flowing, customizable decision for a UICollectionView Controller.",
-      "homepage":"https://github.com/Ramotion/gliding-collection"
-    },
-    {
-      "title":"WeakableSelf",
-      "category":"utility",
-      "description":"A micro-framework to encapsulate [weak self] and guard statements within closures.",
-      "homepage":"https://github.com/vincent-pradeilles/weakable-self"
-    },
-    {
-      "title":"SPPermission",
-      "category":"permissions",
-      "description":"Simple request permission with native UI and interactive animation.",
-      "homepage":"https://github.com/sparrowcode/PermissionsKit"
-    },
-    {
-      "title":"Google",
-      "category":"style-guides",
-      "description":"This style guide is based on Apple’s excellent Swift standard library style and also incorporates feedback from usage across multiple Swift projects within Google.",
-      "homepage":"https://google.github.io/swift/"
-    },
-    {
-      "title":"paper-switch",
-      "category":"switch",
-      "description":"RAMPaperSwitch is a material design UI module which paints over the parent view when the switch is turned on.",
-      "homepage":"https://github.com/Ramotion/paper-switch"
-    },
-    {
-      "title":"OverlayContainer",
-      "category":"ui",
-      "description":"OverlayContainer makes it easier to develop overlay based interfaces, such as the one presented in the Apple Maps or Stocks apps.",
-      "homepage":"https://github.com/applidium/OverlayContainer"
-    },
-    {
-      "title":"ApplyStyleKit",
-      "category":"utility",
-      "description":"Elegantly, Apply style to UIKit using Method Chain.",
-      "homepage":"https://github.com/shindyu/ApplyStyleKit",
-      "tags":[
-        "swift",
-        "methodchain",
-        "design",
-        "ios"
-      ]
-    },
-    {
-      "title":"Model2App",
-      "category":"misc",
-      "description":"Turn your data model into a working CRUD app.",
-      "homepage":"https://github.com/Q-Mobile/Model2App"
-    },
-    {
-      "title":"SwiftFFmpeg",
-      "category":"video",
-      "description":"A wrapper for the FFmpeg C API.",
-      "homepage":"https://github.com/sunlubo/SwiftFFmpeg"
-    },
-    {
-      "title":"HidesNavigationBarWhenPushed",
-      "category":"ui",
-      "description":"A library, which adds the ability to hide navigation bar when view controller is pushed via hidesNavigationBarWhenPushed flag.",
-      "homepage":"https://github.com/gontovnik/HidesNavigationBarWhenPushed"
-    },
-    {
-      "title":"Soundable",
-      "category":"audio",
-      "description":"Soundable allows you to play sounds, single and in sequence, in a very easy way.",
-      "homepage":"https://github.com/lcardevnas/Soundable",
-      "tags":[
-        "avfoundation",
-        "sound",
-        "audio",
-        "avaudioplayer",
-        "avqueueplayer",
-        "avaudiosession",
-        "ios",
-        "swift"
-      ]
-    },
-    {
-      "title":"ZamzamKit",
-      "category":"utility",
-      "description":"A collection of micro utilities and extensions for Standard Library, Foundation and UIKit.",
-      "homepage":"https://github.com/basememara/ZamzamKit"
-    },
-    {
-      "title":"DGElasticPullToRefresh",
-      "category":"uitableview",
-      "description":"Elastic pull to refresh.",
-      "homepage":"https://github.com/gontovnik/DGElasticPullToRefresh"
-    },
-    {
-      "title":"CacheAdvance",
-      "category":"other-data",
-      "description":"A performant cache for logging systems. CacheAdvance persists log events 30x faster than SQLite.",
-      "homepage":"https://github.com/dfed/CacheAdvance"
-    },
-    {
-      "title":"CoreXLSX",
-      "category":"other-data",
-      "description":"Excel spreadsheet (XLSX) format support.",
-      "homepage":"https://github.com/CoreOffice/CoreXLSX"
-    },
-    {
-      "title":"XMLCoder",
-      "category":"xml",
-      "description":"XMLEncoder & XMLDecoder based on Codable protocols from the standard library.",
-      "homepage":"https://github.com/CoreOffice/XMLCoder"
-    },
-    {
-      "title":"Carbon",
-      "category":"form",
-      "description":"🚴 A declarative library for building component-based user interfaces in UITableView and UICollectionView.",
-      "homepage":"https://github.com/ra1028/Carbon"
-    },
-    {
-      "title":"EZLayout",
-      "category":"auto-layout",
-      "description":"An easier and faster way to code Autolayout.",
-      "homepage":"https://github.com/alexliubj/EZAnchor"
-    },
-    {
-      "title":"Swiftbot",
-      "category":"utility",
-      "description":"run swift code on slack.",
-      "homepage":"https://github.com/noppefoxwolf/Swiftbot"
-    },
-    {
-      "title":"Real-time Chat with Firebase",
-      "category":"chat",
-      "description":"Functional real-time chat app with Firebase Firestore using MessageKit.",
-      "homepage":"https://github.com/dopebase/messenger-iOS-chat-swift-firestore"
-    },
-    {
-      "title":"CollapsibleTableSectionViewController",
-      "category":"uitableview",
-      "description":"A library to support collapsible sections in a table view.",
-      "homepage":"https://github.com/jeantimex/CollapsibleTableSectionViewController"
-    },
-    {
-      "title":"Loaf",
-      "category":"alert",
-      "description":"A simple framework for easy iOS Toasts.",
-      "homepage":"https://github.com/schmidyy/Loaf",
-      "tags":[
-        "toast",
-        "alert"
-      ]
-    },
-    {
-      "title":"CircleBar",
-      "category":"tab",
-      "description":"A fun, easy-to-use tab bar navigation controller for iOS.",
-      "homepage":"https://github.com/softhausHQ/CircleBar",
-      "tags":[
-        "tab",
-        "navigation"
-      ]
-    },
-    {
-      "title":"MemoryCache",
-      "category":"cache",
-      "description":"Type-safe memory cache.",
-      "homepage":"https://github.com/yysskk/MemoryCache",
-      "tags":[
-        "cache",
-        "utility"
-      ]
-    },
-    {
-      "title":"Monstra",
-      "category":"cache",
-      "description":"Memory cache framework with TTL, priority-based eviction, and avalanche protection.",
-      "homepage":"https://github.com/yangchenlarkin/Monstra"
-    },
-    {
-      "title":"BadgeHub",
-      "category":"ui",
-      "description":"Make any UIView a full fledged animated notification center. It is a way to quickly add a notification badge icon to a UIView.",
-      "homepage":"https://github.com/jogendra/BadgeHub",
-      "tags":[
-        "animation",
-        "badge"
-      ]
-    },
-    {
-      "title":"RealmWrapper",
-      "category":"realm",
-      "description":"Safe and easy wrappers for RealmSwift.",
-      "homepage":"https://github.com/k-lpmg/RealmWrapper"
-    },
-    {
-      "title":"Tokamak",
-      "category":"events",
-      "description":"React-like declarative API for building native UI components with easy to use one-way data binding.",
-      "homepage":"https://github.com/TokamakUI/Tokamak",
-      "tags":[
-        "react",
-        "redux"
-      ]
-    },
-    {
-      "title":"VEditorKit",
-      "category":"text",
-      "description":"Lightweight and Powerful Editor Kit.",
-      "homepage":"https://github.com/GeekTree0101/VEditorKit"
-    },
-    {
-      "title":"Nantes",
-      "category":"label",
-      "description":"TTTAttributedLabel replacement.",
-      "homepage":"https://github.com/instacart/Nantes"
-    },
-    {
-      "title":"SecureDefaults",
-      "category":"key-value-store",
-      "description":"A lightweight wrapper over UserDefaults & NSUserDefaults with an extra AES-256 encryption layer.",
-      "homepage":"https://github.com/vpeschenkov/SecureDefaults"
-    },
-    {
-      "title":"Codextended",
-      "category":"utility",
-      "description":"Extensions giving Codable API type inference super powers.",
-      "homepage":"https://github.com/JohnSundell/Codextended"
-    },
-    {
-      "title":"AwaitToast",
-      "category":"alert",
-      "description":"🍞 An async waiting toast with basic toast. Inspired by facebook posting toast.",
-      "homepage":"https://github.com/k-lpmg/AwaitToast"
-    },
-    {
-      "title":"Sejima",
-      "category":"UI",
-      "description":"Collection of User Interface components.",
-      "homepage":"https://github.com/MoveUpwards/Sejima",
-      "tags":[
-        "UI",
-        "components"
-      ]
-    },
-    {
-      "title":"WLEmptyState",
-      "category":"uitableview",
-      "description":"A component that lets you customize the view when the dataset of UITableView is empty.",
-      "homepage":"https://github.com/WizelineLabs/WLEmptyState"
-    },
-    {
-      "title":"lottie-ios",
-      "category":"animation",
-      "description":"An iOS library to natively render After Effects vector animations.",
-      "homepage":"https://github.com/airbnb/lottie-ios",
-      "tags":[
-        "swift",
-        "animation"
-      ]
-    },
-    {
-      "title":"glide engine",
-      "category":"game-engine",
-      "description":"SpriteKit and GameplayKit based engine for making 2d games, with practical examples and tutorials.",
-      "homepage":"https://github.com/cocoatoucher/Glide",
-      "tags":[
-        "platformer",
-        "side",
-        "scroller",
-        "tilemap",
-        "tiles",
-        "spritekit"
-      ]
-    },
-    {
-      "title":"ATGValidator",
-      "category":"validation",
-      "description":"Rule based validation framework with form and card validation support for iOS.",
-      "homepage":"https://github.com/altayer-digital/ATGValidator"
-    },
-    {
-      "title":"SPStorkController",
-      "category":"transition",
-      "description":"Now playing controller from Apple Music. Customisable height.",
-      "homepage":"https://github.com/ivanvorobei/SPStorkController",
-      "tags":[
-        "swift",
-        "animation",
-        "UI",
-        "transition",
-        "apple music"
-      ]
-    },
-    {
-      "title":"SPLarkController",
-      "category":"transition",
-      "description":"Custom transition between two controller. Translate to top.",
-      "homepage":"https://github.com/ivanvorobei/SPLarkController",
-      "tags":[
-        "swift",
-        "animation",
-        "UI",
-        "transition"
-      ]
-    },
-    {
-      "title":"Unrealm",
-      "category":"realm",
-      "description":"Unrealm enables you to easily store Swift native Classes, Structs and Enums into Realm.",
-      "homepage":"https://github.com/matghazaryan/Unrealm",
-      "tags":[
-        "swift",
-        "realm",
-        "data-management",
-        "struct"
-      ]
-    },
-    {
-      "title":"SPAlert",
-      "category":"alert",
-      "description":"Native popup from Apple Music & Feedback in AppStore. Contains Done & Heart presets.",
-      "homepage":"https://github.com/sparrowcode/AlertKit",
-      "tags":[
-        "swift",
-        "UI"
-      ]
-    },
-    {
-      "title":"LightweightObservable",
-      "category":"events",
-      "description":"A lightweight implementation of an observable sequence that you can subscribe to.",
-      "homepage":"https://github.com/fxm90/LightweightObservable",
-      "tags":[
-        "swift",
-        "observable",
-        "observer",
-        "reactive"
-      ]
-    },
-    {
-      "title":"SamuraiTransition",
-      "category":"transition",
-      "description":"Swift based library providing a collection of ViewController transitions featuring a number of neat cutting animations.",
-      "homepage":"https://github.com/hachinobu/SamuraiTransition",
-      "tags":[
-        "swift",
-        "animation",
-        "UI",
-        "transition"
-      ]
-    },
-    {
-      "title":"Locatable",
-      "category":"dependency-injection",
-      "description":"A micro-framework that leverages Property Wrappers to implement the Service Locator pattern.",
-      "homepage":"https://github.com/vincent-pradeilles/locatable",
-      "tags":[
-        "swift",
-        "dependency",
-        "property wrapper"
-      ]
-    },
-    {
-      "title":"PanSlip",
-      "category":"transition",
-      "description":"Use PanGesture to dismiss view on UIViewController and UIView.",
-      "homepage":"https://github.com/k-lpmg/PanSlip"
-    },
-    {
-      "title":"Tagging",
-      "category":"text",
-      "description":"A TextView that provides easy to use tagging feature for Mention or Hashtag.",
-      "homepage":"https://github.com/k-lpmg/Tagging"
-    },
-    {
-      "title":"MultiSlider",
-      "category":"ui",
-      "description":"UISlider clone with multiple thumbs and values, range highlight, optional snap intervals, optional value labels, either vertical or horizontal.",
-      "homepage":"https://github.com/yonat/MultiSlider"
-    },
-    {
-      "title":"RadioGroup",
-      "category":"button",
-      "description":"The missing iOS radio buttons group.",
-      "homepage":"https://github.com/yonat/RadioGroup"
-    },
-    {
-      "title":"CameraBackground",
-      "category":"camera",
-      "description":"Show camera layer as a background to any UIView.",
-      "homepage":"https://github.com/yonat/CameraBackground"
-    },
-    {
-      "title":"CheckmarkCollectionViewCell",
-      "category":"uicollectionview",
-      "description":"UICollectionViewCell with checkbox when it isSelected and empty circle when not - like Photos.app 'Select' mode.",
-      "homepage":"https://github.com/yonat/CheckmarkCollectionViewCell"
-    },
-    {
-      "title":"BatteryView",
-      "category":"ui",
-      "description":"Simple battery shaped UIView.",
-      "homepage":"https://github.com/yonat/BatteryView"
-    },
-    {
-      "title":"DiffableDataSources",
-      "category":"uitableview",
-      "description":"💾 A library for backporting UITableView/UICollectionViewDiffableDataSource.",
-      "homepage":"https://github.com/ra1028/DiffableDataSources"
-    },
-    {
-      "title":"TOMLDecoder",
-      "category":"toml",
-      "description":"Latest TOML standard, decoded.",
-      "homepage":"https://github.com/dduan/TOMLDecoder"
-    },
-    {
-      "title":"Pathos",
-      "category":"files",
-      "description":"Efficient Unix file management.",
-      "homepage":"https://github.com/dduan/Pathos",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"VKPinCodeView",
-      "category":"textfield",
-      "description":"Simple and elegant UI component for input PIN.",
-      "homepage":"https://github.com/Sunspension/VKPinCodeView",
-      "tags":[
-        "swift",
-        "UI",
-        "PIN"
-      ]
-    },
-    {
-      "title":"Texstyle",
-      "category":"text",
-      "description":"Texstyle allows you to format attributed strings easily.",
-      "homepage":"https://github.com/rosberry/texstyle"
-    },
-    {
-      "title":"Combinative",
-      "category":"events",
-      "description":"UI event handling using Apple's combine framework.",
-      "homepage":"https://github.com/noppefoxwolf/Combinative"
-    },
-    {
-      "title":"SelectionList",
-      "category":"uitableview",
-      "description":"Simple single-selection or multiple-selection checklist, based on UITableView.",
-      "homepage":"https://github.com/yonat/SelectionList"
-    },
-    {
-      "title":"ResizingTokenField",
-      "category":"ui",
-      "description":"A UICollectionView-based token field which provides intrinsic content height.",
-      "homepage":"https://github.com/tadejr/ResizingTokenField"
-    },
-    {
-      "title":"Bow",
-      "category":"utility",
-      "description":"Companion library for Typed Functional Programming.",
-      "homepage":"https://github.com/bow-swift/bow"
-    },
-    {
-      "title":"AutoMockable",
-      "category":"mock",
-      "description":"A framework that leverages the type system to let you easily create mocked instances of your data types.",
-      "homepage":"https://github.com/vincent-pradeilles/AutoMocker"
-    },
-    {
-      "title":"ShowSomeProgress",
-      "category":"ui",
-      "description":"Animated Progress and Activity Indicators for iOS apps.",
-      "homepage":"https://github.com/stoneburner/ShowSomeProgress"
-    },
-    {
-      "title":"Ribbon",
-      "category":"keyboard",
-      "description":"🎀 A simple cross-platform toolbar/custom input accessory view library for iOS & macOS.",
-      "homepage":"https://github.com/chriszielinski/Ribbon"
-    },
-    {
-      "title":"MultiSelectSegmentedControl",
-      "category":"ui",
-      "description":"UISegmentedControl remake that supports selecting multiple segments, vertical stacking, combining text and images.",
-      "homepage":"https://github.com/yonat/MultiSelectSegmentedControl"
-    },
-    {
-      "title":"MuscleMap",
-      "category":"ui",
-      "description":"Render interactive human body muscle maps with SwiftUI and UIKit.",
-      "homepage":"https://github.com/melihcolpan/MuscleMap"
-    },
-    {
-      "title":"FlexibleHeader",
-      "category":"ui",
-      "description":"A container view that responds to scrolling of UIScrollView.",
-      "homepage":"https://github.com/k-lpmg/FlexibleHeader"
-    },
-    {
-      "title":"ReactiveAPI",
-      "category":"network",
-      "description":"Write clean, concise and declarative network code relying on URLSession, with the power of RxSwift. Inspired by Retrofit.",
-      "homepage":"https://github.com/sky-uk/ReactiveAPI",
-      "tags":[
-        "swift",
-        "declarative",
-        "rx",
-        "reactive",
-        "urlsession"
-      ]
-    },
-    {
-      "title":"PolioPager",
-      "category":"tab",
-      "description":"A flexible TabBarController with search tab like SNKRS.",
-      "homepage":"https://github.com/YuigaWada/PolioPager"
-    },
-    {
-      "title":"DuctTape",
-      "category":"utility",
-      "description":"📦 KeyPath dynamicMemberLookup based syntax sugar for Swift.",
-      "homepage":"https://github.com/marty-suzuki/DuctTape"
-    },
-    {
-      "title":"BTree",
-      "category":"algorithm",
-      "description":"Fast sorted collections for Swift using in-memory B-trees.",
-      "homepage":"https://github.com/attaswift/BTree"
-    },
-    {
-      "title":"SwiftFormat",
-      "category":"quality",
-      "description":"A code library and command-line formatting tool for reformatting Swift code.",
-      "homepage":"https://github.com/nicklockwood/SwiftFormat"
-    },
-    {
-      "title":"SwiftShell",
-      "category":"command-line",
-      "description":"A library for creating command-line applications and running shell commands.",
-      "homepage":"https://github.com/kareman/SwiftShell"
-    },
-    {
-      "title":"TermiNetwork",
-      "category":"network",
-      "description":"🌏 A zero-dependency networking solution for building modern and secure iOS, watchOS, macOS and tvOS applications.",
-      "homepage":"https://github.com/billp/TermiNetwork"
-    },
-    {
-      "title":"Tiercel",
-      "category":"network",
-      "description":"Background downloads, relaunch recovery, resumable transfers, and task management for iOS apps.",
-      "homepage":"https://github.com/Danie1s/Tiercel"
-    },
-    {
-      "title":"SwiftCop",
-      "category":"quality",
-      "description":"A validation library which inspired by the clarity of Ruby On Rails Active Record validations.",
-      "homepage":"https://github.com/andresinaka/SwiftCop"
-    },
-    {
-      "title":"DIKit",
-      "category":"dependency-injection",
-      "description":"Dependency Injection Framework for Swift, inspired by KOIN.",
-      "homepage":"https://github.com/Liftric/DIKit"
-    },
-    {
-      "title":"MockSwift",
-      "category":"mock",
-      "description":"Mock Framework that uses the power of property wrappers.",
-      "homepage":"https://github.com/leoture/MockSwift"
-    },
-    {
-      "title":"OEMentions",
-      "category":"text",
-      "description":"An easy way to add mentions to uitextview like Facebook and Instagram.",
-      "homepage":"https://github.com/omar14/OEMentions",
-      "tags":[
-        "Swift",
-        "UITextView",
-        "UITableView"
-      ]
-    },
-    {
-      "title":"Translatio",
-      "category":"localization",
-      "description":"Super lightweight library that helps you to localize strings, even directly in storyboards.",
-      "homepage":"https://github.com/andrealufino/Translatio",
-      "tags":[
-        "localization",
-        "language",
-        "translation"
-      ]
-    },
-    {
-      "title":"Deviice",
-      "category":"device",
-      "description":"Swift library to easily check the current device and some more info about it.",
-      "homepage":"https://github.com/andrealufino/Deviice",
-      "tags":[
-        "device",
-        "detection"
-      ]
-    },
-    {
-      "title":"Azure Functions for Swift",
-      "category":"serverless",
-      "description":"Swift Worker for Azure Functions.",
-      "homepage":"https://github.com/SalehAlbuga/azure-functions-swift",
-      "tags":[
-        "linux",
-        "macOS",
-        "serverless",
-        "cloud",
-        "azure"
-      ]
-    },
-    {
-      "title":"SweetCurtain",
-      "category":"ui",
-      "description":"Really sweet and easy bottom pullable sheet implementation. You can find a similar implementation in applications like Apple Maps, Find My, Stocks, etc.",
-      "homepage":"https://github.com/ihormalovanyi/SweetCurtain",
-      "tags":[
-        "swift",
-        "pull-up",
-        "curtain",
-        "bottom-sheet",
-        "sliding-menu"
-      ]
-    },
-    {
-      "title":"XMLMapper",
-      "category":"xml",
-      "description":"A simple way to map XML to Objects.",
-      "homepage":"https://github.com/gcharita/XMLMapper",
-      "tags":[
+      "title": "XMLMapper",
+      "category": "xml",
+      "description": "A simple way to map XML to Objects.",
+      "homepage": "https://github.com/gcharita/XMLMapper",
+      "tags": [
         "swift",
         "xml",
         "soap"
       ]
     },
     {
-      "title":"swift-mod",
-      "category":"quality",
-      "description":"A tool for Swift code modification intermediating between code generation and formatting.",
-      "homepage":"https://github.com/ra1028/swift-mod"
+      "title": "YamlSwift",
+      "category": "yaml",
+      "description": "Load YAML and JSON documents.",
+      "homepage": "https://github.com/behrang/YamlSwift"
     },
     {
-      "title":"CGLayout",
-      "category":"layout",
-      "description":"Powerful autolayout framework, that can manage UIView(NSView), CALayer, not rendered views and etc. Provides placeholders.",
-      "homepage":"https://github.com/k-o-d-e-n/CGLayout",
-      "tags":[
+      "title": "Yams",
+      "category": "yaml",
+      "description": "Sweet YAML parser.",
+      "homepage": "https://github.com/jpsim/Yams",
+      "tags": [
         "linux"
       ]
     },
     {
-      "title":"SwiftCoroutine",
-      "category":"concurrency",
-      "description":"Coroutines for iOS, macOS and Linux.",
-      "homepage":"https://github.com/belozierov/SwiftCoroutine",
-      "tags":[
-        "linux",
-        "swift",
-        "coroutine",
-        "coroutines",
-        "await",
-        "async/await"
-      ]
+      "title": "YapAnimator",
+      "category": "animation",
+      "description": "Your fast and friendly physics-based animation system.",
+      "homepage": "https://github.com/yapstudios/YapAnimator"
     },
     {
-      "title":"CrowdinSDK",
-      "category":"localization",
-      "description":"Delivers all new translations from Crowdin project to the application immediately.",
-      "homepage":"https://github.com/crowdin/mobile-sdk-ios",
-      "tags":[
-        "swift",
-        "crowdin",
-        "localization"
-      ]
+      "title": "YiVideoEditor",
+      "category": "video",
+      "description": "a library for rotating, cropping, adding layers (watermark) and as well as adding audio (music) to the videos.",
+      "homepage": "https://github.com/coderyi/YiVideoEditor"
     },
     {
-      "title":"Apphud",
-      "category":"app-store",
-      "description":"Lightweight library to easily handle auto-renewable subscriptions with no backend required.",
-      "homepage":"https://github.com/apphud/ApphudSDK",
-      "tags":[
-        "swift",
-        "StoreKit"
-      ]
+      "title": "YMTreeMap",
+      "category": "ui",
+      "description": "Treemap / Heatmap layout engine, based on Squarified.",
+      "homepage": "https://github.com/yahoo/YMTreeMap"
     },
     {
-      "title":"ExceptionCatcher",
-      "category":"utility",
-      "description":"Catch Objective-C exceptions.",
-      "homepage":"https://github.com/sindresorhus/ExceptionCatcher"
+      "title": "YNDropDownMenu",
+      "category": "menu",
+      "description": "Adorable iOS drop down menu.",
+      "homepage": "https://github.com/younatics/YNDropDownMenu"
     },
     {
-      "title":"PrivacyFlash Pro",
-      "category":"utility",
-      "description":"Generate a privacy policy for your Swift iOS app from its code.",
-      "homepage":"https://github.com/privacy-tech-lab/privacyflash-pro",
-      "tags":[
-        "swift",
-        "iOS",
-        "privacy policy",
-        "privacy"
-      ]
+      "title": "YNExpandableCell",
+      "category": "uitableview",
+      "description": "Awesome expandable, collapsible tableview cell for iOS.",
+      "homepage": "https://github.com/younatics/YNExpandableCell"
     },
     {
-      "title":"Partition Kit",
-      "category":"ui",
-      "description":"A SwiftUI Library for creating resizable partitions for View Content.",
-      "homepage":"https://github.com/kieranb662/PartitionKit",
-      "tags":[
-        "swiftui",
-        "swift-package-manager",
-        "swift-library"
-      ]
-    },
-    {
-      "title":"CachyKit",
-      "category":"cache",
-      "description":"A Caching Library that can cache JSON, Image, Zip or AnyObject with expiry date/TTYL and force refresh.",
-      "homepage":"https://github.com/Sadmansamee/CachyKit"
-    },
-    {
-      "title":"Spin",
-      "category":"patterns",
-      "description":"Provides a versatile Feedback Loop implementation working with RxSwift, ReactiveSwift and Combine.",
-      "homepage":"https://github.com/Spinners/Spin.Swift",
-      "tags":[
-        "swift",
-        "feedback-loop",
-        "rxswift",
-        "reactiveswift",
-        "combine"
-      ]
-    },
-    {
-      "title":"Playbook",
-      "category":"utility",
-      "description":"📘A library for isolated developing UI components and automatically snapshots of them.",
-      "homepage":"https://github.com/playbook-ui/playbook-ios"
-    },
-    {
-      "title":"SecurePropertyStorage",
-      "category":"security",
-      "description":"Helps you define secure storages for your properties using Swift property wrappers.",
-      "homepage":"https://github.com/alexruperez/SecurePropertyStorage",
-      "tags":[
-        "security",
-        "property wrappers",
-        "userdefaults",
-        "keychain",
-        "singleton",
-        "codable",
-        "dependency injection"
-      ]
-    },
-    {
-      "title":"AnyLint",
-      "category":"quality",
-      "description":"Lint anything by combining the power of Swift & regular expressions.",
-      "homepage":"https://github.com/FlineDev/AnyLint",
-      "tags":[
-        "linux"
-      ]
-    },
-    {
-      "title":"PopupView",
-      "category":"alert",
-      "description":"Toasts and popups library written with SwiftUI.",
-      "homepage":"https://github.com/exyte/PopupView",
-      "tags":[
-        "swiftui",
-        "swift-package-manager",
-        "swift-library"
-      ]
-    },
-    {
-      "title":"CHIOTPField",
-      "category":"textfield",
-      "description":"A set of textfields that can be used for One-time passwords, SMS codes, PIN codes, etc.",
-      "homepage":"https://github.com/ChiliLabs/CHIOTPField"
-    },
-    {
-      "title":"AnimatedCardInput",
-      "category":"payment",
-      "description":"Customisable and easy to use Credit Card UI.",
-      "homepage":"https://github.com/netguru/AnimatedCardInput"
-    },
-    {
-      "title":"StateViewController",
-      "category":"patterns",
-      "description":"Stateful UIVIewController composition — the MVC cure for Massive View Controllers.",
-      "homepage":"https://github.com/davidask/StateViewController"
-    },
-    {
-      "title":"KeyboardShortcuts",
-      "category":"keyboard",
-      "description":"Add user-customizable global keyboard shortcuts to your macOS app. Includes a Cocoa and SwiftUI component.",
-      "homepage":"https://github.com/sindresorhus/KeyboardShortcuts",
-      "tags":[
-        "swiftui",
-        "swift-package-manager",
-        "swift-library",
-        "macos",
-        "hotkey",
-        "shortcut"
-      ]
-    },
-    {
-      "title":"Grid",
-      "category":"layout",
-      "description":"The most powerful Grid container missed in SwiftUI.",
-      "homepage":"https://github.com/exyte/Grid",
-      "tags":[
-        "swiftui",
-        "swift-library",
-        "grid-container"
-      ]
-    },
-    {
-      "title":"Mocker",
-      "category":"mock",
-      "description":"Mock Alamofire and URLSession requests without touching your code implementation",
-      "homepage":"https://github.com/WeTransfer/Mocker",
-      "tags":[
-        "alamofire",
-        "urlsession",
-        "mock"
-      ]
-    },
-    {
-      "title":"ContainerController",
-      "category":"ui",
-      "description":"UI Component. This is a copy swipe-panel from app: Apple Maps, Stocks",
-      "homepage":"https://github.com/mrustaa/ContainerController",
-      "tags":[
-        "swift",
-        "maps",
-        "swipe",
-        "panel",
-        "collection",
-        "tableview",
-        "scrollview",
-        "view",
-        "recognizer",
-        "gesture",
-        "pan"
-      ]
-    },
-    {
-      "title":"HorizonCalendar",
-      "category":"calendar",
-      "description":"A declarative, performant, iOS calendar UI component that supports use cases ranging from simple date pickers all the way up to fully-featured calendar apps.",
-      "homepage":"https://github.com/airbnb/HorizonCalendar",
-      "tags":[
-        "calendar",
-        "airbnb",
-        "declerative"
-      ]
-    },
-    {
-      "title":"SuggestionsKit",
-      "category":"walkthrough",
-      "description":"Library for educating users about features in app.",
-      "homepage":"https://github.com/AlphanumericCharactersOrSingleHyphenz/SuggestionsKit",
-      "tags":[
-        "suggestions",
-        "instructions",
-        "hint",
-        "guide"
-      ]
-    },
-    {
-      "title":"ElegantCalendar",
-      "category":"calendar",
-      "description":"The elegant full screen calendar missed in SwiftUI.",
-      "homepage":"https://github.com/ThasianX/ElegantCalendar",
-      "tags":[
-        "elegantcalendar",
-        "calendar",
-        "declarative",
-        "swiftui"
-      ]
-    },
-    {
-      "title":"Atributika",
-      "category":"label",
-      "description":"TConvert text with HTML tags, links, hashtags, mentions into NSAttributedString. Make them clickable with UILabel drop-in replacement.",
-      "homepage":"https://github.com/psharanda/Atributika",
-      "tags":[
-        "html",
-        "attributedstring",
-        "link",
-        "tag",
-        "hashtag",
-        "clickable"
-      ]
-    },
-    {
-      "title":"Mockingbird",
-      "category":"mock",
-      "description":"Simplify software testing, by easily mocking any system using HTTP/HTTPS, allowing a team to test and develop against a service that is not complete, unstable or just to reproduce planned cases.",
-      "homepage":"https://github.com/Farfetch/mockingbird"
-    },
-    {
-      "title":"FDTextFieldTableViewCell",
-      "category":"uitableview",
-      "description":"Adds a UITextField to the cell and places it correctly.",
-      "homepage":"https://github.com/fulldecent/FDTextFieldTableViewCell"
-    },
-    {
-      "title":"FDWaveformView",
-      "category":"audio",
-      "description":"An easy way to display an audio waveform in your app.",
-      "homepage":"https://github.com/fulldecent/FDWaveformView"
-    },
-    {
-        "title":"FluidAudio",
-        "category":"audio",
-        "description":"SDK for real-time on-device audio intelligence on iOS/macOS (diarization, identification, VAD, separation, embeddings, ASR), with CoreML models converted directly from PyTorch to leverage Apple Neural Engine performance.",
-        "homepage":"https://github.com/FluidInference/FluidAudio"
-    },
-    {
-      "title":"FDTake",
-      "category":"camera",
-      "description":"Easily take a photo or video or choose from library.",
-      "homepage":"https://github.com/fulldecent/FDTake"
-    },
-    {
-      "title":"FDSoundActivatedRecorder",
-      "category":"audio",
-      "description":"Start recording when the user speaks.",
-      "homepage":"https://github.com/fulldecent/FDSoundActivatedRecorder"
-    },
-    {
-      "title":"FDBarGauge",
-      "category":"form",
-      "description":"Simulate the level indicator on an audio mixing board",
-      "homepage":"https://github.com/fulldecent/FDBarGauge"
-    },
-    {
-      "title":"FDChessboardView",
-      "category":"games",
-      "description":"A view controller for chess boards",
-      "homepage":"https://github.com/fulldecent/FDChessboardView"
-    },
-    {
-      "title":"BetterSafariView",
-      "category":"ui",
-      "description":"A better way to present a SFSafariViewController or start a ASWebAuthenticationSession in SwiftUI.",
-      "homepage":"https://github.com/stleamist/BetterSafariView"
-    },
-    {
-      "title":"SociableWeaver",
-      "category":"graphql",
-      "description":"Build declarative GraphQL queries and mutations.",
-      "homepage":"https://github.com/NicholasBellucci/SociableWeaver"
-    },
-    {
-      "title":"Fugen",
-      "category":"misc",
-      "description":"A command line tool for exporting resources and generating code from your Figma files.",
-      "homepage":"https://github.com/almazrafi/Fugen",
-      "tags":[
-        "figma",
-        "figma-export",
-        "design-tokens",
-        "design-systems",
-        "xcode-assets",
-        "codegenerator"
-      ]
-    },
-    {
-      "title":"Netswift",
-      "category":"network",
-      "description":"A type-safe, high-level networking solution.",
-      "homepage":"https://github.com/MrSkwiggs/Netswift",
-      "tags":[
-        "swift",
-        "declarative",
-        "protocols",
-        "structured",
-        "urlsession"
-      ]
-    },
-    {
-      "title":"Tactile",
-      "category":"gesture",
-      "description":"A safer and more idiomatic way to respond to gestures and control events.",
-      "homepage":"https://github.com/delba/Tactile"
-    },
-    {
-      "title":"NeumorphismKit",
-      "category":"ui",
-      "description":"Neumorphism framework for UIKit.",
-      "homepage":"https://github.com/y-okudera/NeumorphismKit",
-      "tags":[
-        "neumorphism",
-        "uicomponents",
-        "swift",
-        "ios",
-        "storyboard"
-      ]
-    },
-    {
-      "title":"MonarchRouter",
-      "category":"app-routing",
-      "description":"Declarative state- and URL-based router. Complex automatic View Controllers hierarchy transitions. Time-tested server-side conventions.",
-      "homepage":"https://github.com/nikans/MonarchRouter",
-      "tags":[
-        "routing",
-        "router",
-        "swift",
-        "ios",
-        "declarative",
-        "state-based",
-        "url",
-        "redux",
-        "reactive"
-      ]
-    },
-    {
-      "title":"CardNavigation",
-      "category":"cards",
-      "description":"A navigation controller that displays its view controllers as an interactive stack of cards.",
-      "homepage":"https://github.com/james01/CardNavigation",
-      "tags":[
-        "navigation",
-        "interactive",
-        "cards",
-        "uikit",
-        "transition",
-        "interruptible"
-      ]
-    },
-    {
-      "title":"Swift Argument Parser",
-      "category":"command-line",
-      "description":"Straightforward, type-safe argument parsing for Swift.",
-      "homepage":"https://github.com/apple/swift-argument-parser"
-    },
-    {
-      "title":"Puppy",
-      "category":"logging",
-      "description":"A flexible logging library that supports multiple transports and platforms.",
-      "homepage":"https://github.com/sushichop/Puppy",
-      "tags":[
-        "swift",
-        "linux",
-        "macos",
-        "ios",
-        "tvos",
-        "watchos"
-      ]
-    },
-    {
-      "title":"TwitterTextEditor",
-      "category":"text",
-      "description":"A standalone, flexible API that provides a full featured rich text editor for iOS applications.",
-      "homepage":"https://github.com/twitter/TwitterTextEditor"
-    },
-    {
-      "title":"SwiftPlantUML",
-      "category":"utility",
-      "description":"A command-line tool and Swift Package to generate UML class from your Swift source code. Also available as Xcode Source Editor Extension.",
-      "homepage":"https://github.com/MarcoEidinger/SwiftPlantUML"
-    },
-    {
-      "title":"Kanvas",
-      "category":"images",
-      "description":"A iOS library for adding effects, drawings, text, stickers, and making GIFs from existing media or the camera.",
-      "homepage":"https://github.com/tumblr/kanvas-ios"
-    },
-    {
-      "title":"ColorKit",
-      "category":"colors",
-      "description":"Advanced color manipulation for iOS.",
-      "homepage":"https://github.com/Boris-Em/ColorKit"
-    },
-    {
-      "title":"TextBuilder",
-      "category":"text",
-      "description":"Like a SwiftUI ViewBuilder, but for Text.",
-      "homepage":"https://github.com/davdroman/swiftui-text-builder"
-    },
-    {
-      "title":"TPInAppReceipt",
-      "category":"payment",
-      "description":"A lightweight, pure-Swift library for reading and validating Apple In App Purchase Receipt locally.",
-      "homepage":"https://github.com/tikhop/TPInAppReceipt",
-      "tags":[
-        "swift",
-        "ios",
-        "tvos",
-        "watchos",
-        "macos",
-        "inAppReceipt",
-        "inAppPurchase",
-        "StoreKit",
-        "receipt"
-      ]
-    },
-    {
-      "title":"SOAPEngine",
-      "category":"soap",
-      "description":"Generic SOAP client to access SOAP Web Services using iOS, Mac OS X, and Apple TV.",
-      "homepage":"https://github.com/priore/SOAPEngine",
-      "tags":[
-        "swift",
-        "soap",
-        "macos",
-        "ios",
-        "tvos",
-        "xml"
-      ]
-    },
-    {
-      "title":"The Composable Architecture",
-      "category":"patterns",
-      "description":"A library for building applications in a consistent and understandable way, with composition, testing, and ergonomics in mind.",
-      "homepage":"https://github.com/pointfreeco/swift-composable-architecture",
-      "tags":[
-        "swift",
-        "ios"
-      ]
-    },
-    {
-      "title":"SwiftUI Atom Properties",
-      "category":"patterns",
-      "description":"A Reactive Data-Binding and Dependency Injection Library for SwiftUI x Concurrency.",
-      "homepage":"https://github.com/ra1028/swiftui-atom-properties",
-      "tags":[
-        "swift",
-        "swiftui",
-        "architecture"
-      ]
-    },
-    {
-      "title":"SwiftDraw",
-      "category":"images",
-      "description":"Library that converts SVG images to UIImage, NSImage and generates CoreGraphics source code.",
-      "homepage":"https://github.com/swhitty/SwiftDraw",
-      "tags":[
-        "swift",
-        "ios",
-        "macos"
-      ]
-    },
-    {
-      "title":"SwiftCurrent",
-      "category":"app-routing",
-      "description":"Manage complex workflows wherever Swift can be built. It comes with built-in support for UIKit, Storyboards, and SwiftUI.",
-      "homepage":"https://github.com/wwt/SwiftCurrent",
-      "tags":[
-        "uikit",
-        "storyboard",
-        "swiftui",
-        "iOS",
-        "watchOS",
-        "tvOS",
-        "macOS",
-        "declarative",
-        "navigation"
-      ]
-    },
-    {
-      "title":"Percentage",
-      "category":"utility",
-      "description":"Make percentages more readable and type-safe.",
-      "homepage":"https://github.com/sindresorhus/Percentage"
-    },
-    {
-      "title":"ARHeadsetKit",
-      "category":"augmented-reality",
-      "description":"High-level framework for using $5 Google Cardboard to replicate Microsoft Hololens.",
-      "homepage":"https://github.com/philipturner/ARHeadsetKit",
-      "tags":[
-        "macOS",
-        "swiftui",
-        "iOS",
-        "metal",
-        "virtual reality",
-        "GPGPU",
-        "google cardboard"
-      ]
-    },
-    {
-      "title":"Rugby",
-      "category":"utility",
-      "description":"🏈 Cache CocoaPods for faster rebuild and indexing Xcode project.",
-      "homepage":"https://github.com/swiftyfinch/Rugby"
-    },
-    {
-      "title":"SVGView",
-      "category":"svg",
-      "description":"SVG parser and renderer written in SwiftUI.",
-      "homepage":"https://github.com/exyte/SVGView"
-    },
-    {
-      "title":"ProgressIndicatorView",
-      "category":"ui",
-      "description":"A progress indicator view library written in SwiftUI.",
-      "homepage":"https://github.com/exyte/ProgressIndicatorView"
-    },
-    {
-      "title":"Surmagic",
-      "category":"misc",
-      "description":"Create XCFrameworks with ease! A Command Line Tool to create XCFramework for multiple platforms at one shot! iOS, Mac Catalyst, tvOS, macOS, and watchOS.",
-      "homepage":"https://github.com/gurhub/surmagic",
-      "tags":[
-        "xcframework",
-        "fat-framework",
-        "binary-framework",
-        "generate",
-        "iOS",
-        "Mac Catalyst",
-        "macOS",
-        "tvOS",
-        "watchOS",
-        "ci",
-        "swift"
-      ]
-    },
-    {
-      "title":"YiVideoEditor",
-      "category":"video",
-      "description":"a library for rotating, cropping, adding layers (watermark) and as well as adding audio (music) to the videos.",
-      "homepage":"https://github.com/coderyi/YiVideoEditor"
-    },
-    {
-      "title":"SwiftUICharts",
-      "category":"chart",
-      "description":"A charts / plotting library for SwiftUI. Works on macOS, iOS, watchOS, and tvOS and has accessibility and Localization features built in.",
-      "homepage":"https://github.com/willdale/SwiftUICharts",
-      "tags":[
-        "iOS",
-        "macOS",
-        "tvOS",
-        "watchOS",
-        "swiftui"
-      ]
-    },
-    {
-      "title":"Raylib for Swift",
-      "category":"game-engine",
-      "description":"A Cross-Platform Swift package for Raylib. Builds Raylib from source so no need to fiddle with libraries. Just add as a dependency in you game package and go!",
-      "homepage":"https://github.com/STREGAsGate/Raylib",
-      "tags":[
-        "macOS",
-        "linux",
-        "windows",
-        "swift"
-      ]
-    },
-    {
-      "title":"Scaling Header Scroll View",
-      "category":"layout",
-      "description":"A scroll view with a sticky header which shrinks as you scroll. Written with SwiftUI.",
-      "homepage":"https://github.com/exyte/ScalingHeaderScrollView",
-      "tags":[
-        "swiftui",
-        "iOS",
-        "sticky-header",
-        "scaling-header"
-      ]
-    },
-    {
-      "title":"BottomSheet",
-      "category":"ui",
-      "description":"Powerful Bottom Sheet component with content based size, interactive dismissal and navigation controller support.",
-      "homepage":"https://github.com/joomcode/BottomSheet",
-      "tags":[
-        "uikit",
-        "iOS",
-        "bottom-sheet"
-      ]
-    },
-    {
-      "title":"KVKCalendar",
-      "category":"calendar",
-      "description":"A most fully customization calendar for Apple platforms 📅",
-      "homepage":"https://github.com/kvyatkovskys/KVKCalendar",
-      "tags":[
-        "uikit",
-        "iOS",
-        "calendar",
-        "swiftui"
-      ]
-    },
-    {
-      "title":"SwiftBoost",
-      "category":"utility",
-      "description":"Collection of Swift-extensions to boost development process.",
-      "homepage":"https://github.com/sparrowcode/SwiftBoost",
-      "tags":[
-        "swift",
-        "productivity",
-        "boost"
-      ]
-    },
-    {
-      "title":"ISEmojiView",
-      "category":"keyboard",
-      "description":"Emoji Keyboard for iOS",
-      "homepage":"https://github.com/isaced/ISEmojiView",
-      "tags":[
-        "swift",
-        "emoji"
-      ]
-    },
-    {
-      "title":"TabBar",
-      "category":"tab",
-      "description":"Highly customizable tab bar for SwiftUI applications.",
-      "homepage":"https://github.com/onl1ner/TabBar",
-      "tags":[
-        "swift",
-        "swiftui",
-        "tab-bar",
-        "iOS"
-      ]
-    },
-    {
-      "title":"GoodExtensions-iOS",
-      "category":"utility",
-      "description":"📑 GoodExtensions is a collection of useful and frequently used extensions.",
-      "homepage":"https://github.com/GoodRequest/GoodExtensions-iOS",
-      "tags":[
-        "swift",
-        "iOS",
-        "utility"
-      ]
-    },
-    {
-      "title":"GoodUIKit",
-      "category":"utility",
-      "description":"📑 GoodUIKit is an extensions library filled with reusable UI snippets for faster and more efficient development.",
-      "homepage":"https://github.com/GoodRequest/GoodUIKit",
-      "tags":[
-        "swift",
-        "iOS",
-        "uikit"
-      ]
-    },
-    {
-      "title":"GoodReactor",
-      "category":"patterns",
-      "description":"⚛️ GoodReactor is a Redux-inspired Reactor framework for communication between the View Model, View Controller, and Coordinator.",
-      "homepage":"https://github.com/GoodRequest/GoodReactor",
-      "tags":[
-        "swift",
-        "iOS",
-        "reactorKit"
-      ]
-    },
-    {
-      "title":"GoodPersistence",
-      "category":"keychain",
-      "description":"💾 GoodPersistence simplifies caching data in keychain and UserDefaults. Using a property wrappers.",
-      "homepage":"https://github.com/GoodRequest/GoodPersistence",
-      "tags":[
-        "swift",
-        "iOS",
-        "persistence",
-        "userdefaults",
-        "keychain"
-      ]
-    },
-    {
-      "title":"Temple",
-      "category":"template",
-      "description":"🗂️ Most advanced project and file templates.",
-      "homepage":"https://github.com/GoodRequest/Temple",
-      "tags":[
-        "swift",
-        "iOS",
-        "tempalate",
-        "Xcode"
-      ]
-    },
-    {
-      "title":"GoodProvider",
-      "category":"uicollectionview",
-      "description":"🚀 UITableView and UICollectionView provider to simplify basic scenarios of showing the data.",
-      "homepage":"https://github.com/GoodRequest/GRProvider",
-      "tags":[
-        "swift",
-        "iOS",
-        "UITableView",
-        "UICollectionView"
-      ]
-    },
-    {
-      "title":"Model-View-Presenter template",
-      "category":"boilerplates",
-      "description":"A flexible and easy template created to speed up the development of your iOS application based on the MVP pattern.",
-      "homepage":"https://github.com/onl1ner/ios-mvp-template"
-    },
-    {
-      "title":"Open Source Updates for Swift Projects",
-      "category":"newsletter",
-      "description":"A bi-weekly newsletter to give you the latest updates on popular and unknown open source projects written or related to Swift.",
-      "homepage":"https://ossp-updates.beehiiv.com/"
-    },
-    {
-      "title":"Popovers",
-      "category":"ui",
-      "description":"A library to present popovers. Simple, modern, and highly customizable. Not boring!",
-      "homepage":"https://github.com/aheze/Popovers"
-    },
-    {
-      "title":"CapturePreventionKit",
-      "category":"ui",
-      "description":"Provides `Label` and `ImageView` for `screen capture prevention`.",
-      "homepage":"https://github.com/Jaesung-Jung/CapturePreventionKit",
-      "tags":[
-        "swift",
-        "iOS",
-        "ui",
-        "security"
-      ]
-    },
-    {
-      "title":"AppReview",
-      "category":"app-store",
-      "description":"A tiny library to request review on the AppStore via SKStoreReviewController.",
-      "homepage":"https://github.com/mezhevikin/AppReview"
-    },
-    {
-      "title":"Tracker Aggregator",
-      "category":"analytics",
-      "description":"Versatile analytics abstraction layer.",
-      "homepage":"https://github.com/kafejo/Tracker-Aggregator"
-    },
-    {
-      "title":"RxNetworks",
-      "category":"network",
-      "description":"Network API With RxSwift + Moya + HandyJSON + Plugins.",
-      "homepage":"https://github.com/yangKJ/RxNetworks"
-    },
-    {
-      "title":"HypeUI",
-      "category":"auto-layout",
-      "description":"🌺 HypeUI is a implementation of Apple's SwiftUI DSL style based on UIKit",
-      "homepage":"https://github.com/hyperconnect/HypeUI"
-    },
-    {
-      "title":"MediaPicker",
-      "category":"camera",
-      "description":"SwiftUI customizable media picker - supports camera and gallery with albums",
-      "homepage":"https://github.com/exyte/mediapicker"
-    },
-    {
-      "title":"LiquidSwipe",
-      "category":"transition",
-      "description":"Liquid navigation animation",
-      "homepage":"https://github.com/exyte/LiquidSwipe"
-    },
-    {
-      "title":"BetterCodable",
-      "category":"misc",
-      "description":"Level up your `Codable` structs through property wrappers. The goal of these property wrappers is to avoid implementing a custom `init(from decoder: Decoder)` throws and suffer through boilerplate.",
-      "homepage":"https://github.com/marksands/BetterCodable"
-    },
-    {
-      "title":"Periphery",
-      "category":"utility",
-      "description":"A tool to identify unused code in Swift projects.",
-      "homepage":"https://github.com/peripheryapp/periphery"
-    },
-    {
-      "title":"xc",
-      "category":"misc",
-      "description":"A tool to open the Xcode project file by the specified version.",
-      "homepage":"https://github.com/s2mr/xc"
-    },
-    {
-      "title":"OpenAI",
-      "category":"ai",
-      "description":"Swift package for OpenAI public API.",
-      "homepage":"https://github.com/MacPaw/OpenAI"
-    },
-    {
-      "title":"L10nLint",
-      "category":"quality",
-      "description":"A linter tool for Localizable.strings.",
-      "homepage":"https://github.com/s2mr/L10nLint"
-    },
-    {
-      "title":"AnimatedTabBar",
-      "category":"layout",
-      "description":"A tabbar with a number of preset animations.",
-      "homepage":"https://github.com/exyte/AnimatedTabBar"
-    },
-    {
-      "title":"GoodNetworking",
-      "category":"network",
-      "description":"📡 GoodNetworking simplifies HTTP networking.",
-      "homepage":"https://github.com/GoodRequest/GoodNetworking",
-      "tags":[
-        "swift",
-        "iOS",
-        "networking"
-      ]
-    },
-    {
-      "title":"DMScrollBar",
-      "category":"scroll-bars",
-      "description":"Best in class customizable ScrollBar for any type of ScrollView with Decelerating, Bounce & Rubber band mechanisms and many many more.",
-      "homepage":"https://github.com/batanus/DMScrollBar",
-      "tags":[
-        "swift",
-        "iOS",
-        "scroll-bar",
-        "scroll-indicator",
-        "scroll-view"
-      ]
-    },
-    {
-      "title":"ExyteChat",
-      "category":"chat",
-      "description":"SwiftUI Chat UI framework with fully customizable message cells, input view, and a built-in media picker",
-      "homepage":"https://github.com/exyte/chat",
-      "tags":[
-        "swift",
-        "iOS",
-        "swiftui",
-        "chat"
-      ]
-    },
-    {
-      "title":"SwiftLee",
-      "category":"Newsletter",
-      "description":"A weekly blog about Swift, iOS and Xcode Tips and Tricks.",
-      "homepage":"https://www.avanderlee.com/",
-      "tags":[
-        "swift",
-        "iOS",
-        "swiftui"
-      ]
-    },
-    {
-      "title":"SwiftAutoGUI",
-      "category":"utility",
-      "description":"Used to programmatically control the mouse & keyboard. A library for manipulating macOS with Swift.",
-      "homepage":"https://github.com/NakaokaRei/SwiftAutoGUI",
-      "tags":[
-        "swift",
-        "macos"
-      ]
-    },
-    {
-      "title":"MijickPopups",
-      "category":"alert",
-      "description":"Popups, popovers, sheets, alerts, toasts, banners, (...) presentation made simple.",
-      "homepage":"https://github.com/Mijick/Popups",
-      "tags":[
-        "swiftui",
-        "swift-package-manager",
-        "swift-library",
-        "popupview",
-        "popup"
-      ]
-    },
-    {
-      "title":"MijickNavigattie",
-      "category":"transition",
-      "description":"Easy navigation with SwiftUI.",
-      "homepage":"https://github.com/Mijick/NavigationView",
-      "tags":[
-        "swift",
-        "swiftui",
-        "iOS",
-        "transition",
-        "navigation"
-      ]
-    },
-    {
-      "title":"Aptabase",
-      "category":"analytics",
-      "description":"Open Source, Privacy-First and Simple Analytics for Swift Apps.",
-      "homepage":"https://github.com/aptabase/aptabase",
-      "tags":[
-        "analytics",
-        "swift",
-        "iOS",
-        "macOS",
-        "tvOS"
-      ]
-    },
-    {
-      "title":"TypedDate",
-      "category":"date",
-      "description":"Enhancing Date handling by enabling type-level customization of date components",
-      "homepage":"https://github.com/Ryu0118/swift-typed-date",
-      "tags":[
-        "swift",
-        "date",
-        "iOS",
-        "macOS",
-        "tvOS"
-      ]
-    },
-    {
-      "title":"FullscreenPopup",
-      "category":"alert",
-      "description":"Present any popup above NavigationBar in SwiftUI",
-      "homepage":"https://github.com/Ryu0118/swift-fullscreen-popup",
-      "tags":[
-        "swift",
-        "swiftui",
-        "iOS",
-        "macOS",
-        "tvOS",
-        "popup"
-      ]
-    },
-    {
-      "title":"MemberwiseInit",
-      "category":"misc",
-      "description":"`@MemberwiseInit` is a Swift Macro that can more often provide your intended `init`, while following the same safe-by-default semantics of Swift’s memberwise initializers.",
-      "homepage":"https://github.com/gohanlon/swift-memberwise-init-macro",
-      "tags":[
-        "swift",
-        "macro",
-        "init",
-        "initializers"
-      ]
-    },
-    {
-      "title":"SimplexArchitecture",
-      "category":"patterns",
-      "description":"A Simple architecture that decouples state changes from SwiftUI's View",
-      "homepage":"https://github.com/Ryu0118/swiftui-simplex-architecture",
-      "tags":[
-        "swift",
-        "swiftui",
-        "iOS",
-        "macOS",
-        "tvOS"
-      ]
-    },
-    {
-      "title":"SwiftUIMaterialTabs",
-      "category":"tab",
-      "description":"Material 3-style tabs and Sticky Headers rolled into one SwiftUI library",
-      "homepage":"https://github.com/SwiftKickMobile/SwiftUIMaterialTabs",
-      "tags":[
-        "swiftui",
-        "tab",
-        "ios",
-        "scroll",
-        "header"
-      ]
-    },
-    {
-      "title":"ExtendedAttributes",
-      "category":"files",
-      "description":"Manage extended attributes for files and folders.",
-      "homepage":"https://github.com/sindresorhus/ExtendedAttributes",
-      "tags":[
-        "swift",
-        "system",
-        "file-system"
-      ]
-    },
-    {
-      "title":"AnimatedGradient",
-      "category":"animation",
-      "description":"Animated linear gradient library written with SwiftUI",
-      "homepage":"https://github.com/exyte/AnimatedGradient",
-      "tags":[
-        "swiftui",
-        "gradient",
-        "animation"
-      ]
-    },
-    {
-      "title":"SwiftUISkia",
-      "category":"ui",
-      "description":"Skia based 2d graphics SwiftUI rendering library, based on Rust to implement software rasterization to perform rendering",
-      "homepage":"https://github.com/rustq/swiftui-skia",
-      "tags":[
-        "swift",
-        "swiftui",
-        "skia",
-        "rust"
-      ]
-    },
-    {
-      "title": "FlagAndCountryCode",
-      "category": "utility",
-      "description": "FlagAndCountryCode provides phone codes and flags for every country. Works on UIKit and SwiftUI",
-      "homepage": "https://github.com/exyte/FlagAndCountryCode",
-      "tags": ["swift", "flag", "phone", "country-code"]
-    },
-    {
-      "title": "SwiftFiddle",
-      "category": "repl",
-      "description": "Playground for making, sharing, and embedding Swift code.",
-      "homepage": "https://swiftfiddle.com",
-      "tags": ["swift", "repl", "playground"] 
-    },
-    {
-      "title": "SwiftGodot",
-      "category": "game-engine",
-      "description": "Swift bindings for the Godot game engine to build extensions or act as an api with SwiftGodotKit.",
-      "homepage": "https://migueldeicaza.github.io/SwiftGodotDocs/tutorials/swiftgodot-tutorials/",
-      "tags":["swift", "game-engine", "bindings"]
-    },
-    {
-      "title": "Scout",
-      "category": "analytics",
-      "description": "Production-grade logging SDK for iOS apps using CloudKit as a backend.",
-      "homepage": "https://github.com/kasianov-mikhail/scout",
-      "tags": ["analytics", "swift", "iOS"]
-    },
-    {
-      "title": "Swiftly",
-      "category": "dependency-managers",
-      "description": "Swift CLI toolchain installer to install different versions of Swift.",
-      "homepage": "https://github.com/swiftlang/swiftly",
-      "tags":["swift", "dependency", "cli"]
-    },
-    {
-      "title":"MijickCamera",
-      "category":"camera",
-      "description":"Camera made simple. Fully customizable camera library that significantly reduces implementation time and effort.",
-      "homepage":"https://github.com/Mijick/Camera"
-    },
-    {
-      "title": "ReerCodable",
-      "category": "json",
-      "description": "Codable extensions using Swift macro.",
-      "homepage": "https://github.com/reers/ReerCodable",
-      "tags":["swift", "codable"]
-    },
-    {
-      "title":"JWSETKit",
-      "category":"cryptography",
-      "description":"JOSE library with JWS, JWT, JWE, and JWK support.",
-      "homepage":"https://github.com/amosavian/JWSETKit"
-    },
-    {
-      "title": "swift-build",
-      "category": "utility",
-      "description": "GitHub Action for building and testing Swift packages across all platforms.",
-      "homepage": "https://github.com/brightdigit/swift-build",
-      "tags":["swift", "github"]      
+      "title": "YNSearch",
+      "category": "ui",
+      "description": "Awesome fully customizable search view like Pinterest.",
+      "homepage": "https://github.com/younatics/YNSearch"
     },
     {
       "title": "YouTubeKit",
       "category": "api",
       "description": "Interact with the YouTube API without an API key.",
       "homepage": "https://github.com/b5i/YouTubeKit",
-      "tags": ["youtube", "api", "swift"]
+      "tags": [
+        "youtube",
+        "api",
+        "swift"
+      ]
     },
     {
-      "title":"SwiftUIRoutes",
-      "category":"app-routing",
-      "description":"A minimal and flexible router for SwiftUI apps.",
-      "homepage":"https://github.com/gabriel/swiftui-routes"
+      "title": "YPImagePicker",
+      "category": "images",
+      "description": "Instagram-like image picker & filters for iOS.",
+      "homepage": "https://github.com/Yummypets/YPImagePicker"
+    },
+    {
+      "title": "ZamzamKit",
+      "category": "utility",
+      "description": "A collection of micro utilities and extensions for Standard Library, Foundation and UIKit.",
+      "homepage": "https://github.com/basememara/ZamzamKit"
+    },
+    {
+      "title": "Zephyr",
+      "category": "key-value-store",
+      "description": "Effortlessly synchronize NSUserDefaults over iCloud.",
+      "homepage": "https://github.com/ArtSabintsev/Zephyr"
+    },
+    {
+      "title": "Zewo",
+      "category": "webserver",
+      "description": "Server-Side Swift.",
+      "homepage": "https://github.com/Zewo/Zewo",
+      "tags": [
+        "linux"
+      ]
+    },
+    {
+      "title": "ZImageCropper",
+      "category": "images",
+      "description": "Crop image in any shape.",
+      "homepage": "https://github.com/ZaidPathan/ZImageCropper"
+    },
+    {
+      "title": "Zingle",
+      "category": "alert",
+      "description": "An alert will display underneath your UINavigationBar.",
+      "homepage": "https://github.com/hemangshah/Zingle"
+    },
+    {
+      "title": "Zip",
+      "category": "zip",
+      "description": "Framework for zipping and unzipping files.",
+      "homepage": "https://github.com/marmelroy/Zip"
+    },
+    {
+      "title": "Zip Foundation",
+      "category": "zip",
+      "description": "A library to create, read and modify ZIP archive files.",
+      "homepage": "https://github.com/weichsel/ZIPFoundation"
+    },
+    {
+      "title": "ZMarkupParser",
+      "category": "html",
+      "description": "Helps you convert HTML strings into NSAttributedString with customized styles and tags.",
+      "homepage": "https://github.com/ZhgChgLi/ZMarkupParser"
+    },
+    {
+      "title": "Zolang",
+      "homepage": "https://github.com/Zolang/Zolang",
+      "category": "converters",
+      "description": "A DSL for generating code in multiple programming languages.",
+      "tags": [
+        "extensions",
+        "ios",
+        "macos",
+        "linux",
+        "swift"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds [Claude Code Server-Side Swift Skills](https://github.com/melissa-pereira-deel/claude-code-server-side-swift-skills) to the **Third Party Guides** category in `contents.json`.

## What it is

A collection of 15 production-ready Claude Code skills covering:

- **Server-Side Swift** — Vapor 4, Hummingbird 2, Fluent ORM, JWT auth, Docker deployment, shared client↔server models
- **Xcode Cloud** — Workflow patterns, ci_scripts, TestFlight, App Store submission, troubleshooting

## Why Third Party Guides?

These are educational/reference materials (markdown skill files) that teach Claude Code how to assist with server-side Swift development — not a library or framework. The "Third Party Guides" category best matches this type of educational resource.

## Changes

- Updated `contents.json` only (as instructed by README)
- Added one entry to the `third-party-guides` category
- Projects list remains alphabetically sorted

## Compatibility

- Swift 5.9+, Vapor 4.89+, Hummingbird 2.0+, Xcode 15+
- MIT licensed