### PR TITLE
Add Open Agent SDK

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -8717,6 +8717,13 @@
       "category":"calendar",
       "description":"A modular, customizable SwiftUI/UIKit calendar package for iOS.",
       "homepage":"https://github.com/claustrofob/Yotei"
+    },
+    {
+      "title":"Open Agent SDK",
+      "category":"ai",
+      "description":"Open-source Agent SDK with full agent loop, 34 built-in tools, sub-agent orchestration, MCP integration, and multi-provider LLM support.",
+      "homepage":"https://github.com/terryso/open-agent-sdk-swift",
+      "tags":["agent","mcp","llm","sdk","automation"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
Add [Open Agent SDK](https://github.com/terryso/open-agent-sdk-swift) to the `ai` category in `contents.json`.

## Why it should be included
- Open-source Swift Agent SDK that runs the full agent loop **in-process** with native Swift concurrency
- **34 built-in tools** covering file operations, search, web, task management, team orchestration, cron/plan/worktree
- **Multi-provider LLM**: Anthropic (Claude) and OpenAI-compatible APIs (GLM, Ollama, OpenRouter, etc.)
- **MCP integration**: connect external tools via stdio, SSE, HTTP, or in-process MCP servers
- **Sub-agent orchestration**: spawn child agents, manage teams and inter-agent messaging
- **Self-evolution**: background review agent auto-extracts memory, evolves skills, and curates the skill library
- Well documented with English README, Chinese README, and official website
- MIT licensed, Swift 6.1, macOS 13+
- 18+ GitHub stars, actively maintained

Fits alongside existing AI agent entries like Fazm and EdgeRunner in the `ai` category.

One suggestion per PR ✅
English README ✅
15+ stars ✅
MIT license ✅
Not a duplicate ✅