### PR TITLE
feat: add TWZRD Agent Intel to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ In parternship with:
 * [Espresso](https://github.com/christopherkarani/Espresso) - Compile transformers directly for Apple's Neural Engine.
 * [Fazm](https://github.com/m13v/fazm) - A voice-controlled AI agent for macOS using accessibility APIs and ScreenCaptureKit.
 * [OpenAI](https://github.com/MacPaw/OpenAI) - Swift package for OpenAI public API.
+* [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring MCP server for AI agents on Solana. Verify agent wallet identity before x402 micropayments.
 
 ### Algorithm
 [back to top](#readme) 


### PR DESCRIPTION
## What this adds

[TWZRD Agent Intel](https://intel.twzrd.xyz) — trust scoring MCP server for AI agents on Solana.

Provides on-chain trust scores for AI agent wallets. Verify agent wallet identity before x402 micropayments. Free MCP endpoint: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`

Added to the **AI** section alongside other AI/ML-oriented tools.

**Checklist**:
- [x] Entry in alphabetical order (after OpenAI)
- [x] Format: `* [Name](url) - Description.`
- [x] Project is live and maintained