### PR TITLE
Add AudioLivenessDetection (on-device PCM replay/liveness detection)

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -1232,6 +1232,12 @@
       "homepage":"https://github.com/audiokit/AudioKit"
     },
     {
+      "title":"AudioLivenessDetection",
+      "category":"audio",
+      "description":"On-device PCM audio liveness detection — distinguish live microphone speech from recorded replay on iOS and macOS.",
+      "homepage":"https://github.com/mythkiven/AudioLivenessDetection"
+    },
+    {
       "title":"AudioPlayer",
       "category":"audio",
       "description":"A wrapper around AVPlayer with some cool features.",


### PR DESCRIPTION
Add [AudioLivenessDetection](https://github.com/mythkiven/AudioLivenessDetection) — on-device PCM audio liveness / replay detection for iOS & macOS.

**Why include**
- Lightweight replay detection without ML models or server-side inference
- MIT licensed, CI, technical docs, CLI + iOS SwiftUI demo
- Complements VAD/ASR entries in this list (live mic vs recorded playback)

Maintainer: @mythkiven

**Note on star count:** Project is newly open-sourced. Requesting inclusion under the ecosystem-gap exception — no other Swift SPM library in awesome-ios covers on-device PCM replay/liveness detection with zero dependencies.

Made with [Cursor](https://cursor.com)