### PR TITLE
Add PureMac to Utility section

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -8676,6 +8676,12 @@
       "category":"app-routing",
       "description":"A minimal and flexible router for SwiftUI apps.",
       "homepage":"https://github.com/gabriel/swiftui-routes"
+    },
+    {
+      "title":"PureMac",
+      "category":"utility",
+      "description":"Free, open-source macOS cleaner with zero telemetry. Cleans system caches, Xcode junk, Homebrew cache, and finds large files. Includes scheduled auto-cleaning.",
+      "homepage":"https://github.com/momenbasel/PureMac"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add [PureMac](https://github.com/momenbasel/PureMac) to the Utility category in `contents.json`.
- PureMac is a free, open-source macOS cleaner built with SwiftUI, targeting macOS 13+.
- MIT licensed, zero telemetry, no analytics, no network calls.
- Features: system/user cache cleaning, Xcode junk removal, Homebrew cache cleanup, purgeable space recovery, large/old file finder, and scheduled auto-cleaning.