### PR TITLE
Add MattermostSwift

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ PLEASE DO NOT UPDATE THIS FILE, UPDATE CONTENTS.JSON INSTEAD. THANK YOU :-)
 
 | Awesome | Linux | Projects | Updated |
 |:-------:|:-----:|:--------:|:-------:|
-| [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome) | :penguin: | 1103 | June 15, 2026 |
+| [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome) | :penguin: | 1104 | June 22, 2026 |
 
 In parternship with:
 
@@ -367,6 +367,7 @@ In parternship with:
 
 * [GitHubAPI](https://github.com/serhii-londar/GithubAPI) - Implementation of GitHub REST API v3.
 * [GitHubRestAPISwiftOpenAPI](https://github.com/Wei18/github-rest-api-swift-openapi) - Scheduled generated GitHub's REST API as Swift code from OpenAPI specification.
+* [MattermostSwift](https://github.com/randomsnowflake/MattermostSwift) - Unofficial SDK for building Mattermost clients and tools.
 * [PXGoogleDirections](https://github.com/poulpix/PXGoogleDirections) - Google Directions API helper.
 * [RandomUserSwift](https://github.com/dingwilson/RandomUserSwift) - Framework to Generate Random Users - An Unofficial SDK for randomuser.me.
 * [reddift](https://github.com/sonsongithub/reddift) - reddit API wrapper.

--- a/contents.json
+++ b/contents.json
@@ -8707,6 +8707,13 @@
       "tags": ["youtube", "api", "swift"]
     },
     {
+      "title": "MattermostSwift",
+      "category": "api",
+      "description": "Unofficial SDK for building Mattermost clients and tools.",
+      "homepage": "https://github.com/randomsnowflake/MattermostSwift",
+      "tags": ["mattermost", "api", "sdk"]
+    },
+    {
       "title":"SwiftUIRoutes",
       "category":"app-routing",
       "description":"A minimal and flexible router for SwiftUI apps.",


### PR DESCRIPTION
Adds MattermostSwift, an unofficial Swift SDK for building Mattermost clients and tools.

Note: this project was just open-sourced and is currently below the listed 15-star guideline, so I am opening this as a draft for maintainer consideration.