### PR TITLE
Add Dusty (macOS disk cleaner, allowlist-only engine)

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -8724,6 +8724,13 @@
       "description":"Open-source Agent SDK with full agent loop, 34 built-in tools, sub-agent orchestration, MCP integration, and multi-provider LLM support.",
       "homepage":"https://github.com/terryso/open-agent-sdk-swift",
       "tags":["agent","mcp","llm","sdk","automation"]
+    },
+    {
+      "title":"Dusty",
+      "category":"files",
+      "description":"Open-source macOS menu bar disk cleaner with an allowlist-only, unit-tested deletion engine.",
+      "homepage":"https://github.com/yagcioglutoprak/dusty",
+      "tags":["macos","menu-bar"]
     }
   ]
 }


### PR DESCRIPTION
Adds [Dusty](https://github.com/yagcioglutoprak/dusty), a free, open-source (MIT) macOS menu bar disk cleaner, under the **Files** category.

Dusty reclaims disk space from caches, logs, and developer junk (Xcode DerivedData, simulators, npm/pip/gradle, Homebrew, etc.) with the safety model as the headline feature: the deletion logic is a separate, unit-tested Swift package, and one component (`SafetyValidator`) is the only thing that can authorize a delete. A path is deletable only if it descends from a fixed allowlist of known-safe paths. Protected folders (Documents, Desktop, Photos, Mail, iCloud, Keychains) are rejected even as prefixes, symlinks are never followed, and it stays on the boot volume with no `sudo`.

It meets the listing criteria:

- Actively maintained (latest release v1.5.0, weekly cadence)
- MIT licensed
- Swift 6 language mode, strict concurrency, warnings-as-errors in CI
- 50+ stars
- English README with install + build-from-source instructions
- Works with the latest SDK (macOS 13+, SwiftUI MenuBarExtra)

Signed and notarized, installable via Homebrew (`brew install --cask yagcioglutoprak/tap/dusty`). Happy to adjust the category or tags if **Files** isn't the best fit.

I'm the author of Dusty, so full disclosure on that.