### PR TITLE
Add solid-like-a-rock to Quality

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -8417,6 +8417,15 @@
       "homepage":"https://github.com/s2mr/L10nLint"
     },
     {
+      "title":"solid-like-a-rock",
+      "category":"quality",
+      "description":"Architecture linter that enforces Clean Architecture and TCA import rules using SwiftSyntax.",
+      "homepage":"https://github.com/nenadvulic/solid-like-a-rock",
+      "tags":[
+        "linux"
+      ]
+    },
+    {
       "title":"AnimatedTabBar",
       "category":"layout",
       "description":"A tabbar with a number of preset animations.",


### PR DESCRIPTION
Adding [solid-like-a-rock](https://github.com/nenadvulic/solid-like-a-rock) to the **Quality** category.

> Architecture linter that enforces Clean Architecture and TCA import rules using SwiftSyntax.

It parses Swift sources with SwiftSyntax to enforce module import boundaries (Clean Architecture layers and The Composable Architecture peer isolation), as a CI-ready guardrail.

Criteria checklist:
- ✅ Actively maintained (latest release v0.7.0)
- ✅ Performs a useful function (architecture/import linting)
- ✅ Well documented (README in English, examples, GitHub Action)
- ✅ Works with the latest SDK — Swift 6.0 toolchain
- ✅ 17+ GitHub stars
- ✅ Supports Swift 5+ (also ships static Linux binaries → `linux` tag)
- ✅ MIT licensed

Edited `contents.json` (not the generated README), per the contribution guidelines.